### PR TITLE
Upgrade React 17 to 18

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ All of these must pass before merging to master:
 
 ## Architecture
 
-**Frontend** (React 17, Vite): `src/` — pages in `src/pages/`, components in `src/components/` organized by feature (Game, Grid, Player, Chat, Auth, Toolbar, Upload). State via Redux-like stores in `src/store/` plus React Context (AuthContext, GlobalContext). API clients in `src/api/`. Build tooling: Vite for dev/build, Vitest for frontend tests.
+**Frontend** (React 18, Vite): `src/` — pages in `src/pages/`, components in `src/components/` organized by feature (Game, Grid, Player, Chat, Auth, Toolbar, Upload). State via Redux-like stores in `src/store/` plus React Context (AuthContext, GlobalContext). API clients in `src/api/`. Build tooling: Vite for dev/build, Vitest for frontend tests.
 
 **Backend** (Express + TypeScript): `server/` — routes in `server/api/`, database models in `server/model/`, auth via Passport + JWT in `server/auth/`. Entry point is `server/server.ts`.
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "@types/morgan": "^1.9.2",
     "@types/node": "^14.14.14",
     "@types/querystringify": "^2.0.0",
-    "@types/react": "^17.0.0",
-    "@types/react-dom": "^17.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
     "@types/react-router": "^5.1.11",
     "@types/react-router-dom": "^5.1.7",
     "aws-sdk": "^2.496.0",
@@ -44,10 +44,10 @@
     "pg": "^8.3.3",
     "puzjs": "^1.0.2",
     "querystringify": "^2.2.0",
-    "react": "^17.0.0",
+    "react": "^18.0.0",
     "react-color": "^2.19.3",
     "react-confetti": "^5.0.1",
-    "react-dom": "^17.0.0",
+    "react-dom": "^18.0.0",
     "react-dropzone": "^4.0.0",
     "react-flexview": "^3.0.1",
     "react-helmet": "^5.2.0",
@@ -67,7 +67,8 @@
     "uuid": "^8.3.2"
   },
   "resolutions": {
-    "@types/react": "^17.0.0"
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",
@@ -86,7 +87,7 @@
     "@types/passport-local": "^1.0.38",
     "@types/pg": "^7.14.7",
     "@types/react-color": "^3.0.4",
-    "@types/react-helmet": "^6.1.0",
+    "@types/react-helmet": "^6.1.11",
     "@types/uuid": "^8.3.0",
     "@types/ws": "^8.5.4",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/src/components/Fencing/FencingCountdown.tsx
+++ b/src/components/Fencing/FencingCountdown.tsx
@@ -8,6 +8,7 @@ export const FencingCountdown: React.FC<{
   playerActions: PlayerActions;
   gameState: GameState;
   gameEventsHook: GameEventsHook;
+  children?: React.ReactNode;
 }> = (props) => {
   const [renderCount, setRenderCount] = useState(0);
   const classes = useStyles();

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -146,7 +146,6 @@ export default class Grid extends React.PureComponent<GridProps> {
   render() {
     const {size, cellStyle} = this.props;
     const sizeClass = Grid.getSizeClass(size);
-
     const data = this.props.grid.map((row, r) =>
       row.map((cell, c) => ({
         ...cell,

--- a/src/components/RerenderBoundary.tsx
+++ b/src/components/RerenderBoundary.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {usePrevious} from 'react-use';
 
-const RerenderBoundary: React.FC<{name: string; hash: string}> = (props) => {
+const RerenderBoundary: React.FC<{name: string; hash: string; children?: React.ReactNode}> = (props) => {
   const prevChildren = React.useRef<React.ReactNode>(props.children);
   const prevHash = usePrevious(props.hash);
   if (prevHash !== props.hash) {

--- a/src/components/Toolbar/ActionMenu.js
+++ b/src/components/Toolbar/ActionMenu.js
@@ -1,6 +1,5 @@
 import './css/ActionMenu.css';
 import React, {Component} from 'react';
-import {findDOMNode} from 'react-dom';
 
 /*
  * Summary of ActionMenu component
@@ -37,8 +36,7 @@ export default class ActionMenu extends Component {
   }
 
   handlePointerDown = (e) => {
-    // eslint-disable-next-line react/no-find-dom-node
-    const refNode = findDOMNode(this.containerRef.current);
+    const refNode = this.containerRef.current;
     if (refNode?.contains(e.target)) {
       return;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classnames from 'classnames';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import React from 'react';
 
 import useMediaQuery from '@material-ui/core/useMediaQuery';
@@ -142,5 +142,4 @@ ReactDOM.render(
   document.getElementById('root')
 );
 */
-// eslint-disable-next-line react/no-deprecated -- React 16 doesn't support createRoot
-ReactDOM.render(<Root />, document.getElementById('root'));
+createRoot(document.getElementById('root')).render(<Root />);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,15 +2520,15 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@^17.0.0":
-  version "17.0.26"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.26.tgz#fa7891ba70fd39ddbaa7e85b6ff9175bb546bc1b"
-  integrity sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==
+"@types/react-dom@^18.0.0":
+  version "18.3.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
+  integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
-"@types/react-helmet@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.0.tgz"
-  integrity sha512-PYRoU1XJFOzQ3BHvWL1T8iDNbRjdMDJMT5hFmZKGbsq09kbSqJy61uwEpTrbTNWDopVphUT34zUSVLK9pjsgYQ==
+"@types/react-helmet@^6.1.11":
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.11.tgz#8cafcafff38f75361f451563ba7b406b0c5d3907"
+  integrity sha512-0QcdGLddTERotCXo3VFlUSWO3ztraw8nZ6e3zJSgG7apwV5xt+pJUS8ewPBqT4NYB1optGLprNQzFleIY84u/g==
   dependencies:
     "@types/react" "*"
 
@@ -2556,13 +2556,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.0":
-  version "17.0.91"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.91.tgz#0a972a41c430f56d2feb7c15368bc51642495e0b"
-  integrity sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==
+"@types/react@*", "@types/react@^18.0.0":
+  version "18.3.28"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.28.tgz#0a85b1a7243b4258d9f626f43797ba18eb5f8781"
+  integrity sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "^0.16"
     csstype "^3.2.2"
 
 "@types/reactcss@*":
@@ -2571,11 +2570,6 @@
   integrity sha512-d2gQQ0IL6hXLnoRfVYZukQNWHuVsE75DzFTLPUuyyEhJS8G2VvlE+qfQQ91SJjaMqlURRCNIsX7Jcsw6cEuJlA==
   dependencies:
     "@types/react" "*"
-
-"@types/scheduler@^0.16":
-  version "0.16.8"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
-  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12":
   version "7.7.1"
@@ -9359,14 +9353,13 @@ react-confetti@^5.0.1:
   dependencies:
     tween-functions "^1.2.0"
 
-react-dom@^17.0.0:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.2"
 
 react-dropzone@^4.0.0:
   version "4.3.0"
@@ -9519,13 +9512,12 @@ react-use@^15.3.4:
     ts-easing "^0.2.0"
     tslib "^2.0.0"
 
-react@^17.0.0:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -9986,13 +9978,12 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 screenfull@^5.0.0:
   version "5.1.0"


### PR DESCRIPTION
## Summary
- Upgrades React from 17 to 18 (Phase 2 of MODERNIZATION_PLAN.md)
- Migrates entry point from `ReactDOM.render` to `createRoot`
- Adds explicit `children` prop to `React.FC` components (React 18 types remove implicit children)
- Removes deprecated `findDOMNode` from ActionMenu (uses `ref.current` directly)
- Updates type packages and resolutions for React 18 compatibility

## What does NOT change
- All 21 class components remain as-is (fully supported in React 18)
- MUI v4, react-router v5, sweetalert — all compatible at runtime
- No deprecated lifecycle methods, string refs, or legacy context API in the codebase

## Test plan
- [x] Frontend tests pass (225/225)
- [x] Server tests pass (158/158)
- [x] Frontend + server type checks clean
- [x] Production build succeeds
- [x] ESLint + Prettier pass (pre-existing issues only)
- [x] Manual testing: grid typing, toolbar actions, chat, navigation
- [x] E2E tests pass (35/35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)