### PR TITLE
Clarify upload dialog phrasing

### DIFF
--- a/src/components/Upload/Upload.js
+++ b/src/components/Upload/Upload.js
@@ -73,11 +73,13 @@ export default class Upload extends Component {
           <p>
             You are about to upload the puzzle &quot;
             {puzzleTitle}
-            &quot;. Continue?
+            &quot;. This will create a shareable game link, and anyone with the link will be able to
+            solve it. Continue?
           </p>
           <div id="unlistedRow">
             <label>
-              <input type="checkbox" onChange={this.handleChangePublicCheckbox} /> Upload Publicly
+              <input type="checkbox" onChange={this.handleChangePublicCheckbox} /> Also post this
+              puzzle on the public site homepage
             </label>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Clarifies the upload dialog text to better explain what happens when uploading a puzzle.

Closes #30

## Changes
- Updated dialog text to explain that uploading creates a shareable link anyone can access
- Changed checkbox label from "Upload Publicly" to "Also post this puzzle on the public site homepage"

This addresses user confusion about the "Upload Publicly" checkbox - users didn't realize that all uploads create shareable links, and the checkbox only controls homepage visibility.

## Test plan
- [x] Upload a puzzle and verify the new dialog text is shown
- [x] Verify checkbox label reads "Also post this puzzle on the public site homepage"

🤖 Generated with [Claude Code](https://claude.com/claude-code)