### PR TITLE
fix lack of padding on chat toolbar

### DIFF
--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -108,6 +108,7 @@ code {
 
 .toolbar--mobile {
   height: 48px;
+  padding: 0 16px 0 16px;
   background-color: var(--main-blue);
   justify-content: space-between;
   font-size: 14pt;
@@ -116,7 +117,6 @@ code {
 
 .toolbar--mobile a:first-child {
   color: white;
-  margin-left: 16px;
   text-decoration: none;
   font-weight: 600;
 }
@@ -143,8 +143,4 @@ code {
 
 .toolbar--mobile .clock {
   color: white;
-}
-
-.toolbar--mobile .toolbar--expand:last-child {
-  margin-right: 16px;
 }

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -269,9 +269,9 @@ export default class Toolbar extends Component {
   renderExpandMenuButton() {
     const {expandMenu} = this.props;
     return expandMenu ? (
-      <AiOutlineMenuFold onClick={this.handleToggleExpandMenu} className="toolbar--expand" />
+      <AiOutlineMenuFold onClick={this.handleToggleExpandMenu} />
     ) : (
-      <AiOutlineMenuUnfold onClick={this.handleToggleExpandMenu} className="toolbar--expand" />
+      <AiOutlineMenuUnfold onClick={this.handleToggleExpandMenu} />
     );
   }
 


### PR DESCRIPTION
The right side padding is missing when you enter the chat view, making it hard to click the close X

<img width="308" height="144" alt="image" src="https://github.com/user-attachments/assets/d8fbfea2-6ecf-4a79-bdee-a9b802ae85c2" />

Fixed

<img width="302" height="134" alt="image" src="https://github.com/user-attachments/assets/9e1235c7-3834-4432-b77e-a468e0be1be4" />

The issue was that the right side padding was being applied to a class only present on the in-game toolbar. Rather than write another rule applying it to a class only present in the chat toolbar, I simplified the approach. The toolbar now always has padding regardless of what it's being used for.