### PR TITLE
fix dark mode icon misalignment on mobile

### DIFF
--- a/src/components/common/css/nav.css
+++ b/src/components/common/css/nav.css
@@ -56,6 +56,8 @@
 .nav--info {
   cursor: pointer;
   margin-left: 20px;
+  display: flex;
+  align-items: center;
 }
 
 .nav--v2 {

--- a/src/dark.css
+++ b/src/dark.css
@@ -3,10 +3,8 @@
 .dark-mode-toggle {
   cursor: pointer;
   text-align: right;
-  margin-top: -10px;
-  /* Ignore padding from parent so dark mode setting doesn't expand Nav bar */
-  margin-bottom: -10px;
-  /* Can remove these if there's a more compact dark mode switching UI */
+  display: flex;
+  align-items: center;
 }
 
 .dark-mode-toggle:hover {


### PR DESCRIPTION
before

<img width="289" height="109" alt="image" src="https://github.com/user-attachments/assets/48cedce3-b3ed-4c87-9d08-e7a8d573546d" />

after

<img width="288" height="120" alt="image" src="https://github.com/user-attachments/assets/cd48c3af-6589-4376-87b4-275c9a6b543e" />