### PR TITLE
Support one-liner for frontend dev against remote server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ If you notice a bug or have a feature request, feel free to open an issue.
 5. Run frontend server
    `yarn start`
 
+   Or if you just want to do frontend development against the remote server
+   `REACT_APP_STAGING_API_URL="downforacross-com.onrender.com" yarn start`
+
 ### Contributing
 
 Cross with Friends is open to contributions from developers of any level or experience.

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -1,8 +1,8 @@
-const DEV_REMOTE_SERVER_URL = process.env.STAGING_REACT_APP_API_URL || 'staging-downforacross-com.onrender.com';
+const DEV_REMOTE_SERVER_URL = process.env.REACT_APP_STAGING_API_URL || 'staging-downforacross-com.onrender.com';
 const PROD_REMOTE_SERVER_URL = process.env.REACT_APP_API_URL || 'downforacross-com.onrender.com';
 const REMOTE_SERVER =
   process.env.NODE_ENV === 'development' ? DEV_REMOTE_SERVER_URL : PROD_REMOTE_SERVER_URL;
-const REMOTE_SERVER_URL = `${window.location.protocol}//${REMOTE_SERVER}`;
+const REMOTE_SERVER_URL = `https://${REMOTE_SERVER}`;
 if (window.location.protocol === 'https' && process.env.NODE_ENV === 'development') {
   throw new Error('Please use http in development');
 }


### PR DESCRIPTION
The frontend uses `react-scripts` which says that all env vars are ignored unless they start with `REACT_APP_`. This made it impossible to set the env var `STAGING_REACT_APP_API_URL`. It is now renamed to `REACT_APP_STAGING_API_URL` so that it can be controlled by env.

The frontend also used to copy the frontend's protocol (http or https) when talking to the backend. However, local dev requires http and the remote backends require https. The backends are now hardcoded to only use https regardless of what protocol the frontend is using. This change doesn't impact production, since visiting http://crosswithfriends.com will redirect you to https long before it connects to the server - it's impossible to talk to the production backend from the production frontend over http.

Someone who wants to contribute to the frontend can now follow the simple instructions in the readme, including launching their dev server with this command:
```REACT_APP_STAGING_API_URL="downforacross-com.onrender.com" yarn start```