### PR TITLE
Add helmet middleware for security headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "firebase": "^7.8.1",
     "firebase-admin": "^8.9.2",
     "gaussian": "^1.1.0",
+    "helmet": "^8.1.0",
     "joi": "^17.3.0",
     "left-pad": "^1.3.0",
     "lodash": "^4.17.21",

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import morgan from 'morgan';
 import bodyParser from 'body-parser';
+import helmet from 'helmet';
 
 import http from 'http';
 import {Server} from 'socket.io';
@@ -11,6 +12,11 @@ import apiRouter from './api/router';
 
 const app = express();
 const server = new http.Server(app);
+app.use(
+  helmet({
+    contentSecurityPolicy: false, // disable CSP for now — MUI v4 uses inline styles
+  })
+);
 app.use(bodyParser.json());
 const port = process.env.PORT || 3000;
 const io = new Server(server, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8907,6 +8907,11 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+helmet@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.1.0.tgz#f96d23fedc89e9476ecb5198181009c804b8b38c"
+  integrity sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==
+
 history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"


### PR DESCRIPTION
## Summary
- Adds `helmet` middleware to set standard security response headers (X-Content-Type-Options, X-Frame-Options, Strict-Transport-Security, Referrer-Policy) and removes the X-Powered-By header
- Content-Security-Policy is disabled for now since MUI v4 relies on inline styles
- Zero-config, no behavioral changes — only adds response headers

## Test plan
- [x] Backend compiles cleanly (`tsc --noEmit`)
- [x] Frontend builds (`npm run build`)
- [x] ESLint and Prettier pass
- [x] Manual testing: app loads, puzzles work, socket.io unaffected
- [x] Verify headers present via `curl -I` or browser Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)