### PR TITLE
Auto-advance to next clue on desktop

### DIFF
--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -247,7 +247,7 @@ export default class GridControls extends Component {
     } else if (!this.props.frozen) {
       const letter = key.toUpperCase();
       if (validLetter(letter)) {
-        this.typeLetter(letter, shiftKey);
+        this.typeLetter(letter, shiftKey, {nextClueIfFilled: true});
         return true;
       }
     }
@@ -324,7 +324,7 @@ export default class GridControls extends Component {
     } else if (vimInsert && !this.props.frozen) {
       const letter = key.toUpperCase();
       if (validLetter(letter)) {
-        this.typeLetter(letter, shiftKey);
+        this.typeLetter(letter, shiftKey, {nextClueIfFilled: true});
         return true;
       }
     }


### PR DESCRIPTION
## Summary
- Pass `nextClueIfFilled: true` to `typeLetter()` in desktop keyboard handlers (normal and vim insert mode), matching the existing mobile behavior
- When a user fills in the last empty cell of a clue, the cursor now automatically advances to the next clue instead of staying put

Closes #50

## Test plan
- [x] Verified locally: typing the last letter of an across clue advances cursor to the next clue
- [x] Verified vim insert mode also advances
- [x] Mobile behavior unchanged (already had this option)
- [x] All frontend tests pass (283/283)
- [x] All server tests pass (27/27)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)