### PR TITLE
Split profile stats by day of week

### DIFF
--- a/e2e/tests/toolbar-actions.spec.ts
+++ b/e2e/tests/toolbar-actions.spec.ts
@@ -2,8 +2,16 @@ import {test, expect, assertNoFatalErrors} from '../fixtures/game';
 
 test.describe('Toolbar actions', () => {
   test('Check Square marks a wrong letter as bad', async ({gamePage}) => {
-    const {clickCell, typeLetter, openActionMenu, clickAction, cellHasClass, findFirstWhiteCell, consoleErrors, page} =
-      gamePage;
+    const {
+      clickCell,
+      typeLetter,
+      openActionMenu,
+      clickAction,
+      cellHasClass,
+      findFirstWhiteCell,
+      consoleErrors,
+      page,
+    } = gamePage;
 
     const {r, c} = await findFirstWhiteCell();
     await clickCell(r, c);
@@ -32,7 +40,15 @@ test.describe('Toolbar actions', () => {
   });
 
   test('Reveal Square confirms and applies answer', async ({gamePage}) => {
-    const {clickCell, typeLetter, openActionMenu, clickAction, findFirstWhiteCell, consoleErrors, page} = gamePage;
+    const {
+      clickCell,
+      typeLetter,
+      openActionMenu,
+      clickAction,
+      findFirstWhiteCell,
+      consoleErrors,
+      page,
+    } = gamePage;
 
     const {r, c} = await findFirstWhiteCell();
     await clickCell(r, c);
@@ -61,8 +77,16 @@ test.describe('Toolbar actions', () => {
   });
 
   test('Reset Square clears the cell value', async ({gamePage}) => {
-    const {clickCell, typeLetter, getCellValue, openActionMenu, clickAction, findFirstWhiteCell, consoleErrors, page} =
-      gamePage;
+    const {
+      clickCell,
+      typeLetter,
+      getCellValue,
+      openActionMenu,
+      clickAction,
+      findFirstWhiteCell,
+      consoleErrors,
+      page,
+    } = gamePage;
 
     const {r, c} = await findFirstWhiteCell();
     await clickCell(r, c);
@@ -121,7 +145,15 @@ test.describe('Toolbar actions', () => {
   });
 
   test('Check Word marks wrong cells', async ({gamePage}) => {
-    const {clickCell, typeLetter, openActionMenu, clickAction, findFirstWhiteCell, consoleErrors, page} = gamePage;
+    const {
+      clickCell,
+      typeLetter,
+      openActionMenu,
+      clickAction,
+      findFirstWhiteCell,
+      consoleErrors,
+      page,
+    } = gamePage;
 
     const {r, c} = await findFirstWhiteCell();
     await clickCell(r, c);

--- a/server/__tests__/model/puzzle_solve.test.ts
+++ b/server/__tests__/model/puzzle_solve.test.ts
@@ -69,10 +69,14 @@ describe('getUserSolveStats', () => {
     resetPoolMocks();
   });
 
-  it('returns {totalSolved, bySize, history} structure', async () => {
+  it('returns {totalSolved, bySize, byDay, history} structure', async () => {
     // Stats query
     pool.query.mockResolvedValueOnce({
       rows: [{size: '15x15', count: 5, avg_time: 300}],
+    });
+    // Day stats query
+    pool.query.mockResolvedValueOnce({
+      rows: [{dow: 'Mon', count: 3, avg_time: 120}],
     });
     // History query
     pool.query.mockResolvedValueOnce({
@@ -82,7 +86,9 @@ describe('getUserSolveStats', () => {
     const result = await getUserSolveStats('user-1');
     expect(result).toHaveProperty('totalSolved');
     expect(result).toHaveProperty('bySize');
+    expect(result).toHaveProperty('byDay');
     expect(result).toHaveProperty('history');
+    expect(result.byDay).toEqual([{day: 'Mon', count: 3, avgTime: 120}]);
   });
 
   it('sums count across sizes for totalSolved', async () => {
@@ -92,7 +98,8 @@ describe('getUserSolveStats', () => {
         {size: '15x15', count: 7, avg_time: 300},
       ],
     });
-    pool.query.mockResolvedValueOnce({rows: []});
+    pool.query.mockResolvedValueOnce({rows: []}); // day stats
+    pool.query.mockResolvedValueOnce({rows: []}); // history
 
     const result = await getUserSolveStats('user-1');
     expect(result.totalSolved).toBe(10);
@@ -101,6 +108,7 @@ describe('getUserSolveStats', () => {
 
   it('defaults title to "Untitled" and playerCount to 1', async () => {
     pool.query.mockResolvedValueOnce({rows: []}); // stats
+    pool.query.mockResolvedValueOnce({rows: []}); // day stats
     pool.query.mockResolvedValueOnce({
       rows: [
         {
@@ -111,6 +119,7 @@ describe('getUserSolveStats', () => {
           player_count: null,
           title: null,
           size: '5x5',
+          dow: null,
         },
       ],
     }); // history
@@ -118,10 +127,34 @@ describe('getUserSolveStats', () => {
     const result = await getUserSolveStats('user-1');
     expect(result.history[0].title).toBe('Untitled');
     expect(result.history[0].playerCount).toBe(1);
+    expect(result.history[0].dow).toBeNull();
+  });
+
+  it('includes dow field in history items', async () => {
+    pool.query.mockResolvedValueOnce({rows: []}); // stats
+    pool.query.mockResolvedValueOnce({rows: []}); // day stats
+    pool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          pid: 'p1',
+          gid: 'g1',
+          time_taken_to_solve: 200,
+          solved_time: new Date('2026-01-15'),
+          player_count: 1,
+          title: 'Monday Puzzle',
+          size: '5x5',
+          dow: 'Mon',
+        },
+      ],
+    }); // history
+
+    const result = await getUserSolveStats('user-1');
+    expect(result.history[0].dow).toBe('Mon');
   });
 
   it('fetches co-solvers for collaborative games (player_count > 1)', async () => {
     pool.query.mockResolvedValueOnce({rows: []}); // stats
+    pool.query.mockResolvedValueOnce({rows: []}); // day stats
     pool.query.mockResolvedValueOnce({
       rows: [
         {
@@ -132,6 +165,7 @@ describe('getUserSolveStats', () => {
           player_count: 3,
           title: 'Collab Puzzle',
           size: '15x15',
+          dow: null,
         },
       ],
     }); // history

--- a/server/__tests__/model/sql_helpers.test.ts
+++ b/server/__tests__/model/sql_helpers.test.ts
@@ -1,0 +1,35 @@
+import {dayOfWeekExtract} from '../../model/sql_helpers';
+
+describe('dayOfWeekExtract', () => {
+  it('returns SQL with table alias prefix when alias is provided', () => {
+    const sql = dayOfWeekExtract('p');
+    expect(sql).toContain("p.content->'info'->>'title'");
+    expect(sql).toContain("THEN 'Mon'");
+    expect(sql).toContain("THEN 'Sun'");
+  });
+
+  it('returns SQL without prefix when alias is empty string', () => {
+    const sql = dayOfWeekExtract('');
+    expect(sql).toContain("content->'info'->>'title'");
+    expect(sql).not.toContain(".content->'info'->>'title'");
+  });
+
+  it('uses default empty alias when called with no arguments', () => {
+    const sql = dayOfWeekExtract();
+    expect(sql).toContain("content->'info'->>'title'");
+    expect(sql).not.toContain(".content->'info'->>'title'");
+  });
+
+  it('contains all seven days of the week', () => {
+    const sql = dayOfWeekExtract('p');
+    const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    days.forEach((day) => {
+      expect(sql).toContain(`THEN '${day}'`);
+    });
+  });
+
+  it('includes ELSE NULL fallback', () => {
+    const sql = dayOfWeekExtract('p');
+    expect(sql).toContain('ELSE NULL');
+  });
+});

--- a/server/api/user_stats.ts
+++ b/server/api/user_stats.ts
@@ -32,7 +32,7 @@ router.get('/:userId', async (req, res, next) => {
       return;
     }
 
-    const {totalSolved, bySize, history} = await getUserSolveStats(userId);
+    const {totalSolved, bySize, byDay, history} = await getUserSolveStats(userId);
 
     let uploads: Awaited<ReturnType<typeof getUserUploadedPuzzles>> = [];
     try {
@@ -55,7 +55,7 @@ router.get('/:userId', async (req, res, next) => {
         displayName: user.display_name,
         createdAt: user.created_at,
       },
-      stats: {totalSolved, bySize},
+      stats: {totalSolved, bySize, byDay},
       history,
       uploads,
       inProgress,

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -4,6 +4,7 @@ import Joi from 'joi';
 import * as uuid from 'uuid';
 import {PuzzleJson, ListPuzzleRequestFilters, AddPuzzleResult} from '@shared/types';
 import {pool} from './pool';
+import {dayOfWeekExtract} from './sql_helpers';
 
 // ================ Read and Write methods used to interface with postgres ========== //
 
@@ -69,19 +70,8 @@ const buildTypeFilterClause = (typeFilter: ListPuzzleRequestFilters['typeFilter'
   return `AND (${conditions.join(' OR ')})`;
 };
 
-// Case-insensitive day extraction with support for various abbreviations (Mon, Tues, Weds, Thurs, etc.)
-const DAY_EXTRACT = `
-  CASE
-    WHEN UPPER(content->'info'->>'title') ~ '\\m(MONDAY|MON)\\M' THEN 'Mon'
-    WHEN UPPER(content->'info'->>'title') ~ '\\m(TUESDAY|TUE|TUES)\\M' THEN 'Tue'
-    WHEN UPPER(content->'info'->>'title') ~ '\\m(WEDNESDAY|WED|WEDS)\\M' THEN 'Wed'
-    WHEN UPPER(content->'info'->>'title') ~ '\\m(THURSDAY|THU|THURS)\\M' THEN 'Thu'
-    WHEN UPPER(content->'info'->>'title') ~ '\\m(FRIDAY|FRI)\\M' THEN 'Fri'
-    WHEN UPPER(content->'info'->>'title') ~ '\\m(SATURDAY|SAT)\\M' THEN 'Sat'
-    WHEN UPPER(content->'info'->>'title') ~ '\\m(SUNDAY|SUN)\\M' THEN 'Sun'
-    ELSE NULL
-  END
-`;
+// Day-of-week extraction from puzzle titles — no alias needed here since queries reference `content` directly
+const DAY_EXTRACT = dayOfWeekExtract('');
 
 const buildDayOfWeekFilterClause = (
   dayFilter: ListPuzzleRequestFilters['dayOfWeekFilter'],

--- a/server/model/puzzle_solve.ts
+++ b/server/model/puzzle_solve.ts
@@ -1,12 +1,14 @@
 import moment from 'moment';
 import {PuzzleJson} from '@shared/types';
 import {pool} from './pool';
+import {dayOfWeekExtract} from './sql_helpers';
 
 export type UserSolveHistoryItem = {
   pid: string;
   gid: string;
   title: string;
   size: string;
+  dow: string | null;
   time: number;
   solvedAt: string;
   playerCount: number;
@@ -20,9 +22,20 @@ export type SizeStats = {
   avgTime: number;
 };
 
+export type DayOfWeekStats = {
+  day: string;
+  count: number;
+  avgTime: number;
+};
+
 export async function getUserSolveStats(
   userId: string
-): Promise<{totalSolved: number; bySize: SizeStats[]; history: UserSolveHistoryItem[]}> {
+): Promise<{
+  totalSolved: number;
+  bySize: SizeStats[];
+  byDay: DayOfWeekStats[];
+  history: UserSolveHistoryItem[];
+}> {
   // Summary stats by grid size — count distinct puzzles, use best time per puzzle for avg
   const statsResult = await pool.query(
     `SELECT size, COUNT(*)::int AS count, ROUND(AVG(best_time))::int AS avg_time
@@ -51,6 +64,30 @@ export async function getUserSolveStats(
     avgTime: r.avg_time,
   }));
 
+  // Stats by day of week — group by day extracted from puzzle title
+  const dayResult = await pool.query(
+    `SELECT dow, COUNT(*)::int AS count, ROUND(AVG(best_time))::int AS avg_time
+     FROM (
+       SELECT DISTINCT ON (ps.pid)
+         ps.pid,
+         ps.time_taken_to_solve AS best_time,
+         ${dayOfWeekExtract('p')} AS dow
+       FROM puzzle_solves ps
+       JOIN puzzles p ON ps.pid = p.pid
+       WHERE ps.user_id = $1
+       ORDER BY ps.pid, ps.time_taken_to_solve ASC
+     ) best_solves
+     WHERE dow IS NOT NULL
+     GROUP BY dow`,
+    [userId]
+  );
+
+  const byDay: DayOfWeekStats[] = dayResult.rows.map((r: any) => ({
+    day: r.dow,
+    count: r.count,
+    avgTime: r.avg_time,
+  }));
+
   // Recent solve history with puzzle info
   const historyResult = await pool.query(
     `SELECT
@@ -59,7 +96,8 @@ export async function getUserSolveStats(
        GREATEST(jsonb_array_length(p.content->'grid'), jsonb_array_length(p.content->'grid'->0))::text
          || 'x' ||
        LEAST(jsonb_array_length(p.content->'grid'), jsonb_array_length(p.content->'grid'->0))::text
-         AS size
+         AS size,
+       ${dayOfWeekExtract('p')} AS dow
      FROM puzzle_solves ps
      JOIN puzzles p ON ps.pid = p.pid
      WHERE ps.user_id = $1
@@ -109,6 +147,7 @@ export async function getUserSolveStats(
       gid: r.gid,
       title: r.title || 'Untitled',
       size: r.size,
+      dow: r.dow || null,
       time: Number(r.time_taken_to_solve),
       solvedAt: r.solved_time ? r.solved_time.toISOString() : '',
       playerCount: pc,
@@ -117,7 +156,7 @@ export async function getUserSolveStats(
     };
   });
 
-  return {totalSolved, bySize, history};
+  return {totalSolved, bySize, byDay, history};
 }
 
 export type InProgressGameItem = {

--- a/server/model/sql_helpers.ts
+++ b/server/model/sql_helpers.ts
@@ -1,0 +1,20 @@
+/**
+ * Returns a SQL CASE expression that extracts the day of the week from a puzzle title.
+ * Uses PostgreSQL regex word boundaries to match day names and common abbreviations.
+ *
+ * @param tableAlias - Table alias for the puzzles table (e.g. 'p'). Pass empty string for no alias.
+ */
+export function dayOfWeekExtract(tableAlias = ''): string {
+  const prefix = tableAlias ? `${tableAlias}.` : '';
+  return `
+  CASE
+    WHEN UPPER(${prefix}content->'info'->>'title') ~ '\\m(MONDAY|MON)\\M' THEN 'Mon'
+    WHEN UPPER(${prefix}content->'info'->>'title') ~ '\\m(TUESDAY|TUE|TUES)\\M' THEN 'Tue'
+    WHEN UPPER(${prefix}content->'info'->>'title') ~ '\\m(WEDNESDAY|WED|WEDS)\\M' THEN 'Wed'
+    WHEN UPPER(${prefix}content->'info'->>'title') ~ '\\m(THURSDAY|THU|THURS)\\M' THEN 'Thu'
+    WHEN UPPER(${prefix}content->'info'->>'title') ~ '\\m(FRIDAY|FRI)\\M' THEN 'Fri'
+    WHEN UPPER(${prefix}content->'info'->>'title') ~ '\\m(SATURDAY|SAT)\\M' THEN 'Sat'
+    WHEN UPPER(${prefix}content->'info'->>'title') ~ '\\m(SUNDAY|SUN)\\M' THEN 'Sun'
+    ELSE NULL
+  END`;
+}

--- a/src/api/user_stats.ts
+++ b/src/api/user_stats.ts
@@ -10,6 +10,7 @@ export interface SolveHistoryItem {
   gid: string;
   title: string;
   size: string;
+  dow: string | null;
   time: number;
   solvedAt: string;
   playerCount: number;
@@ -19,6 +20,12 @@ export interface SolveHistoryItem {
 
 export interface SizeStats {
   size: string;
+  count: number;
+  avgTime: number;
+}
+
+export interface DayOfWeekStats {
+  day: string;
   count: number;
   avgTime: number;
 }
@@ -49,6 +56,7 @@ export interface UserStatsResponse {
   stats?: {
     totalSolved: number;
     bySize: SizeStats[];
+    byDay: DayOfWeekStats[];
   };
   history?: SolveHistoryItem[];
   uploads?: UploadedPuzzle[];

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -57,23 +57,43 @@ function CollabTag({playerCount, coSolvers, anonCount}) {
   );
 }
 
+const DAY_ORDER = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
 function StatsCards({stats}) {
-  const {totalSolved, bySize} = stats;
+  const {totalSolved, bySize, byDay} = stats;
+
+  const sortedByDay = byDay ? DAY_ORDER.map((d) => byDay.find((s) => s.day === d)).filter(Boolean) : [];
 
   return (
-    <div className="profile--stats-grid">
-      <div className="profile--stat-card">
-        <div className="profile--stat-card--value">{totalSolved}</div>
-        <div className="profile--stat-card--label">Puzzles Solved</div>
-      </div>
-      {bySize.map((s) => (
-        <div key={s.size} className="profile--stat-card">
-          <div className="profile--stat-card--value">{s.count}</div>
-          <div className="profile--stat-card--label">{s.size}</div>
-          <div className="profile--stat-card--sub">avg {formatTime(s.avgTime)}</div>
+    <>
+      <div className="profile--stats-grid">
+        <div className="profile--stat-card">
+          <div className="profile--stat-card--value">{totalSolved}</div>
+          <div className="profile--stat-card--label">Puzzles Solved</div>
         </div>
-      ))}
-    </div>
+        {bySize.map((s) => (
+          <div key={s.size} className="profile--stat-card">
+            <div className="profile--stat-card--value">{s.count}</div>
+            <div className="profile--stat-card--label">{s.size}</div>
+            <div className="profile--stat-card--sub">avg {formatTime(s.avgTime)}</div>
+          </div>
+        ))}
+      </div>
+      {sortedByDay.length > 0 && (
+        <>
+          <h3 className="profile--stats-section-title">By Day of Week</h3>
+          <div className="profile--stats-grid">
+            {sortedByDay.map((s) => (
+              <div key={s.day} className="profile--stat-card">
+                <div className="profile--stat-card--value">{s.count}</div>
+                <div className="profile--stat-card--label">{s.day}</div>
+                <div className="profile--stat-card--sub">avg {formatTime(s.avgTime)}</div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </>
   );
 }
 
@@ -88,6 +108,7 @@ function HistoryTable({history}) {
           <tr>
             <th>Puzzle</th>
             <th>Size</th>
+            <th className="profile--day-col">Day</th>
             <th>Time</th>
             <th>Date</th>
             <th>Actions</th>
@@ -105,6 +126,7 @@ function HistoryTable({history}) {
                 />
               </td>
               <td>{item.size}</td>
+              <td className="profile--day-col">{item.dow || '\u2014'}</td>
               <td>{formatTime(item.time)}</td>
               <td>{formatDate(item.solvedAt)}</td>
               <td className="profile--actions">

--- a/src/pages/css/profile.css
+++ b/src/pages/css/profile.css
@@ -63,6 +63,15 @@
   margin-top: 2px;
 }
 
+.profile--stats-section-title {
+  margin: 4px 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
 .profile--history {
   margin-top: 24px;
 }
@@ -155,7 +164,8 @@
   }
 
   .profile--history-table th:nth-child(2),
-  .profile--history-table td:nth-child(2) {
+  .profile--history-table td:nth-child(2),
+  .profile--history-table .profile--day-col {
     display: none;
   }
 
@@ -224,6 +234,10 @@
 
 .dark .profile--stat-card--sub {
   color: rgba(255, 255, 255, 0.35);
+}
+
+.dark .profile--stats-section-title {
+  color: rgba(255, 255, 255, 0.5);
 }
 
 .dark .profile--history h3 {


### PR DESCRIPTION
## Summary
- Adds day-of-week breakdown to the Profile page stats section (closes #198)
- Puzzles with day names in their titles (e.g. "Monday Mini", "Friday NYT") are grouped Mon-Sun with solve count and average time
- "Day" column added to the solve history table
- Extracted shared `dayOfWeekExtract()` SQL helper for reuse across puzzle browsing and profile stats

## Changes
- **server/model/sql_helpers.ts** — new shared helper for day-of-week SQL extraction
- **server/model/puzzle.ts** — uses shared helper instead of inline SQL
- **server/model/puzzle_solve.ts** — new `byDay` aggregation query + `dow` field on history items
- **server/api/user_stats.ts** — passes `byDay` through to API response
- **src/api/user_stats.ts** — updated TypeScript interfaces
- **src/pages/Profile.js** — "By Day of Week" stat cards + Day column in history table
- **src/pages/css/profile.css** — section title styling, dark mode, mobile responsive (Day column hidden)

## Test plan
- [x] Server tests pass (158/158) including new sql_helpers tests and updated puzzle_solve mocks
- [x] Frontend tests pass (347/347)
- [x] TypeCheck, ESLint, Prettier, Build all pass
- [x] Tested locally — day-of-week cards render correctly, Day column shows in history

🤖 Generated with [Claude Code](https://claude.com/claude-code)