### PR TITLE
update Google Analytics to new GA4 property

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,14 +10,14 @@
     <script src="/wordlist.js"></script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-122725269-1"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-HTCFN5Z4RM"></script>
     <script src="https://cdn.jsdelivr.net/npm/fullscreen-api-polyfill@1.1.2/fullscreen-api-polyfill.min.js"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'UA-122725269-1');
+      gtag('config', 'G-HTCFN5Z4RM');
     </script>
   </head>
   <body>


### PR DESCRIPTION
Replace legacy Universal Analytics property (UA-122725269-1) with new GA4 property (G-HTCFN5Z4RM).

Closes #55