### PR TITLE
Fix mobile typing broken by ESLint refactor

### DIFF
--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -13,7 +13,7 @@ function safe_while(condition, step, capLimit = 500) {
   }
 }
 
-function validLetter(letter) {
+export function validLetter(letter) {
   const VALID_SYMBOLS = '!@#$%^&*()-+=`~/?\\'; // special theme puzzles have these sometimes;
   if (VALID_SYMBOLS.indexOf(letter) !== -1) return true;
   return letter.match(/^[A-Z0-9]$/);

--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -5,7 +5,7 @@ import Flex from 'react-flexview';
 import {MdKeyboardArrowLeft, MdKeyboardArrowRight} from 'react-icons/md';
 import _ from 'lodash';
 import Clue from './ClueText';
-import GridControls from './GridControls';
+import GridControls, {validLetter} from './GridControls';
 import GridObject from '../../lib/wrappers/GridWrapper';
 
 const RunOnce = ({effect}) => {
@@ -430,7 +430,7 @@ export default class MobileGridControls extends GridControls {
       // support gesture-based keyboards that allow inputting words at a time
       let delay = 0;
       for (const char of input) {
-        if (this.validLetter(char.toUpperCase())) {
+        if (validLetter(char.toUpperCase())) {
           this.setState({dbgstr: `TYPE letter ${char.toUpperCase()}`});
           if (delay) {
             setTimeout(() => {


### PR DESCRIPTION
## Summary
- **Production bug**: Typing on mobile devices was completely broken — no letters would register
- **Root cause**: ESLint warning fix (`0e6d48b`) moved `validLetter` from a `GridControls` class method to a standalone function, but `MobileGridControls` still called `this.validLetter()` which became `undefined`
- **Fix**: Export `validLetter` from `GridControls.js` and import it in `MobileGridControls.js`

## Test plan
- [x] Tested typing on mobile — letters register correctly
- [x] Desktop typing unaffected
- [x] ESLint, Prettier, and build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)