### PR TITLE
Update game event validation schema to enforce string keys for info and cursor records

### DIFF
--- a/server/validation/gameEvents.ts
+++ b/server/validation/gameEvents.ts
@@ -11,7 +11,7 @@ const createEventParamsSchema = z.object({
   pid: z.string().min(1),
   version: z.number().positive(),
   game: z.object({
-    info: z.record(z.unknown()).optional(),
+    info: z.record(z.string(), z.unknown()).optional(),
     grid: z.array(z.array(z.any())),
     solution: z.array(z.array(z.string())),
     circles: z.array(z.string()).optional(),
@@ -20,7 +20,7 @@ const createEventParamsSchema = z.object({
         messages: z.array(z.any()),
       })
       .optional(),
-    cursor: z.record(z.unknown()).optional(),
+    cursor: z.record(z.string(), z.unknown()).optional(),
     clock: z
       .object({
         lastUpdated: z.number(),
@@ -127,7 +127,8 @@ export function validateGameEvent(event: unknown): {
   const {type, params} = baseResult.data;
 
   // Check if event type is known
-  if (!(type in eventParamsSchemas)) {
+  const paramsSchema = eventParamsSchemas[type];
+  if (!paramsSchema) {
     return {
       valid: false,
       error: `Unknown event type: ${type}`,
@@ -135,7 +136,6 @@ export function validateGameEvent(event: unknown): {
   }
 
   // Validate type-specific params
-  const paramsSchema = eventParamsSchemas[type];
   const paramsResult = paramsSchema.safeParse(params);
   if (!paramsResult.success) {
     return {


### PR DESCRIPTION
This pull request makes improvements to the validation logic in `server/validation/gameEvents.ts` by tightening the schema definitions and simplifying the event type checking. The main changes ensure that object keys for certain properties are explicitly typed as strings and that the event type validation logic is more concise.

Schema improvements:

* Updated the `info` and `cursor` fields in the `game` object schema to use `z.record(z.string(), z.unknown())`, ensuring that all keys are strings. [[1]](diffhunk://#diff-6c01505b3ddb877cb6ed8d797cc9278d2ce0e51897cd0053d4105401fbcf3080L14-R14) [[2]](diffhunk://#diff-6c01505b3ddb877cb6ed8d797cc9278d2ce0e51897cd0053d4105401fbcf3080L23-R23)

Validation logic simplification:

* Refactored the event type validation in `validateGameEvent` to fetch the schema directly and check for its existence, making the code more straightforward and readable.…nd cursor records

- Modified the `createEventParamsSchema` to require string keys for the `info` and `cursor` records, enhancing type safety.
- Improved the validation logic in `validateGameEvent` by directly referencing the schema for event type checks.