### PR TITLE
Fix chat auto-scroll regression from lint cleanup

### DIFF
--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -89,12 +89,6 @@ export default class Chat extends Component {
     this.setState({username});
   };
 
-  static handleMessagesRef(el) {
-    if (el) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }
-
   handleToggleChat = () => {
     this.props.onToggleChat();
   };
@@ -437,7 +431,16 @@ export default class Chat extends Component {
         <div className="chat">
           {this.renderChatHeader()}
           {this.renderChatSubheader()}
-          <div ref={Chat.handleMessagesRef} className="chat--messages">
+          {/* eslint-disable react/jsx-no-bind -- intentionally unstable ref to auto-scroll on every render */}
+          <div
+            ref={(el) => {
+              if (el) {
+                el.scrollTop = el.scrollHeight;
+              }
+            }}
+            className="chat--messages"
+          >
+            {/* eslint-enable react/jsx-no-bind */}
             <div className="chat--message chat--system-message">
               <div>
                 <i>


### PR DESCRIPTION
## Summary
- Restore inline ref callback for chat messages container that was converted to a stable static method during the lint warning cleanup (#163)
- The inline ref intentionally re-runs on every render to keep chat pinned to the latest message — making it stable broke auto-scroll in active rooms
- Added `eslint-disable` comment explaining why the inline ref is intentional

## Test plan
- [x] Open a game room with chat messages — chat should be scrolled to the bottom
- [ ] Send messages in an active room — new messages should auto-scroll into view
- [x] ESLint passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)