### PR TITLE
Respect skipFilledSquares in starting square on tab

### DIFF
--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -65,14 +65,16 @@ export default class GridControls extends Component {
 
     trySelectNextClue();
     safe_while(() => !hasSelectableCells(), trySelectNextClue);
-    this.selectClue(currentDirection, currentClueNumber);
+    this.selectClue(currentDirection, currentClueNumber, skipFilledSquares);
   }
 
-  selectClue(direction, number) {
+  selectClue(direction, number, skipFilledSquares) {
     const clueRoot = this.grid.getCellByNumber(number);
     if (clueRoot) {
       this.setDirection(direction);
-      const firstEmptyCell = this.grid.getNextEmptyCell(clueRoot.r, clueRoot.c, direction);
+      const firstEmptyCell = this.grid.getNextEmptyCell(clueRoot.r, clueRoot.c, direction, {
+        skipFilledSquares,
+      });
       let targetCell = firstEmptyCell || clueRoot;
       // if not selectable
       while (targetCell && !this.isSelectable(targetCell.r, targetCell.c)) {

--- a/src/lib/wrappers/GridWrapper.js
+++ b/src/lib/wrappers/GridWrapper.js
@@ -169,7 +169,7 @@ export default class GridWrapper {
       // recurse but not infinitely
       const result = this.getNextEmptyCell(r, c, direction, {
         noWraparound: true,
-        skipFilledSquares: skipFilledSquares,
+        skipFilledSquares,
       });
       if (!result || (result.r === _r && result.c === _c)) return undefined;
       return result;


### PR DESCRIPTION
Fixing a bug in a43e01, where I forgot to pass the option into the logic that selects the starting square when cycling through clues with tab / shift + tab.