### PR TITLE
Update some imports to .js to resolve relative import path error

### DIFF
--- a/server/api/puzzle.ts
+++ b/server/api/puzzle.ts
@@ -1,7 +1,7 @@
 import {FastifyInstance, FastifyRequest, FastifyReply} from 'fastify';
-import {AddPuzzleResponse, AddPuzzleRequest} from '@shared/types';
+import {AddPuzzleResponse, AddPuzzleRequest} from '@shared/types.js';
 
-import {addPuzzle} from '../model/puzzle';
+import {addPuzzle} from '../model/puzzle.js';
 
 async function puzzleRouter(fastify: FastifyInstance) {
   fastify.post<{Body: AddPuzzleRequest; Reply: AddPuzzleResponse}>(

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import Joi from 'joi';
 import * as uuid from 'uuid';
-import {PuzzleJson, ListPuzzleRequestFilters} from '@shared/types';
-import {pool} from './pool';
+import {PuzzleJson, ListPuzzleRequestFilters} from '@shared/types.js';
+import {pool} from './pool.js';
 
 // ================ Read and Write methods used to interface with postgres ========== //
 
@@ -13,6 +13,7 @@ export async function getPuzzle(pid: string): Promise<PuzzleJson> {
       SELECT content
       FROM puzzles
       WHERE pid = $1
+      
     `,
     [pid]
   );

--- a/server/server.ts
+++ b/server/server.ts
@@ -3,8 +3,8 @@ import cors from '@fastify/cors';
 import {Server as SocketIOServer} from 'socket.io';
 import {Server as HTTPServer} from 'http';
 import _ from 'lodash';
-import SocketManager from './SocketManager';
-import apiRouter from './api/router';
+import SocketManager from './SocketManager.js';
+import apiRouter from './api/router.js';
 
 const port = process.env.PORT || 3000;
 


### PR DESCRIPTION
Fixing errors of the form
```
import {pool} from './pool'; 
Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './pool.js'? 

import {pool} from './pool.ts'; 
An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
```