### PR TITLE
Fix dark mode across site

### DIFF
--- a/src/dark.css
+++ b/src/dark.css
@@ -306,14 +306,13 @@
   border-color: #5f6368 !important;
 }
 
-/* SweetAlert modals */
-
+/* SweetAlert Modals */
 .dark .swal-overlay {
   background-color: rgba(0, 0, 0, 0.6);
 }
 
 .dark .swal-modal {
-  background-color: #2d2d2d;
+  background-color: #1e1e1e;
   border: 1px solid #444;
 }
 
@@ -322,11 +321,15 @@
 }
 
 .dark .swal-text {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.75);
 }
 
-.dark .swal-text a {
-  color: var(--dark-blue-2);
+.dark .swal-content {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.dark .swal-content a {
+  color: #6aa9f4;
 }
 
 .dark .swal-button {
@@ -335,28 +338,83 @@
 }
 
 .dark .swal-button:hover {
-  background-color: var(--dark-blue-2);
+  background-color: #2d6da3;
 }
 
 .dark .swal-button--cancel {
-  background-color: #444;
-  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .dark .swal-button--cancel:hover {
-  background-color: #555;
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 .dark .swal-button--danger {
-  background-color: #c62828;
+  background-color: #d32f2f;
+  color: white;
 }
 
 .dark .swal-button--danger:hover {
   background-color: #b71c1c;
 }
 
-/* Chat header (puzzle instructions / description) */
+.dark .swal-button--loading {
+  color: transparent;
+}
 
+.dark .swal-icon--success {
+  border-color: #4caf50;
+}
+
+.dark .swal-icon--success__line {
+  background-color: #4caf50;
+}
+
+.dark .swal-icon--success__ring {
+  border-color: rgba(76, 175, 80, 0.3);
+}
+
+.dark .swal-icon--success__hide-corners {
+  background-color: #1e1e1e;
+}
+
+.dark .swal-icon--warning {
+  border-color: #ff9800;
+}
+
+.dark .swal-icon--warning__body,
+.dark .swal-icon--warning__dot {
+  background-color: #ff9800;
+}
+
+.dark .swal-icon--error {
+  border-color: #ef5350;
+}
+
+.dark .swal-icon--error__line {
+  background-color: #ef5350;
+}
+
+.dark .swal-icon--info {
+  border-color: #6aa9f4;
+}
+
+.dark .swal-icon--info::before,
+.dark .swal-icon--info::after {
+  background-color: #6aa9f4;
+}
+
+.dark .swal-footer {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-top-color: #444;
+}
+
+.dark .swal-content input[type='checkbox'] {
+  accent-color: #6aa9f4;
+}
+
+/* Chat header (puzzle instructions / description) */
 .dark .chat--header--subtitle {
   color: rgba(255, 255, 255, 0.6);
 }
@@ -365,33 +423,14 @@
   color: rgba(255, 255, 255, 0.7);
 }
 
-/* ActionMenu dropdowns (Check, Reveal, Reset, Extras, Play Again) */
-
-.dark .action-menu--list {
-  background-color: #2d2d2d;
-  border: 1px solid #555;
-}
-
-.dark .action-menu--list--action {
-  color: var(--dark-primary-text);
-  border-color: #555;
-}
-
-.dark .action-menu--list--action:hover {
-  background-color: #444;
-  color: var(--dark-primary-text);
-}
-
-/* Popup info panel (How to Enter Answers) */
-
+/* Toolbar Popup Menu */
 .dark .popup-menu--content {
-  background-color: #2d2d2d;
+  background-color: #2a2a2a;
   color: var(--dark-primary-text);
-  border: 1px solid #555;
 }
 
 .dark .popup-menu--content tr:nth-child(even) {
-  background-color: rgba(255, 255, 255, 0.06);
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 .dark .popup-menu--content code {
@@ -400,12 +439,47 @@
 }
 
 .dark .popup-menu--button:hover {
+  background-color: #383838;
+  color: var(--dark-primary-text);
+}
+
+.dark .popup-menu--content--popup {
+  border-color: #555;
+}
+
+/* Toolbar Action Menu */
+.dark .action-menu {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.dark .action-menu--button {
   background-color: transparent;
   color: var(--dark-primary-text);
 }
 
-/* Contest puzzle buttons */
+.dark .action-menu--list {
+  background-color: #2a2a2a;
+}
 
+.dark .action-menu--list--action {
+  border-color: #555;
+}
+
+.dark .action-menu--list--action:hover {
+  color: var(--dark-primary-text);
+  background-color: #383838;
+}
+
+/* Toolbar extras */
+.dark .toolbar code {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.dark .toolbar button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+/* Contest puzzle buttons */
 .dark .toolbar--mark-solved {
   background: #2e7d32;
 }
@@ -425,6 +499,39 @@
 .dark .entry--contest {
   color: #f0a050;
   border-color: #f0a050;
+}
+
+/* File Uploader */
+.dark .file-uploader--wrapper {
+  background-color: rgba(255, 255, 255, 0.05);
+  outline-color: rgba(255, 255, 255, 0.3);
+}
+
+.dark .file-uploader--box {
+  color: var(--dark-primary-text);
+}
+
+/* Powerups */
+.dark .powerups--main {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.dark .powerups--count {
+  background-color: #1565c0;
+}
+
+/* Welcome Page (additional) */
+.dark .welcome--searchbar {
+  border-color: #555;
+}
+
+.dark input::placeholder {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+/* Misc */
+.dark .info--hr {
+  border-top-color: rgba(255, 255, 255, 0.1);
 }
 
 :root {

--- a/src/pages/css/battle.css
+++ b/src/pages/css/battle.css
@@ -95,3 +95,13 @@
   font-size: 20px;
   font-weight: bold;
 }
+
+/* Dark mode */
+.dark .battle--main {
+  border-color: #444;
+}
+
+.dark .battle--button.disabled {
+  color: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.2);
+}

--- a/src/pages/css/replay.css
+++ b/src/pages/css/replay.css
@@ -110,3 +110,41 @@
   font-size: 13px;
   color: var(--main-gray-1);
 }
+
+/* Dark mode */
+.dark .replay .header--title {
+  color: var(--dark-primary-text);
+}
+
+.dark .replay .header--subtitle {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.dark .replay .scrub.active {
+  color: #6aa9f4;
+}
+
+.dark .replay--controls-container {
+  background: var(--dark-background);
+  border-top-color: #444;
+}
+
+.dark .replay--control-icons {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.dark .scrub--speed--option {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.dark .scrub--speed--option.selected {
+  color: #6aa9f4;
+}
+
+.dark .replay--unavailable {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.dark .replay--save-status {
+  color: rgba(255, 255, 255, 0.5);
+}

--- a/src/pages/css/replays.css
+++ b/src/pages/css/replays.css
@@ -97,3 +97,38 @@
 .replays .main-table td a:hover {
   text-decoration: underline;
 }
+
+/* Dark mode */
+.dark .replays .header--title {
+  color: var(--dark-primary-text);
+}
+
+.dark .replays .header--subtitle {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.dark .replays .scrub.active {
+  color: #6aa9f4;
+}
+
+.dark .replays .limit--button {
+  border-color: #555;
+  color: var(--dark-primary-text);
+}
+
+.dark .replays .limit--button:hover {
+  color: var(--dark-primary-text);
+  background-color: #383838;
+}
+
+.dark .replays .main-table tr:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.dark .replays .main-table td {
+  border-bottom-color: #444;
+}
+
+.dark .replays .main-table td a {
+  color: #6aa9f4;
+}


### PR DESCRIPTION
## Summary
- Fixes #191 — SweetAlert upload dialog dark mode (checkmark icon, loading dots overlapping text)
- Adds comprehensive dark mode support for all previously unstyled components:
  - **SweetAlert modals**: background, text, buttons, all icon types (success/warning/error/info), loading state
  - **Toolbar menus**: popup menu and action menu dropdowns
  - **File uploader**: dropzone background and outline
  - **Powerups**: background and badge color
  - **Replay page**: header, controls, scrub speeds
  - **Replays list page**: header, table, limit buttons, links
  - **Battle page**: borders and disabled button
  - **Welcome page gaps**: search bar border, input placeholder
  - **Misc**: info hr border, toolbar code/button hover

## Test plan
- [ ] Toggle dark mode on via nav menu
- [ ] Upload a puzzle — verify success dialog (green checkmark renders cleanly, no white artifacts)
- [ ] Upload invalid file — verify warning dialog
- [ ] Click info button in nav — verify info dialog
- [ ] Open Check/Reveal/More toolbar menus in a game — verify dark dropdown styling
- [ ] Check file uploader dropzone appearance
- [ ] Check welcome page search bar and filters
- [ ] Navigate to replay and replays pages
- [ ] Navigate to battle page

🤖 Generated with [Claude Code](https://claude.com/claude-code)