### PR TITLE
Fix color attribution sidebar on mobile

### DIFF
--- a/src/components/Player/css/index.css
+++ b/src/components/Player/css/index.css
@@ -87,6 +87,7 @@
 
 .player--mobile--wrapper {
   display: flex;
+  flex-direction: column;
   flex: 1;
 }
 


### PR DESCRIPTION
## Summary
- `.player--mobile--wrapper` had `display: flex` with default `flex-direction: row`, causing the color attribution counts panel to render beside the grid horizontally
- This squeezed the grid and created a narrow, unusable sidebar on mobile
- Fix: add `flex-direction: column` so the counts render below the grid

Closes #75

## Test plan
- [x] Toggle color attribution on mobile with filled squares — counts appear below grid, no sidebar squish
- [x] Desktop layout unaffected (uses separate `.player--main--wrapper` class)
- [x] All tests pass, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)