### PR TITLE
Add missing imports to api/game

### DIFF
--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -2,6 +2,10 @@ import express from 'express';
 import {CreateGameResponse, CreateGameRequest} from '../../src/shared/types';
 
 import {addInitialGameEvent} from '../model/game';
+import {getPuzzleInfo} from '../model/puzzle';
+import {getPuzzleSolves} from '../model/puzzle_solve';
+
+import {InfoJson} from '../../src/shared/types';
 
 const router = express.Router();
 


### PR DESCRIPTION
`yarn devbackend` isn't working, gives TS errors. I added imports for the missing items

```
TSError: ⨯ Unable to compile TypeScript:
server/api/game.ts:19:32 - error TS2304: Cannot find name 'getPuzzleSolves'.

19     const puzzleSolves = await getPuzzleSolves([gid]);
                                  ~~~~~~~~~~~~~~~
server/api/game.ts:26:30 - error TS2304: Cannot find name 'getPuzzleInfo'.

26     const puzzleInfo = await getPuzzleInfo(gameState.pid) as InfoJson;
                                ~~~~~~~~~~~~~
server/api/game.ts:26:62 - error TS2304: Cannot find name 'InfoJson'.

26     const puzzleInfo = await getPuzzleInfo(gameState.pid) as InfoJson;
                                                                ~~~~~~~~
```