### PR TITLE
Add TypeCheck CI job, remove redundant push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [master]
-  push:
-    branches: [master]
 
 jobs:
   lint:
@@ -67,9 +65,32 @@ jobs:
       - name: Run tests
         run: yarn test --watchAll=false --ci
 
+  typecheck:
+    name: TypeCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: TypeCheck frontend
+        run: yarn tsc --noEmit
+
+      - name: TypeCheck server
+        run: yarn tsc --noEmit -p server/tsconfig.json
+
   build:
     name: Build
-    needs: [lint, format, test]
+    needs: [lint, format, test, typecheck]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Adds `tsc --noEmit` CI job checking both frontend and server TypeScript (currently 0 errors)
- Removes redundant `push: branches: [master]` trigger — CI already runs on PRs and branch protection requires PR merges
- Build job now gates on all four checks: lint, format, test, typecheck

Updated job graph:
```
lint ──────────┐
format ────────┤
test ──────────┤──> build
typecheck ─────┘
```

**Note:** After merging, add "TypeCheck" as a required status check in branch protection.

## Test plan
- [x] `tsc --noEmit` passes (0 errors, frontend)
- [x] `tsc --noEmit -p server/tsconfig.json` passes (0 errors, server)
- [x] All 79 unit tests pass
- [x] ESLint passes (0 errors)
- [x] Prettier check passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)