### PR TITLE
Make auto-advance to next clue a toggleable setting

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -15,6 +15,7 @@ import {toArr} from '../../lib/jsUtils';
 import {toHex, darken, GREENISH} from '../../lib/colors';
 
 const skipFilledSquaresKey = 'skip-filled-squares';
+const autoAdvanceCursorKey = 'auto-advance-cursor';
 const vimModeKey = 'vim-mode';
 const vimModeRegex = /^\d+(a|d)*$/;
 
@@ -30,6 +31,7 @@ export default class Game extends Component {
       vimInsert: false,
       vimCommand: false,
       skipFilledSquares: true,
+      autoAdvanceCursor: true,
       colorAttributionMode: false,
       expandMenu: false,
     };
@@ -57,6 +59,17 @@ export default class Game extends Component {
       console.error('Failed to parse local storage: skipFilledSquares');
     }
     this.setState({skipFilledSquares});
+
+    let autoAdvanceCursor = this.state.autoAdvanceCursor;
+    try {
+      const storedValue = localStorage.getItem(autoAdvanceCursorKey);
+      if (storedValue != null) {
+        autoAdvanceCursor = JSON.parse(storedValue);
+      }
+    } catch (e) {
+      console.error('Failed to parse local storage: autoAdvanceCursor');
+    }
+    this.setState({autoAdvanceCursor});
 
     this.componentDidUpdate({});
   }
@@ -215,6 +228,14 @@ export default class Game extends Component {
     });
   };
 
+  handleToggleAutoAdvanceCursor = () => {
+    this.setState((prevState) => {
+      const autoAdvanceCursor = !prevState.autoAdvanceCursor;
+      localStorage.setItem(autoAdvanceCursorKey, JSON.stringify(autoAdvanceCursor));
+      return {autoAdvanceCursor};
+    });
+  };
+
   handleTogglePencil = () => {
     this.setState((prevState) => ({
       pencilMode: !prevState.pencilMode,
@@ -361,6 +382,7 @@ export default class Game extends Component {
         onVimCommandPressEscape={this.handleRefocus}
         skipFilledSquares={this.state.skipFilledSquares}
         onToggleSkipFilledSquares={this.handleToggleSkipFilledSquares}
+        autoAdvanceCursor={this.state.autoAdvanceCursor}
         colorAttributionMode={this.state.colorAttributionMode}
         mobile={mobile}
         pickups={this.props.pickups}
@@ -403,6 +425,7 @@ export default class Game extends Component {
         autocheckMode={autocheckMode}
         vimMode={vimMode}
         skipFilledSquares={skipFilledSquares}
+        autoAdvanceCursor={this.state.autoAdvanceCursor}
         solved={solved}
         contest={!!this.game.contest}
         vimInsert={vimInsert}
@@ -419,6 +442,7 @@ export default class Game extends Component {
         onTogglePencil={this.handleTogglePencil}
         onToggleVimMode={this.handleToggleVimMode}
         onToggleSkipFilledSquares={this.handleToggleSkipFilledSquares}
+        onToggleAutoAdvanceCursor={this.handleToggleAutoAdvanceCursor}
         onToggleAutocheck={this.handleToggleAutocheck}
         onToggleListView={this.handleToggleListView}
         onToggleChat={this.handleToggleChat}

--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -247,7 +247,7 @@ export default class GridControls extends Component {
     } else if (!this.props.frozen) {
       const letter = key.toUpperCase();
       if (validLetter(letter)) {
-        this.typeLetter(letter, shiftKey, {nextClueIfFilled: true});
+        this.typeLetter(letter, shiftKey, {nextClueIfFilled: this.props.autoAdvanceCursor});
         return true;
       }
     }
@@ -324,7 +324,7 @@ export default class GridControls extends Component {
     } else if (vimInsert && !this.props.frozen) {
       const letter = key.toUpperCase();
       if (validLetter(letter)) {
-        this.typeLetter(letter, shiftKey, {nextClueIfFilled: true});
+        this.typeLetter(letter, shiftKey, {nextClueIfFilled: this.props.autoAdvanceCursor});
         return true;
       }
     }

--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -456,10 +456,14 @@ export default class MobileGridControls extends GridControls {
           this.setState({dbgstr: `TYPE letter ${char.toUpperCase()}`});
           if (delay) {
             setTimeout(() => {
-              this.typeLetter(char.toUpperCase(), char.toUpperCase() === char, {nextClueIfFilled: true});
+              this.typeLetter(char.toUpperCase(), char.toUpperCase() === char, {
+                nextClueIfFilled: this.props.autoAdvanceCursor,
+              });
             }, delay);
           } else {
-            this.typeLetter(char.toUpperCase(), char.toUpperCase() === char, {nextClueIfFilled: true});
+            this.typeLetter(char.toUpperCase(), char.toUpperCase() === char, {
+              nextClueIfFilled: this.props.autoAdvanceCursor,
+            });
           }
           delay += 20;
         }

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -366,6 +366,7 @@ export default class Player extends Component {
       onVimCommand,
       skipFilledSquares,
       onToggleSkipFilledSquares,
+      autoAdvanceCursor,
       grid,
       clues,
       circles,
@@ -459,6 +460,7 @@ export default class Player extends Component {
               onPressPeriod={onPressPeriod}
               skipFilledSquares={skipFilledSquares}
               onToggleSkipFilledSquares={onToggleSkipFilledSquares}
+              autoAdvanceCursor={autoAdvanceCursor}
               selected={selected}
               direction={direction}
               onSetDirection={this._setDirection}
@@ -491,6 +493,7 @@ export default class Player extends Component {
             onPressPeriod={onPressPeriod}
             skipFilledSquares={skipFilledSquares}
             onToggleSkipFilledSquares={onToggleSkipFilledSquares}
+            autoAdvanceCursor={autoAdvanceCursor}
             selected={selected}
             direction={direction}
             onSetDirection={this._setDirection}
@@ -535,6 +538,7 @@ export default class Player extends Component {
             onVimCommand={onVimCommand}
             skipFilledSquares={skipFilledSquares}
             onToggleSkipFilledSquares={onToggleSkipFilledSquares}
+            autoAdvanceCursor={autoAdvanceCursor}
             selected={selected}
             direction={direction}
             onSetDirection={this._setDirection}
@@ -572,6 +576,7 @@ export default class Player extends Component {
           onVimCommand={onVimCommand}
           skipFilledSquares={skipFilledSquares}
           onToggleSkipFilledSquares={onToggleSkipFilledSquares}
+          autoAdvanceCursor={autoAdvanceCursor}
           selected={selected}
           direction={direction}
           onSetDirection={this._setDirection}

--- a/src/components/Toolbar/css/ActionMenu.css
+++ b/src/components/Toolbar/css/ActionMenu.css
@@ -38,7 +38,14 @@
   background-color: #dddddd;
 }
 
+.toolbar--mobile--top .action-menu--list {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
 .toolbar--mobile--top .action-menu--list--action {
   box-sizing: border-box;
-  height: 48px;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
 }

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -186,9 +186,10 @@ export default class Toolbar extends Component {
   };
 
   renderExtrasMenu() {
-    const {vimMode, onToggleColorAttributionMode, skipFilledSquares} = this.props;
-    const vimModeLabel = vimMode ? 'Disable Vim Mode' : 'Enable Vim Mode';
-    const skipFilledSquaresLabel = skipFilledSquares ? "Don't skip filled squares" : 'Skip filled squares';
+    const {vimMode, onToggleColorAttributionMode, skipFilledSquares, autoAdvanceCursor} = this.props;
+    const vimModeLabel = vimMode ? 'Vim mode off' : 'Vim mode';
+    const skipFilledSquaresLabel = skipFilledSquares ? "Don't skip filled" : 'Skip filled';
+    const autoAdvanceLabel = autoAdvanceCursor ? 'No auto-advance' : 'Auto-advance';
     return (
       <ActionMenu
         label="Extras"
@@ -196,11 +197,12 @@ export default class Toolbar extends Component {
         actions={{
           [vimModeLabel]: this.handleVimModeClick,
           [skipFilledSquaresLabel]: this.handleSkipFilledSquaresClick,
+          [autoAdvanceLabel]: this.props.onToggleAutoAdvanceCursor,
           'Color Attribution': onToggleColorAttributionMode,
           'List View': this.props.onToggleListView,
           Pencil: this.props.onTogglePencil,
           Autocheck: this.props.onToggleAutocheck,
-          'Create new game link': () => window.open(`/beta/play/${this.props.pid}?new=1`, '_blank'),
+          'New game link': () => window.open(`/beta/play/${this.props.pid}?new=1`, '_blank'),
         }}
       />
     );
@@ -576,6 +578,7 @@ export default class Toolbar extends Component {
                 {this.renderColorAttributionToggle()}
                 {this.renderListViewButton()}
                 {!contest && this.renderAutocheck()}
+                {!replayMode && this.renderExtrasMenu()}
                 {this.renderChatButton()}
               </>
             )}


### PR DESCRIPTION
## Summary
- Add "Auto-advance" / "No auto-advance" toggle to the Extras menu, persisted to localStorage
- Defaults to **on** (current behavior) — users who prefer the old behavior can disable it
- Add Extras menu to mobile expanded toolbar (was previously desktop-only)
- Fix mobile menu overflow with `max-height: 70vh` + scrollable container
- Use `min-height` instead of fixed `height` for mobile menu items so multi-line labels don't overlap
- Shorten all Extras menu labels for better mobile fit

Closes #50

## Test plan
- [x] Desktop: toggle works, persists across page reload
- [x] Mobile: Extras menu visible in expanded toolbar, no overflow
- [x] ESLint, Prettier, Build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)