### PR TITLE
Update api/game.ts: add get route to get game's results

### DIFF
--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -13,4 +13,28 @@ router.post<{}, CreateGameResponse, CreateGameRequest>('/', async (req, res) => 
   });
 });
 
+router.get<{gid: string}>('/:gid', async (req, res) => {
+  try {
+    const {gid} = req.params;
+    const puzzleSolves = await getPuzzleSolves([gid]);
+
+    if (puzzleSolves.length === 0) {
+      return res.status(404).json({error: 'Game not found'});
+    }
+
+    const gameState = puzzleSolves[0];
+    const puzzleInfo = await getPuzzleInfo(gameState.pid) as InfoJson;
+
+    res.json({
+      title: gameState.title,
+      author: puzzleInfo?.author || 'Unknown',
+      duration: gameState.time_taken_to_solve,
+      size: gameState.size
+    });
+  } catch (error) {
+    console.error('Error fetching game state:', error);
+    res.status(500).json({error: 'Internal server error'});
+  }
+});
+
 export default router;


### PR DESCRIPTION
Porting the PR over from downforacross: https://github.com/downforacross/downforacross.com/pull/349

**Overview:**

This PR adds a new get route to the game api endpoint that returns a specified game id (gid) game state in json. There's likely things wrong with this PR, but it seems mostly correct. Open to making changes and feedback on this. Thanks!

**Context/Why:**

Right now, as far as I know, there's no way to get the state of a game without opening a game link and having the client reconstruct the game via websocket events. It'd be neat if we could just get the state of a solved game by passing the gid (game id) directly to the api.

My friends and I would like to keep track of who solves what puzzles and how long it took them to solve, so that we can store it automatically in our database and keep track of how people are doing. 