### PR TITLE
Add skipFilledSquares support to mobile and list view modes

### DIFF
--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -447,6 +447,8 @@ export default class Player extends Component {
               ref="mobileGridControls"
               onPressEnter={onPressEnter}
               onPressPeriod={onPressPeriod}
+              skipFilledSquares={skipFilledSquares}
+              onToggleSkipFilledSquares={onToggleSkipFilledSquares}
               selected={selected}
               direction={direction}
               onSetDirection={this._setDirection}
@@ -477,6 +479,8 @@ export default class Player extends Component {
             ref="mobileGridControls"
             onPressEnter={onPressEnter}
             onPressPeriod={onPressPeriod}
+            skipFilledSquares={skipFilledSquares}
+            onToggleSkipFilledSquares={onToggleSkipFilledSquares}
             selected={selected}
             direction={direction}
             onSetDirection={this._setDirection}
@@ -519,6 +523,8 @@ export default class Player extends Component {
             onVimInsert={onVimInsert}
             onVimNormal={onVimNormal}
             onVimCommand={onVimCommand}
+            skipFilledSquares={skipFilledSquares}
+            onToggleSkipFilledSquares={onToggleSkipFilledSquares}
             selected={selected}
             direction={direction}
             onSetDirection={this._setDirection}


### PR DESCRIPTION
All the other types of controls depend on GridControls, so all that's needed is to just pass the param through to the other control schemes.

This also fixes a bug introduced in last patch that causes these other modes to start skipping squares.