### PR TITLE
Use same-origin API proxy to fix cross-origin cookie problem

### DIFF
--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -46,7 +46,7 @@ const REFRESH_COOKIE = 'cwf_refresh';
 const REFRESH_COOKIE_OPTIONS = {
   httpOnly: true,
   secure: process.env.NODE_ENV === 'production',
-  sameSite: (process.env.NODE_ENV === 'production' ? 'none' : 'lax') as 'none' | 'lax',
+  sameSite: 'lax' as const,
   maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
   path: '/api/auth',
 };

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -7,14 +7,23 @@ if (window.location.protocol === 'https' && process.env.NODE_ENV === 'developmen
   throw new Error('Please use http in development');
 }
 
-export const SERVER_URL = process.env.REACT_APP_USE_LOCAL_SERVER
+// Local dev with local server: direct to localhost
+// Local dev without local server: direct to staging/prod backend
+// Production build: '' → same-origin through Render rewrite proxy
+function getServerUrl() {
+  if (process.env.REACT_APP_USE_LOCAL_SERVER) return 'http://localhost:3021';
+  if (process.env.NODE_ENV === 'production') return '';
+  return REMOTE_SERVER_URL;
+}
+export const SERVER_URL = getServerUrl();
+
+// Socket.IO always connects directly to backend (WebSocket, token auth, no cookies)
+export const SOCKET_HOST = process.env.REACT_APP_USE_LOCAL_SERVER
   ? 'http://localhost:3021'
   : REMOTE_SERVER_URL;
 
-// socket.io server is same as api server
-export const SOCKET_HOST = SERVER_URL;
-
 console.log('--------------------------------------------------------------------------------');
 console.log('Frontend API Protocol:', window.location.protocol);
-console.log('Frontend Connecting to API/Socket at:', SERVER_URL);
+console.log('Frontend API at:', SERVER_URL || '(same-origin)');
+console.log('Frontend Socket at:', SOCKET_HOST);
 console.log('--------------------------------------------------------------------------------');


### PR DESCRIPTION
## Summary
- Make `SERVER_URL` empty in production so API fetches use relative URLs (`/api/...`) through a Render Static Site rewrite rule — cookies become first-party
- Split `SOCKET_HOST` to keep Socket.IO connecting directly to the backend (WebSocket + token auth, no cookies)
- Change `sameSite` from `'none'` to `'lax'` since API requests are now same-origin

## Infrastructure required (before deploying frontend)
1. **Render Static Site** → Add rewrite rule: `/api/*` → `https://downforacross-com.onrender.com/api/*` (must be above `/* → /index.html`)
2. **Google Cloud Console** → Add redirect URI: `https://crosswithfriends.com/api/auth/google/callback`
3. **Render backend env** → Set `GOOGLE_CALLBACK_URL=https://crosswithfriends.com/api/auth/google/callback`

## Deploy order
1. Add rewrite rule + Google OAuth URI (dormant, no impact)
2. Deploy frontend first (`SERVER_URL = ''`)
3. Verify auth works through proxy
4. Deploy backend (`sameSite: 'lax'`) — safe once requests are same-origin

## Test plan
- [x] Local dev: auth flows work with `REACT_APP_USE_LOCAL_SERVER=1`
- [ ] Staging: verify proxy rewrite + auth through same-origin
- [ ] Production: login, signup, refresh, Google OAuth, cross-browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)