### PR TITLE
Fix Mac keyboard shortcuts for Check/Reveal

### DIFF
--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -187,22 +187,21 @@ export default class GridControls extends Component {
     this.actions[action](shiftKey);
   }
 
-  handleAltKey(key, shiftKey) {
-    const lowerKey = key.toLowerCase();
+  handleAltKey(code, shiftKey) {
     const altAction = shiftKey ? this.props.onReveal : this.props.onCheck;
-    if (lowerKey === 's') {
+    if (code === 'KeyS') {
       altAction('square');
     }
-    if (lowerKey === 'w') {
+    if (code === 'KeyW') {
       altAction('word');
     }
-    if (lowerKey === 'p') {
+    if (code === 'KeyP') {
       altAction('puzzle');
     }
   }
 
   // takes in key, a string
-  _handleKeyDown = (key, shiftKey, altKey) => {
+  _handleKeyDown = (key, shiftKey, altKey, code) => {
     const actionKeys = {
       ArrowLeft: 'left',
       ArrowUp: 'up',
@@ -239,7 +238,7 @@ export default class GridControls extends Component {
       return true;
     }
     if (altKey) {
-      this.handleAltKey(key, shiftKey);
+      this.handleAltKey(code, shiftKey);
       return true;
     }
     if (key === 'Escape') {
@@ -254,7 +253,7 @@ export default class GridControls extends Component {
     return undefined;
   };
 
-  _handleKeyDownVim = (key, shiftKey, altKey) => {
+  _handleKeyDownVim = (key, shiftKey, altKey, code) => {
     const actionKeys = {
       ArrowLeft: 'left',
       ArrowUp: 'up',
@@ -295,7 +294,7 @@ export default class GridControls extends Component {
       return true;
     }
     if (altKey) {
-      this.handleAltKey(key, shiftKey);
+      this.handleAltKey(code, shiftKey);
       return true;
     }
     if (!vimInsert && !vimCommand) {
@@ -344,7 +343,9 @@ export default class GridControls extends Component {
     if (ev.target !== this.inputRef && (ev.tagName === 'INPUT' || ev.metaKey || ev.ctrlKey)) {
       return;
     }
-    if (keyDownHandler(ev.key, ev.shiftKey, ev.altKey)) {
+    // React 16 SyntheticEvent doesn't expose ev.code; read from nativeEvent
+    const code = ev.nativeEvent ? ev.nativeEvent.code : ev.code;
+    if (keyDownHandler(ev.key, ev.shiftKey, ev.altKey, code)) {
       ev.preventDefault();
       ev.stopPropagation();
     }

--- a/src/components/Player/__tests__/GridControls.test.js
+++ b/src/components/Player/__tests__/GridControls.test.js
@@ -81,6 +81,50 @@ describe('GridControls._handleKeyDown — action keys', () => {
   });
 });
 
+describe('GridControls._handleKeyDown — alt key shortcuts', () => {
+  it('calls onCheck("square") for Alt+S on Mac (ev.key="ß", ev.code="KeyS")', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('ß', false, true, 'KeyS');
+    expect(props.onCheck).toHaveBeenCalledWith('square');
+  });
+
+  it('calls onCheck("word") for Alt+W on Mac (ev.key="∑", ev.code="KeyW")', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('∑', false, true, 'KeyW');
+    expect(props.onCheck).toHaveBeenCalledWith('word');
+  });
+
+  it('calls onCheck("puzzle") for Alt+P on Mac (ev.key="π", ev.code="KeyP")', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('π', false, true, 'KeyP');
+    expect(props.onCheck).toHaveBeenCalledWith('puzzle');
+  });
+
+  it('calls onReveal("square") for Alt+Shift+S on Mac', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('ß', true, true, 'KeyS');
+    expect(props.onReveal).toHaveBeenCalledWith('square');
+  });
+
+  it('calls onReveal("word") for Alt+Shift+W on Mac', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('∑', true, true, 'KeyW');
+    expect(props.onReveal).toHaveBeenCalledWith('word');
+  });
+
+  it('calls onReveal("puzzle") for Alt+Shift+P on Mac', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('π', true, true, 'KeyP');
+    expect(props.onReveal).toHaveBeenCalledWith('puzzle');
+  });
+
+  it('works with Latin ev.key values on Windows/Linux', () => {
+    const {instance, props} = makeControlsInstance(GridControls);
+    instance._handleKeyDown('s', false, true, 'KeyS');
+    expect(props.onCheck).toHaveBeenCalledWith('square');
+  });
+});
+
 describe('GridControls.delete', () => {
   it('clears a filled cell and returns true', () => {
     const {instance, props} = makeControlsInstance(GridControls, {

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -414,7 +414,7 @@ export default class Toolbar extends Component {
               </tr>
               <tr>
                 <td>
-                  <code>Alt</code> + <code>S</code>, <code>W</code>, or <code>P</code>
+                  <code>Alt</code> / <code>Option</code> + <code>S</code>, <code>W</code>, or <code>P</code>
                 </td>
                 <td>
                   Check <b>S</b>quare, <b>W</b>ord, or <b>P</b>uzzle
@@ -422,7 +422,8 @@ export default class Toolbar extends Component {
               </tr>
               <tr>
                 <td>
-                  <code>Alt</code> + <code>Shift</code> + <code>S</code>, <code>W</code>, or <code>P</code>
+                  <code>Alt</code> / <code>Option</code> + <code>Shift</code> + <code>S</code>, <code>W</code>
+                  , or <code>P</code>
                 </td>
                 <td>
                   Reveal <b>S</b>quare, <b>W</b>ord, or <b>P</b>uzzle


### PR DESCRIPTION
## Summary
- Fix Alt+S/W/P (Check) and Alt+Shift+S/W/P (Reveal) keyboard shortcuts not working on Mac
- On Mac, Option key produces special Unicode characters (ß, ∑, π) as `ev.key`, causing the letter comparisons to fail silently
- Switch from `ev.key` to `ev.code` (physical key identifier like `KeyS`) which is consistent across all platforms
- Update shortcut help text to show "Alt / Option" for Mac users

## Test plan
- [x] All 260 existing tests pass
- [x] 7 new tests added covering Mac special chars, Shift+Alt reveal, and Windows/Linux Latin keys
- [ ] Manual: press Option+S/W/P on Mac to check square/word/puzzle
- [ ] Manual: press Option+Shift+S/W/P on Mac to reveal square/word/puzzle
- [ ] Manual: verify Alt+S/W/P still works on Windows/Linux

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)