### PR TITLE
Add an option to opt-out of skipping filled squares on non-mobile gride mode.

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -25,6 +25,7 @@ export default class Game extends Component {
       vimMode: false,
       vimInsert: false,
       vimCommand: false,
+      skipFilledSquares: true,
       colorAttributionMode: false,
       expandMenu: false,
     };
@@ -180,6 +181,12 @@ export default class Game extends Component {
     });
   };
 
+  handleToggleSkipFilledSquares = () => {
+    this.setState((prevState) => ({
+      skipFilledSquares: !prevState.skipFilledSquares,
+    }));
+  };
+
   handleTogglePencil = () => {
     this.setState((prevState) => ({
       pencilMode: !prevState.pencilMode,
@@ -324,6 +331,8 @@ export default class Game extends Component {
         onVimCommand={this.handleVimCommand}
         onVimCommandPressEnter={this.handleVimCommandPressEnter}
         onVimCommandPressEscape={this.handleRefocus}
+        skipFilledSquares={this.state.skipFilledSquares}
+        onToggleSkipFilledSquares={this.handleToggleSkipFilledSquares}
         colorAttributionMode={this.state.colorAttributionMode}
         mobile={mobile}
         pickups={this.props.pickups}
@@ -339,7 +348,16 @@ export default class Game extends Component {
     if (!this.game) return;
     const {clock, solved} = this.game;
     const {mobile} = this.props;
-    const {pencilMode, autocheckMode, vimMode, vimInsert, vimCommand, listMode, expandMenu} = this.state;
+    const {
+      pencilMode,
+      autocheckMode,
+      vimMode,
+      vimInsert,
+      vimCommand,
+      skipFilledSquares,
+      listMode,
+      expandMenu,
+    } = this.state;
     const {lastUpdated: startTime, totalTime: pausedTime, paused: isPaused} = clock;
     return (
       <Toolbar
@@ -355,6 +373,7 @@ export default class Game extends Component {
         pencilMode={pencilMode}
         autocheckMode={autocheckMode}
         vimMode={vimMode}
+        skipFilledSquares={skipFilledSquares}
         solved={solved}
         vimInsert={vimInsert}
         vimCommand={vimCommand}
@@ -367,6 +386,7 @@ export default class Game extends Component {
         onKeybind={this.handleKeybind}
         onTogglePencil={this.handleTogglePencil}
         onToggleVimMode={this.handleToggleVimMode}
+        onToggleSkipFilledSquares={this.handleToggleSkipFilledSquares}
         onToggleAutocheck={this.handleToggleAutocheck}
         onToggleListView={this.handleToggleListView}
         onToggleChat={this.handleToggleChat}

--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -48,13 +48,15 @@ export default class GridControls extends Component {
   selectNextClue(backwards, parallel = false) {
     let currentClueNumber = this.getSelectedClueNumber();
     let currentDirection = this.props.direction;
+    let skipFilledSquares = this.props.skipFilledSquares;
     const trySelectNextClue = () => {
       const {direction, clueNumber} = this.grid.getNextClue(
         currentClueNumber,
         currentDirection,
         this.props.clues,
         backwards,
-        parallel
+        parallel,
+        skipFilledSquares
       );
       currentClueNumber = clueNumber;
       currentDirection = direction;
@@ -342,9 +344,11 @@ export default class GridControls extends Component {
   }
 
   goToNextEmptyCell({nextClueIfFilled = false} = {}) {
+    const skipFilledSquares = this.props.skipFilledSquares;
     const {r, c} = this.props.selected;
     const nextEmptyCell = this.grid.getNextEmptyCell(r, c, this.props.direction, {
       skipFirst: true,
+      skipFilledSquares: skipFilledSquares,
     });
     if (nextEmptyCell) {
       this.setSelected(nextEmptyCell);

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -357,6 +357,8 @@ export default class Player extends Component {
       onVimNormal,
       onVimInsert,
       onVimCommand,
+      skipFilledSquares,
+      onToggleSkipFilledSquares,
       grid,
       clues,
       circles,
@@ -552,6 +554,8 @@ export default class Player extends Component {
           onVimInsert={onVimInsert}
           onVimNormal={onVimNormal}
           onVimCommand={onVimCommand}
+          skipFilledSquares={skipFilledSquares}
+          onToggleSkipFilledSquares={onToggleSkipFilledSquares}
           selected={selected}
           direction={direction}
           onSetDirection={this._setDirection}

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -152,15 +152,21 @@ export default class Toolbar extends Component {
     this.props.onToggleVimMode();
   };
 
+  handleSkipFilledSquaresClick = (e) => {
+    this.props.onToggleSkipFilledSquares();
+  };
+
   renderExtrasMenu() {
-    const {vimMode, onToggleColorAttributionMode} = this.props;
+    const {vimMode, onToggleColorAttributionMode, skipFilledSquares} = this.props;
     const vimModeLabel = vimMode ? 'Disable Vim Mode' : 'Enable Vim Mode';
+    const skipFilledSquaresLabel = skipFilledSquares ? "Don't skip filled squares" : 'Skip filled squares';
     return (
       <ActionMenu
         label="Extras"
         onBlur={this.handleBlur}
         actions={{
           [vimModeLabel]: this.handleVimModeClick,
+          [skipFilledSquaresLabel]: this.handleSkipFilledSquaresClick,
           'Color Attribution': onToggleColorAttributionMode,
           'List View': this.props.onToggleListView,
           Pencil: this.props.onTogglePencil,
@@ -332,9 +338,7 @@ export default class Toolbar extends Component {
               </tr>
               <tr>
                 <td>Letter / Number</td>
-                <td>
-                  Fill in current cell and advance cursor to next unfilled cell in the same word, if any
-                </td>
+                <td>Fill in current cell and advance cursor to the next cell in the same word, if any</td>
               </tr>
               <tr>
                 <td>
@@ -389,7 +393,7 @@ export default class Toolbar extends Component {
                 <td>
                   <code>Tab</code> and <code>Shift+Tab</code>
                 </td>
-                <td>Move cursor to first unfilled square of next or previous unfilled clue</td>
+                <td>Move cursor to the next or previous clue</td>
               </tr>
               <tr>
                 <td>

--- a/src/lib/wrappers/GridWrapper.js
+++ b/src/lib/wrappers/GridWrapper.js
@@ -147,10 +147,10 @@ export default class GridWrapper {
   getNextEmptyCell(r, c, direction, options = {}) {
     const _r = r;
     const _c = c;
-    let {noWraparound = false, skipFirst = false} = options;
+    let {noWraparound = false, skipFirst = false, skipFilledSquares = true} = options;
 
     while (this.isWriteable(r, c)) {
-      if (!this.isFilled(r, c)) {
+      if (skipFilledSquares && !this.isFilled(r, c)) {
         if (!skipFirst) {
           return {r, c};
         }
@@ -169,6 +169,7 @@ export default class GridWrapper {
       // recurse but not infinitely
       const result = this.getNextEmptyCell(r, c, direction, {
         noWraparound: true,
+        skipFilledSquares: skipFilledSquares,
       });
       if (!result || (result.r === _r && result.c === _c)) return undefined;
       return result;
@@ -185,7 +186,7 @@ export default class GridWrapper {
     return !this.hasEmptyCells(clueRoot.r, clueRoot.c, direction);
   }
 
-  getNextClue(clueNumber, direction, clues, backwards, parallel) {
+  getNextClue(clueNumber, direction, clues, backwards, parallel, skipFilledSquares) {
     clueNumber = parallel ? this.parallelMap[direction][clueNumber] : clueNumber;
     const add = backwards ? -1 : 1;
     const start = () => (backwards ? clues[direction].length - 1 : 1);
@@ -201,7 +202,7 @@ export default class GridWrapper {
       const number = parallel ? this.parallelMapInverse[direction][clueNumber] : clueNumber;
       return (
         clues[direction][number] !== undefined &&
-        (this.isGridFilled() || !this.isWordFilled(direction, number))
+        (this.isGridFilled() || !skipFilledSquares || !this.isWordFilled(direction, number))
       );
     };
     step();


### PR DESCRIPTION
Only works on non-mobile grid mode for now, but could be easily passed into other modes as well if it becomes desirable.

This option is meant to allow opting-out of behavior to skip filled cells or finished words when tabbing between clues or filling in letters.

I couldn't find where the tests were and I'm not sure what the Editor is for, so it's possible this is missing a lot. Please let me know and I'm happy to make any changes needed.