### PR TITLE
Add tests for grid input handling

### DIFF
--- a/src/components/Player/__tests__/GridControls.test.js
+++ b/src/components/Player/__tests__/GridControls.test.js
@@ -1,0 +1,133 @@
+/* eslint no-underscore-dangle: "off" */
+import GridControls from '../GridControls';
+import {makeGrid, makeControlsInstance} from '../testHelpers';
+
+describe('GridControls._handleKeyDown — letter input', () => {
+  it('calls updateGrid with uppercase letter', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    jest.useFakeTimers();
+    instance._handleKeyDown('a', false, false);
+    jest.runAllTimers();
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 0, 'A');
+    jest.useRealTimers();
+  });
+
+  it('does not call updateGrid when frozen', () => {
+    const {instance, props} = makeControlsInstance(GridControls, {frozen: true});
+    instance._handleKeyDown('a', false, false);
+    expect(props.updateGrid).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-letter, non-action characters', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('é', false, false);
+    expect(props.updateGrid).not.toHaveBeenCalled();
+  });
+
+  it('accepts digit keys', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    jest.useFakeTimers();
+    instance._handleKeyDown('5', false, false);
+    jest.runAllTimers();
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 0, '5');
+    jest.useRealTimers();
+  });
+});
+
+describe('GridControls._handleKeyDown — action keys', () => {
+  it('handles Backspace', () => {
+    const {instance, props} = makeControlsInstance(GridControls, {
+      grid: makeGrid({'0,0': {value: 'A'}}),
+    });
+    instance._handleKeyDown('Backspace', false, false);
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 0, '');
+  });
+
+  it('handles Delete', () => {
+    const {instance, props} = makeControlsInstance(GridControls, {
+      grid: makeGrid({'0,0': {value: 'A'}}),
+    });
+    instance._handleKeyDown('Delete', false, false);
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 0, '');
+  });
+
+  it('handles ArrowRight navigation', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('ArrowRight', false, false);
+    expect(props.onSetSelected).toHaveBeenCalledWith({r: 0, c: 1});
+  });
+
+  it('handles space to flip direction', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown(' ', false, false);
+    expect(props.onSetDirection).toHaveBeenCalledWith('down');
+  });
+
+  it('handles period', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('.', false, false);
+    expect(props.onPressPeriod).toHaveBeenCalled();
+  });
+
+  it('handles Enter', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('Enter', false, false);
+    expect(props.onPressEnter).toHaveBeenCalled();
+  });
+
+  it('handles Tab without throwing', () => {
+    const {instance} = makeControlsInstance(GridControls);
+    expect(() => instance._handleKeyDown('Tab', false, false)).not.toThrow();
+  });
+});
+
+describe('GridControls.delete', () => {
+  it('clears a filled cell and returns true', () => {
+    const {instance, props} = makeControlsInstance(GridControls, {
+      grid: makeGrid({'0,0': {value: 'A'}}),
+    });
+    expect(instance.delete()).toBe(true);
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 0, '');
+  });
+
+  it('does not clear a verified ("good") cell', () => {
+    const {instance, props} = makeControlsInstance(GridControls, {
+      grid: makeGrid({'0,0': {value: 'A', good: true}}),
+    });
+    expect(instance.delete()).toBe(false);
+    expect(props.updateGrid).not.toHaveBeenCalled();
+  });
+
+  it('returns false on empty cell', () => {
+    const {instance} = makeControlsInstance(GridControls);
+    expect(instance.delete()).toBe(false);
+  });
+});
+
+describe('GridControls.backspace', () => {
+  it('deletes current cell if filled', () => {
+    const {instance, props} = makeControlsInstance(GridControls, {
+      grid: makeGrid({'0,1': {value: 'B'}}),
+      selected: {r: 0, c: 1},
+    });
+    instance.backspace();
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 1, '');
+  });
+
+  it('moves to previous cell and clears it when current is empty', () => {
+    const {instance, props} = makeControlsInstance(GridControls, {
+      selected: {r: 0, c: 1},
+      direction: 'across',
+    });
+    instance.backspace();
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 0, '');
+  });
+
+  it('stays put when shouldStay is true and current is empty', () => {
+    const {instance, props} = makeControlsInstance(GridControls, {
+      selected: {r: 0, c: 1},
+    });
+    instance.backspace(true);
+    expect(props.onSetSelected).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Player/__tests__/MobileGridControls.test.js
+++ b/src/components/Player/__tests__/MobileGridControls.test.js
@@ -1,0 +1,139 @@
+import MobileGridControls from '../MobileGridControls';
+import {makeGrid, makeDefaultProps} from '../testHelpers';
+
+function makeMobileInstance(overrides = {}) {
+  const props = makeDefaultProps({
+    size: 30,
+    enablePan: false,
+    onSetCursorLock: jest.fn(),
+    onChangeDirection: jest.fn(),
+    ...overrides,
+  });
+  const instance = new MobileGridControls(props);
+  instance.props = props;
+  instance.inputRef = {
+    current: {
+      focus: jest.fn(),
+      value: '$',
+      selectionStart: 1,
+      selectionEnd: 1,
+    },
+  };
+  instance.zoomContainer = {
+    current: {
+      getBoundingClientRect: () => ({x: 0, y: 0, width: 300, height: 300}),
+    },
+  };
+  instance.state = {
+    anchors: [],
+    transform: {scale: 1, translateX: 0, translateY: 0},
+    dbgstr: undefined,
+  };
+  instance.setState = jest.fn((updater) => {
+    if (typeof updater === 'function') {
+      Object.assign(instance.state, updater(instance.state));
+    } else {
+      Object.assign(instance.state, updater);
+    }
+  });
+  return {instance, props};
+}
+
+function makeInputEvent(value) {
+  return {
+    target: {
+      value,
+      selectionStart: value.length,
+      selectionEnd: value.length,
+    },
+  };
+}
+
+describe('MobileGridControls.handleInputChange — letter input', () => {
+  it('types a letter when input changes from "$" to "$a"', () => {
+    const {instance, props} = makeMobileInstance();
+    jest.useFakeTimers();
+    instance.handleInputChange(makeInputEvent('$a'));
+    jest.runAllTimers();
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 0, 'A');
+    jest.useRealTimers();
+  });
+
+  it('types multiple letters for gesture keyboard input "$hello"', () => {
+    const {instance, props} = makeMobileInstance();
+    jest.useFakeTimers();
+    instance.handleInputChange(makeInputEvent('$hello'));
+    jest.runAllTimers();
+    expect(props.updateGrid).toHaveBeenCalledTimes(5);
+    jest.useRealTimers();
+  });
+
+  it('handles digit input', () => {
+    const {instance, props} = makeMobileInstance();
+    jest.useFakeTimers();
+    instance.handleInputChange(makeInputEvent('$5'));
+    jest.runAllTimers();
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 0, '5');
+    jest.useRealTimers();
+  });
+});
+
+describe('MobileGridControls.handleInputChange — backspace', () => {
+  it('triggers backspace when input becomes empty', () => {
+    const {instance, props} = makeMobileInstance({
+      grid: makeGrid({'0,0': {value: 'A'}}),
+    });
+    jest.useFakeTimers();
+    instance.handleInputChange(makeInputEvent(''));
+    jest.runAllTimers();
+    expect(props.updateGrid).toHaveBeenCalledWith(0, 0, '');
+    jest.useRealTimers();
+  });
+});
+
+describe('MobileGridControls.handleInputChange — special inputs', () => {
+  it('handles space input (direction flip)', () => {
+    const {instance, props} = makeMobileInstance();
+    instance.handleInputChange(makeInputEvent('$ '));
+    expect(props.onSetDirection).toHaveBeenCalled();
+  });
+
+  it('handles @ as space (iOS email keyboard quirk)', () => {
+    const {instance, props} = makeMobileInstance();
+    instance.handleInputChange(makeInputEvent('$@'));
+    expect(props.onSetDirection).toHaveBeenCalled();
+  });
+
+  it('handles period input', () => {
+    const {instance, props} = makeMobileInstance();
+    instance.handleInputChange(makeInputEvent('$.'));
+    expect(props.onPressPeriod).toHaveBeenCalled();
+  });
+
+  it('handles comma input (tab to next clue) without throwing', () => {
+    const {instance} = makeMobileInstance();
+    expect(() => instance.handleInputChange(makeInputEvent('$,'))).not.toThrow();
+  });
+});
+
+describe('MobileGridControls — validLetter regression', () => {
+  it('does not have validLetter as an instance method', () => {
+    // validLetter must be a standalone import, not a class method.
+    // If it ever becomes a class method again, the coupling is fragile.
+    const {instance} = makeMobileInstance();
+    expect(instance.validLetter).toBeUndefined();
+  });
+
+  it('processes letter input without throwing (the exact regression)', () => {
+    // This is THE critical test. Before the fix, this threw:
+    // TypeError: this.validLetter is not a function
+    const {instance, props} = makeMobileInstance();
+    jest.useFakeTimers();
+    expect(() => {
+      instance.handleInputChange(makeInputEvent('$A'));
+    }).not.toThrow();
+    jest.runAllTimers();
+    expect(props.updateGrid).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});

--- a/src/components/Player/__tests__/validLetter.test.js
+++ b/src/components/Player/__tests__/validLetter.test.js
@@ -1,0 +1,38 @@
+import {validLetter} from '../GridControls';
+
+describe('validLetter', () => {
+  it('is exported as a standalone function', () => {
+    // Regression gate: if someone moves validLetter back to a class method
+    // or removes the export, this test fails immediately.
+    expect(typeof validLetter).toBe('function');
+  });
+
+  it('accepts uppercase A-Z', () => {
+    for (const ch of 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') {
+      expect(validLetter(ch)).toBeTruthy();
+    }
+  });
+
+  it('accepts digits 0-9', () => {
+    for (const ch of '0123456789') {
+      expect(validLetter(ch)).toBeTruthy();
+    }
+  });
+
+  it('accepts special symbols used in theme puzzles', () => {
+    const symbols = '!@#$%^&*()-+=`~/?\\';
+    for (const ch of symbols) {
+      expect(validLetter(ch)).toBeTruthy();
+    }
+  });
+
+  it('rejects lowercase letters (input is uppercased before calling validLetter)', () => {
+    expect(validLetter('a')).toBeFalsy();
+    expect(validLetter('z')).toBeFalsy();
+  });
+
+  it('rejects whitespace', () => {
+    expect(validLetter(' ')).toBeFalsy();
+    expect(validLetter('\t')).toBeFalsy();
+  });
+});

--- a/src/components/Player/testHelpers.js
+++ b/src/components/Player/testHelpers.js
@@ -1,0 +1,75 @@
+import GridWrapper from '../../lib/wrappers/GridWrapper';
+
+// 3x3 grid with black square at (1,1)
+//  _ _ _
+//  _ . _
+//  _ _ _
+export function makeGrid(cellOverrides = {}) {
+  const grid = [
+    [
+      {value: '', black: false},
+      {value: '', black: false},
+      {value: '', black: false},
+    ],
+    [
+      {value: '', black: false},
+      {value: '', black: true},
+      {value: '', black: false},
+    ],
+    [
+      {value: '', black: false},
+      {value: '', black: false},
+      {value: '', black: false},
+    ],
+  ];
+  const wrapper = new GridWrapper(grid);
+  wrapper.assignNumbers();
+  // Copy assigned parents/numbers back into the raw grid
+  for (const [r, c] of wrapper.keys()) {
+    grid[r][c] = {...grid[r][c], ...wrapper.grid[r][c]};
+  }
+  // Apply any cell-level overrides, keyed by "r,c"
+  for (const key of Object.keys(cellOverrides)) {
+    const [r, c] = key.split(',').map(Number);
+    Object.assign(grid[r][c], cellOverrides[key]);
+  }
+  return grid;
+}
+
+export function makeDefaultProps(overrides = {}) {
+  return {
+    grid: makeGrid(),
+    selected: {r: 0, c: 0},
+    direction: 'across',
+    clues: {across: [undefined, 'Clue 1A'], down: [undefined, 'Clue 1D']},
+    frozen: false,
+    editMode: false,
+    beta: false,
+    skipFilledSquares: true,
+    updateGrid: jest.fn(),
+    onSetSelected: jest.fn(),
+    onSetDirection: jest.fn(),
+    canSetDirection: jest.fn(() => true),
+    onPressEnter: jest.fn(),
+    onPressPeriod: jest.fn(),
+    onPressEscape: jest.fn(),
+    onCheck: jest.fn(),
+    onReveal: jest.fn(),
+    ...overrides,
+  };
+}
+
+export function makeControlsInstance(ControlsClass, overrides = {}) {
+  const props = makeDefaultProps(overrides);
+  const instance = new ControlsClass(props);
+  instance.props = props;
+  instance.inputRef = {current: {focus: jest.fn()}};
+  instance.setState = jest.fn((updater) => {
+    if (typeof updater === 'function') {
+      Object.assign(instance.state, updater(instance.state));
+    } else {
+      Object.assign(instance.state, updater);
+    }
+  });
+  return {instance, props};
+}


### PR DESCRIPTION
## Summary
- Adds 33 tests covering the desktop and mobile input pipelines for the crossword grid
- **Regression gate**: `validLetter` must remain an exported standalone function (not a class method) — the exact issue that broke mobile typing in #167
- Tests `handleInputChange` (mobile), `_handleKeyDown` (desktop), `delete()`, and `backspace()` code paths
- Shared test helpers in `testHelpers.js` with `makeGrid`, `makeDefaultProps`, `makeControlsInstance`

## Test plan
- [x] All 33 new tests pass
- [x] Full suite (253 tests) passes
- [x] ESLint + Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)