### PR TITLE
Enhance puzzle filters (phase 2)

### DIFF
--- a/src/components/PuzzleList/Entry.tsx
+++ b/src/components/PuzzleList/Entry.tsx
@@ -34,10 +34,18 @@ export default class Entry extends Component<EntryProps> {
   handleMouseLeave = () => {};
 
   get size() {
-    const {grid} = this.props;
+    const {grid, title} = this.props;
+    const titleLower = (title || '').toLowerCase();
+    const titleHasMini = /\bmini\b/.test(titleLower);
+    const titleHasMidi = /\bmidi\b/.test(titleLower);
+
     if (grid) {
       const maxDim = Math.max(grid.length, grid[0]?.length ?? 0);
-      if (maxDim <= 7) return 'Mini';
+      // Title-based override: "mini" in title → Mini, "midi" in title → Midi
+      if (titleHasMini && !titleHasMidi) return 'Mini';
+      if (titleHasMidi) return 'Midi';
+      // Size-based classification
+      if (maxDim <= 8) return 'Mini';
       if (maxDim <= 12) return 'Midi';
       if (maxDim <= 16) return 'Standard';
       return 'Large';

--- a/src/dark.css
+++ b/src/dark.css
@@ -230,6 +230,18 @@
   background-color: var(--dark-blue-1);
 }
 
+.dark .filter-quick-toggle {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.dark .filter-quick-toggle--link {
+  color: #6aa9f4;
+}
+
+.dark .filter-quick-toggle--link:hover {
+  color: #8bc4ff;
+}
+
 :root {
   --dark-blue-1: rgb(36, 79, 115);
   --dark-blue-2: #183a60;

--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -22,7 +22,7 @@ export default class Welcome extends Component {
     super(props);
     this.state = {
       userHistory: {},
-      collapsedFilters: {Day: true, Type: true, Status: true},
+      collapsedFilters: {},
       mobileSidebarOpen: false,
     };
     this.loading = false;
@@ -146,6 +146,36 @@ export default class Welcome extends Component {
     }
   };
 
+  handleSelectAll = (header) => {
+    if (header === 'Day') {
+      this.props.setDayOfWeekFilter({
+        Mon: true,
+        Tue: true,
+        Wed: true,
+        Thu: true,
+        Fri: true,
+        Sat: true,
+        Sun: true,
+        Unknown: true,
+      });
+    }
+  };
+
+  handleSelectNone = (header) => {
+    if (header === 'Day') {
+      this.props.setDayOfWeekFilter({
+        Mon: false,
+        Tue: false,
+        Wed: false,
+        Thu: false,
+        Fri: false,
+        Sat: false,
+        Sun: false,
+        Unknown: false,
+      });
+    }
+  };
+
   updateSearch = _.debounce((search) => {
     this.props.setSearch(search);
   }, 250);
@@ -202,7 +232,7 @@ export default class Welcome extends Component {
       margin: 'unset',
     };
 
-    const checkboxGroup = (header, items, handleChange) => {
+    const checkboxGroup = (header, items, handleChange, showQuickToggle = false) => {
       const collapsed = collapsedFilters[header];
       return (
         <Flex column style={groupStyle} className="checkbox-group">
@@ -214,6 +244,23 @@ export default class Welcome extends Component {
               <MdExpandLess style={{width: 20, height: 20}} />
             )}
           </span>
+          {!collapsed && showQuickToggle && (
+            <div className="filter-quick-toggle">
+              <span
+                className="filter-quick-toggle--link"
+                onClick={() => this.handleSelectAll(header)}
+              >
+                All
+              </span>
+              <span className="filter-quick-toggle--separator">/</span>
+              <span
+                className="filter-quick-toggle--link"
+                onClick={() => this.handleSelectNone(header)}
+              >
+                None
+              </span>
+            </div>
+          )}
           {!collapsed &&
             _.keys(items).map((name, i) => (
               <label
@@ -246,7 +293,7 @@ export default class Welcome extends Component {
       <Flex className="filters" column hAlignContent="left" shrink={0}>
         {checkboxGroup('Size', sizeFilter, this.handleFilterChange)}
         {checkboxGroup('Type', typeFilter, this.handleFilterChange)}
-        {checkboxGroup('Day', dayOfWeekFilter, this.handleFilterChange)}
+        {checkboxGroup('Day', dayOfWeekFilter, this.handleFilterChange, true)}
         {checkboxGroup('Status', statusFilter, this.handleFilterChange)}
       </Flex>
     );

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -111,6 +111,26 @@
   opacity: 0;
 }
 
+.filter-quick-toggle {
+  font-size: 11px;
+  margin: 4px 0 2px 0;
+  color: #666;
+}
+
+.filter-quick-toggle--link {
+  color: #6aa9f4;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.filter-quick-toggle--link:hover {
+  color: #4a89d4;
+}
+
+.filter-quick-toggle--separator {
+  margin: 0 4px;
+}
+
 .quickplay {
   padding: 5px;
   border-top: 2px solid #6aa9f4;


### PR DESCRIPTION
- Fix day-of-week parsing: case-insensitive, support Tues/Weds/Thurs abbreviations
- Fix size classification: expand Mini to ≤8, add title-based override (mini/midi keywords)
- Add All/None quick toggle for Day filter
- Expand all filter groups by default
- Add dark mode styles for quick toggle