### PR TITLE
Re-persist updateDisplayName and updateColor events

### DIFF
--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -27,8 +27,9 @@ function assignTimestamp(event: SocketEvent) {
 }
 
 // Event types that are broadcast to connected clients but NOT persisted to the database.
-// These are only meaningful in real-time and not needed for game resume or replay.
-const EPHEMERAL_EVENT_TYPES = new Set(['updateCursor', 'addPing', 'updateDisplayName', 'updateColor']);
+// updateCursor and addPing are high-frequency and only meaningful in real-time.
+// updateDisplayName and updateColor are persisted so players remain visible on reload.
+const EPHEMERAL_EVENT_TYPES = new Set(['updateCursor', 'addPing']);
 
 // ============== Socket Manager ==============
 

--- a/server/sql/create_game_events.sql
+++ b/server/sql/create_game_events.sql
@@ -1,7 +1,7 @@
 -- psql < create_puzzles.sql
 --
--- Persisted event types: create, updateCell, check, reveal, reset, updateClock, chat
--- Ephemeral event types (broadcast only, NOT written to DB): updateCursor, addPing, updateDisplayName, updateColor
+-- Persisted event types: create, updateCell, check, reveal, reset, updateClock, chat, updateDisplayName, updateColor
+-- Ephemeral event types (broadcast only, NOT written to DB): updateCursor, addPing
 -- See EPHEMERAL_EVENT_TYPES in server/SocketManager.ts
 
 CREATE TABLE public.game_events


### PR DESCRIPTION
## Summary
- Reverts part of PR #162 (reduce-game-events) that made `updateDisplayName` and `updateColor` ephemeral
- These events are low-frequency (once per user per session) and need to be persisted so players remain visible on page reload
- `updateCursor` and `addPing` remain ephemeral as intended

Fixes #175

## Test plan
- [x] Join a game, set display name and color
- [x] Reload the page — player should still appear with their name and color
- [ ] Verify `updateCursor` and `addPing` events are still NOT written to DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)