### PR TITLE
Add Playwright E2E smoke tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 backfills/
 build/
+e2e/
 jest.config.server.js
 middleware.ts
 prettier.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,13 @@ backfills/*.json
 
 .vercel
 
+# Playwright
+e2e/test-results/
+e2e/playwright-report/
+e2e/blob-report/
+e2e/playwright/.cache/
+playwright-report/
+test-results/
+
 # Claude Code
 .claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,18 @@ yarn test -- --testPathPattern=path     # Run a single frontend test file
 yarn test:server -- --testPathPattern=path  # Run a single server test file
 ```
 
+### E2E Tests (Playwright)
+```sh
+yarn test:e2e                           # All browsers against production
+yarn test:e2e:chromium                  # Quick single-browser run
+BASE_URL=https://testing.crosswithfriends.com yarn test:e2e  # Against testing env
+BASE_URL=http://localhost:3020 yarn test:e2e  # Against local dev server
+yarn test:e2e:headed                    # Debug with visible browsers
+yarn test:e2e:ui                        # Playwright UI mode
+npx playwright install                  # First-time: install browser binaries
+```
+E2E tests live in `e2e/` and cover smoke tests: page rendering, navigation, puzzle list, dark mode, and game page loading. Configurable via `BASE_URL` env var (defaults to `https://crosswithfriends.com`). When `BASE_URL` points to localhost, Playwright auto-starts the dev server via `yarn start` (or reuses one already running).
+
 ### Quality Checks
 ```sh
 npx eslint . --ext .js,.jsx,.ts,.tsx    # Lint (CI enforces --max-warnings 0)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ yarn build
 
 A pre-commit hook (via Husky + lint-staged) automatically lints and formats staged files on commit.
 
+**E2E tests (Playwright):**
+
+```sh
+yarn test:e2e                # Run against production (all browsers)
+yarn test:e2e:chromium       # Quick single-browser run
+
+# Run against a different environment
+BASE_URL=https://testing.crosswithfriends.com yarn test:e2e
+
+# Run against local dev server (auto-starts if not already running)
+BASE_URL=http://localhost:3020 yarn test:e2e
+```
+
+First-time setup: `npx playwright install` to download browser binaries.
+
 ## Database Scripts
 
 Scripts in `server/jobs/` for database maintenance:

--- a/e2e/fixtures/base.ts
+++ b/e2e/fixtures/base.ts
@@ -1,0 +1,54 @@
+import {test as base, expect, Page} from '@playwright/test';
+
+export interface SmokeHelpers {
+  page: Page;
+  consoleErrors: string[];
+}
+
+export const test = base.extend<{smoke: SmokeHelpers}>({
+  smoke: async ({page}, use) => {
+    const consoleErrors: string[] = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    page.on('pageerror', (err) => {
+      consoleErrors.push(err.message);
+    });
+
+    await use({page, consoleErrors});
+  },
+});
+
+export {expect};
+
+/**
+ * Assert no fatal React errors occurred (blank page, crash).
+ * Filters out known benign warnings.
+ */
+export function assertNoFatalErrors(consoleErrors: string[]) {
+  const fatal = consoleErrors.filter(
+    (e) =>
+      !e.includes('Warning:') &&
+      !e.includes('DevTools') &&
+      !e.includes('favicon') &&
+      !e.includes('third-party cookie') &&
+      !e.includes('WebSocket') &&
+      !e.includes('net::ERR') &&
+      !e.includes('Failed to load resource') &&
+      !e.includes('the server responded with a status of') &&
+      !e.includes('Viewport argument key')
+  );
+  expect(fatal).toEqual([]);
+}
+
+/**
+ * Assert the page rendered meaningful content (not a blank white page).
+ */
+export async function assertPageRendered(page: Page) {
+  await expect(page.locator('#root')).not.toBeEmpty();
+  await expect(page.locator('.router-wrapper')).toBeVisible();
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,50 @@
+import {defineConfig, devices} from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'https://crosswithfriends.com';
+const isLocal = BASE_URL.includes('localhost') || BASE_URL.includes('127.0.0.1');
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+    {
+      name: 'firefox',
+      use: {...devices['Desktop Firefox']},
+    },
+    {
+      name: 'webkit',
+      use: {...devices['Desktop Safari']},
+    },
+  ],
+  outputDir: './test-results',
+
+  // When testing against localhost, start the dev server automatically
+  ...(isLocal
+    ? {
+        webServer: {
+          command: 'yarn start',
+          url: BASE_URL,
+          reuseExistingServer: true,
+          timeout: 60_000,
+        },
+      }
+    : {}),
+});

--- a/e2e/tests/dark-mode.spec.ts
+++ b/e2e/tests/dark-mode.spec.ts
@@ -1,0 +1,65 @@
+import {test, expect, assertNoFatalErrors, assertPageRendered} from '../fixtures/base';
+
+test.describe('Dark mode', () => {
+  test('toggles through dark mode states: Off -> On -> System -> Off', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/');
+    await assertPageRendered(page);
+
+    const routerWrapper = page.locator('.router-wrapper');
+
+    // Initially dark mode should be off
+    await expect(routerWrapper).not.toHaveClass(/\bdark\b/);
+
+    // Open user menu
+    await page.locator('.nav--user-menu--trigger').click();
+    await expect(page.locator('.nav--user-menu--dropdown')).toBeVisible();
+
+    // Should show "Dark Mode: Off"
+    await expect(page.locator('.nav--user-menu--dark-mode')).toContainText('Dark Mode: Off');
+
+    // Toggle to On
+    await page.locator('.nav--user-menu--dark-mode').click();
+    await expect(page.locator('.nav--user-menu--dark-mode')).toContainText('Dark Mode: On');
+    await expect(routerWrapper).toHaveClass(/\bdark\b/);
+
+    // Body should also have dark class
+    const bodyHasDark = await page.evaluate(() => document.body.classList.contains('dark'));
+    expect(bodyHasDark).toBe(true);
+
+    // Toggle to System
+    await page.locator('.nav--user-menu--dark-mode').click();
+    await expect(page.locator('.nav--user-menu--dark-mode')).toContainText('Dark Mode: System');
+
+    // Toggle back to Off
+    await page.locator('.nav--user-menu--dark-mode').click();
+    await expect(page.locator('.nav--user-menu--dark-mode')).toContainText('Dark Mode: Off');
+    await expect(routerWrapper).not.toHaveClass(/\bdark\b/);
+
+    assertNoFatalErrors(consoleErrors);
+  });
+
+  test('dark mode applies visual changes to the nav', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/');
+    await assertPageRendered(page);
+
+    // Get nav background color in light mode
+    const lightNavBg = await page.locator('.nav').evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    // Toggle to dark mode
+    await page.locator('.nav--user-menu--trigger').click();
+    await page.locator('.nav--user-menu--dark-mode').click();
+    await expect(page.locator('.router-wrapper')).toHaveClass(/\bdark\b/);
+
+    // Get nav background color in dark mode
+    const darkNavBg = await page.locator('.nav').evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    // Colors should be different
+    expect(darkNavBg).not.toEqual(lightNavBg);
+
+    assertNoFatalErrors(consoleErrors);
+  });
+});

--- a/e2e/tests/game.spec.ts
+++ b/e2e/tests/game.spec.ts
@@ -1,0 +1,47 @@
+import {test, expect, assertNoFatalErrors, assertPageRendered} from '../fixtures/base';
+
+test.describe('Game page', () => {
+  test('navigating to a puzzle from the list loads the game page', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/');
+    await assertPageRendered(page);
+
+    // Wait for puzzle entries to load
+    await expect(page.locator('.entry').first()).toBeVisible({timeout: 15_000});
+
+    // Get the first puzzle link
+    const firstPuzzleLink = page.locator('a[href*="/beta/play/"]').first();
+    const href = await firstPuzzleLink.getAttribute('href');
+    expect(href).toBeTruthy();
+
+    // Navigate to the puzzle
+    await page.goto(href!);
+    await assertPageRendered(page);
+
+    // Game page should render .room container
+    await expect(page.locator('.room')).toBeVisible({timeout: 15_000});
+
+    // Nav should be present
+    await expect(page.locator('.nav')).toBeVisible();
+
+    assertNoFatalErrors(consoleErrors);
+  });
+
+  test('game page does not show a blank screen', async ({smoke}) => {
+    const {page} = smoke;
+
+    await page.goto('/');
+    await expect(page.locator('.entry').first()).toBeVisible({timeout: 15_000});
+
+    const firstPuzzleLink = page.locator('a[href*="/beta/play/"]').first();
+    await firstPuzzleLink.click();
+
+    // Wait for page to settle
+    await page.waitForLoadState('networkidle');
+
+    // Root should have content
+    const rootContent = await page.locator('#root').innerHTML();
+    expect(rootContent.length).toBeGreaterThan(100);
+  });
+});

--- a/e2e/tests/home.spec.ts
+++ b/e2e/tests/home.spec.ts
@@ -1,0 +1,37 @@
+import {test, expect, assertNoFatalErrors, assertPageRendered} from '../fixtures/base';
+
+test.describe('Home page', () => {
+  test('renders the welcome page with nav and puzzle list', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/');
+    await assertPageRendered(page);
+
+    // Nav bar with site name
+    await expect(page.locator('.nav')).toBeVisible();
+    await expect(page.locator('.nav--left a')).toContainText('Cross with Friends');
+
+    // User menu trigger
+    await expect(page.locator('.nav--user-menu--trigger')).toBeVisible();
+
+    // Welcome page container
+    await expect(page.locator('.welcome')).toBeVisible();
+
+    // Search bar input
+    await expect(page.locator('input.welcome--searchbar')).toBeVisible();
+
+    // Filter sidebar (desktop viewport)
+    await expect(page.locator('.welcome--sidebar')).toBeVisible();
+
+    // At least one filter checkbox group
+    await expect(page.locator('.checkbox-group').first()).toBeVisible();
+
+    assertNoFatalErrors(consoleErrors);
+  });
+
+  test('page title is correct', async ({smoke}) => {
+    const {page} = smoke;
+    await page.goto('/');
+    await expect(page).toHaveTitle('Cross with Friends');
+  });
+});

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -1,0 +1,83 @@
+import {test, expect, assertNoFatalErrors, assertPageRendered} from '../fixtures/base';
+
+test.describe('Navigation', () => {
+  test('nav logo links to home page', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/privacy');
+    await assertPageRendered(page);
+
+    // Click the logo/site name link
+    await page.locator('.nav--left a').click();
+
+    // Should navigate to home (may redirect to www.)
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator('.welcome')).toBeVisible();
+
+    assertNoFatalErrors(consoleErrors);
+  });
+
+  test('footer links navigate correctly', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/help');
+    await assertPageRendered(page);
+
+    // Privacy Policy link
+    await page.locator('.footer--links a', {hasText: 'Privacy Policy'}).click();
+    await expect(page).toHaveURL(/\/privacy$/);
+    await expect(page.locator('h1')).toContainText('Privacy Policy');
+
+    // Terms of Service link
+    await page.locator('.footer--links a', {hasText: 'Terms of Service'}).click();
+    await expect(page).toHaveURL(/\/terms$/);
+    await expect(page.locator('h1')).toContainText('Terms of Service');
+
+    // Help link
+    await page.locator('.footer--links a', {hasText: 'Help'}).click();
+    await expect(page).toHaveURL(/\/help$/);
+    await expect(page.locator('h1')).toContainText('Help & FAQ');
+
+    assertNoFatalErrors(consoleErrors);
+  });
+
+  test('user menu opens with expected items for unauthenticated user', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/');
+    await assertPageRendered(page);
+
+    // Open user menu
+    await page.locator('.nav--user-menu--trigger').click();
+    await expect(page.locator('.nav--user-menu--dropdown')).toBeVisible();
+
+    // Unauthenticated items
+    await expect(page.locator('.nav--user-menu--item', {hasText: 'Sign Up / Log In'})).toBeVisible();
+    await expect(page.locator('.nav--user-menu--dark-mode')).toBeVisible();
+    await expect(page.locator('.nav--user-menu--item', {hasText: 'About'})).toBeVisible();
+    await expect(page.locator('.nav--user-menu--item', {hasText: 'Help'})).toBeVisible();
+
+    // Should NOT show authenticated items
+    await expect(page.locator('.nav--user-menu--item', {hasText: 'Settings'})).not.toBeVisible();
+    await expect(page.locator('.nav--user-menu--item', {hasText: 'Log out'})).not.toBeVisible();
+
+    assertNoFatalErrors(consoleErrors);
+  });
+
+  test('user menu Help link navigates to /help', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/');
+    await assertPageRendered(page);
+
+    // Open user menu and click Help
+    await page.locator('.nav--user-menu--trigger').click();
+    await expect(page.locator('.nav--user-menu--dropdown')).toBeVisible();
+    await page.locator('.nav--user-menu--item', {hasText: 'Help'}).click();
+
+    await expect(page).toHaveURL(/\/help$/);
+    await expect(page.locator('h1')).toContainText('Help & FAQ');
+
+    assertNoFatalErrors(consoleErrors);
+  });
+});

--- a/e2e/tests/puzzle-list.spec.ts
+++ b/e2e/tests/puzzle-list.spec.ts
@@ -1,0 +1,54 @@
+import {test, expect, assertNoFatalErrors, assertPageRendered} from '../fixtures/base';
+
+test.describe('Puzzle list', () => {
+  test('loads puzzles from the API', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/');
+    await assertPageRendered(page);
+
+    // Wait for puzzle entries to appear (API + Firebase can be slow)
+    await expect(page.locator('.entry').first()).toBeVisible({timeout: 15_000});
+
+    // Multiple entries loaded
+    const entryCount = await page.locator('.entry').count();
+    expect(entryCount).toBeGreaterThan(0);
+
+    assertNoFatalErrors(consoleErrors);
+  });
+
+  test('search input accepts text and filters results', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/');
+    await assertPageRendered(page);
+
+    // Wait for puzzles to load
+    await expect(page.locator('.entry').first()).toBeVisible({timeout: 15_000});
+
+    // Type a search term
+    await page.locator('input.welcome--searchbar').fill('mini');
+
+    // Wait for debounce (250ms) + re-render
+    await page.waitForTimeout(500);
+
+    // List should still have entries (mini puzzles exist)
+    await expect(page.locator('.entry').first()).toBeVisible();
+
+    assertNoFatalErrors(consoleErrors);
+  });
+
+  test('puzzle entry links to a play page', async ({smoke}) => {
+    const {page, consoleErrors} = smoke;
+
+    await page.goto('/');
+    await expect(page.locator('.entry').first()).toBeVisible({timeout: 15_000});
+
+    // First entry link should point to /beta/play/
+    const firstEntryLink = page.locator('a[href*="/beta/play/"]').first();
+    const href = await firstEntryLink.getAttribute('href');
+    expect(href).toMatch(/\/beta\/play\//);
+
+    assertNoFatalErrors(consoleErrors);
+  });
+});

--- a/e2e/tests/static-pages.spec.ts
+++ b/e2e/tests/static-pages.spec.ts
@@ -1,0 +1,36 @@
+import {test, expect, assertNoFatalErrors, assertPageRendered} from '../fixtures/base';
+
+const staticPages = [
+  {path: '/privacy', title: 'Privacy Policy - Cross with Friends', heading: 'Privacy Policy'},
+  {path: '/terms', title: 'Terms of Service - Cross with Friends', heading: 'Terms of Service'},
+  {path: '/help', title: 'Help & FAQ - Cross with Friends', heading: 'Help & FAQ'},
+];
+
+for (const {path, title, heading} of staticPages) {
+  test.describe(`${heading} page`, () => {
+    test(`renders at ${path}`, async ({smoke}) => {
+      const {page, consoleErrors} = smoke;
+
+      await page.goto(path);
+      await assertPageRendered(page);
+
+      // Page title via react-helmet
+      await expect(page).toHaveTitle(title);
+
+      // Nav bar
+      await expect(page.locator('.nav')).toBeVisible();
+
+      // Main heading
+      await expect(page.locator('h1')).toContainText(heading);
+
+      // Content section has text
+      await expect(page.locator('.legal--content')).not.toBeEmpty();
+
+      // Footer with links
+      await expect(page.locator('.footer')).toBeVisible();
+      await expect(page.locator('.footer--links')).toBeVisible();
+
+      assertNoFatalErrors(consoleErrors);
+    });
+  });
+}

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@babel/core": "^7.0.0-0",
     "@babel/node": "^7.10.5",
     "@babel/preset-env": "^7.11.0",
+    "@playwright/test": "^1.58.2",
     "@types/argparse": "^1.0.38",
     "@types/bcrypt": "^6.0.0",
     "@types/cookie-parser": "^1.4.10",
@@ -122,10 +123,15 @@
     "test": "react-scripts test --env=jsdom",
     "test:server": "jest --config jest.config.server.js",
     "eject": "react-scripts eject",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:e2e": "npx playwright test --config=e2e/playwright.config.ts",
+    "test:e2e:headed": "npx playwright test --config=e2e/playwright.config.ts --headed",
+    "test:e2e:ui": "npx playwright test --config=e2e/playwright.config.ts --ui",
+    "test:e2e:chromium": "npx playwright test --config=e2e/playwright.config.ts --project=chromium",
+    "test:e2e:report": "npx playwright show-report e2e/playwright-report"
   },
   "lint-staged": {
-    "!(backfills|utils)/**/*.{js,jsx,ts,tsx}": [
+    "!(backfills|utils|e2e)/**/*.{js,jsx,ts,tsx}": [
       "eslint --max-warnings=0",
       "prettier --write"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2659,6 +2659,13 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
+"@playwright/test@^1.58.2":
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#b0ad585d2e950d690ef52424967a42f40c6d2cbd"
+  integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
+  dependencies:
+    playwright "1.58.2"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.17"
   resolved "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz"
@@ -7692,15 +7699,15 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@2.3.2, fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^2.3.2:
   version "2.3.3"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
-fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -11840,6 +11847,20 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+playwright-core@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.2.tgz#ac5f5b4b10d29bcf934415f0b8d133b34b0dcb13"
+  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+
+playwright@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.2.tgz#afe547164539b0bcfcb79957394a7a3fa8683cfd"
+  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+  dependencies:
+    playwright-core "1.58.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
## Summary
- Adds 16 Playwright E2E smoke tests across 6 test files (home, puzzle list, static pages, navigation, dark mode, game page)
- Configurable via `BASE_URL` env var — defaults to production, works against testing env and localhost
- Auto-starts local dev server when `BASE_URL` points to localhost
- Excludes `e2e/` from ESLint and lint-staged (Playwright has different conventions)
- Updates README.md and CLAUDE.md with E2E test commands

## Test plan
- [x] 48/48 passed against production (Chromium, Firefox, WebKit)
- [x] 48/48 passed against localhost (all browsers)
- [ ] Run against `testing.crosswithfriends.com` to validate React 17 upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)