### PR TITLE
Fix broken puzzle upload (replace swal with React modals)

### DIFF
--- a/src/components/Upload/FileUploader.js
+++ b/src/components/Upload/FileUploader.js
@@ -4,8 +4,6 @@ import './css/fileUploader.css';
 import React, {Component} from 'react';
 import Dropzone from 'react-dropzone';
 import {MdFileUpload} from 'react-icons/md';
-import swal from '@sweetalert/with-react';
-
 import {hasShape} from '../../lib/jsUtils';
 import PUZtoJSON from '../../lib/converter/PUZtoJSON';
 import iPUZtoJSON from '../../lib/converter/iPUZtoJSON';
@@ -115,7 +113,7 @@ export default class FileUploader extends Component {
     const file = acceptedFiles[0];
     const fileType = file.name.split('.').pop();
     const reader = new FileReader();
-    const {success, fail} = this.props;
+    const {success, fail, onError} = this.props;
     reader.addEventListener('loadend', () => {
       try {
         const puzzle = attemptPuzzleConversion(reader.result, fileType);
@@ -125,21 +123,11 @@ export default class FileUploader extends Component {
           fail();
         }
       } catch (e) {
-        let defaultTitle = 'Something went wrong';
-        let defaultText = `The error message was: ${e.message}`;
-        let defaultIcon = 'warning';
-
-        if (e?.errorTitle) defaultTitle = e.errorTitle;
-        if (e?.errorText) defaultText = e.errorText;
-        if (e?.errorIcon) defaultIcon = e.errorIcon;
-
-        swal({
-          title: defaultTitle,
-          text: defaultText,
-          icon: defaultIcon,
-          buttons: 'OK',
-          dangerMode: true,
-        });
+        const title = e?.errorTitle || 'Something went wrong';
+        const text = e?.errorText || `The error message was: ${e.message}`;
+        if (onError) {
+          onError({title, text});
+        }
       }
       window.URL.revokeObjectURL(acceptedFiles[0].preview);
     });

--- a/src/components/Upload/Upload.js
+++ b/src/components/Upload/Upload.js
@@ -1,9 +1,9 @@
 import './css/index.css';
 
 import React, {Component} from 'react';
-import swal from '@sweetalert/with-react';
 import actions from '../../actions';
 import FileUploader from './FileUploader';
+import UploadModal from './UploadModal';
 import {createNewPuzzle} from '../../api/puzzle';
 import AuthContext from '../../lib/AuthContext';
 
@@ -16,19 +16,26 @@ export default class Upload extends Component {
       puzzle: null,
       recentUnlistedPid: null,
       publicCheckboxChecked: false,
+      modal: null, // null | {type: 'confirm'|'success'|'duplicate'|'fail'|'malformed'|'error', ...}
+      uploading: false,
     };
   }
+
+  closeModal = () => {
+    this.setState({modal: null, uploading: false});
+  };
 
   success = (puzzle) => {
     this.setState({
       puzzle: {...puzzle},
       recentUnlistedPid: null,
       publicCheckboxChecked: false,
+      modal: {type: 'confirm', puzzleTitle: puzzle.info?.title || 'Untitled'},
     });
-    this.renderSuccessModal(puzzle);
   };
 
   create = async () => {
+    this.setState({uploading: true});
     const isPublic = this.state.publicCheckboxChecked;
     const puzzle = {
       ...this.state.puzzle,
@@ -36,136 +43,163 @@ export default class Upload extends Component {
     };
     // store in both firebase & pg
     actions.createPuzzle(puzzle, (pid) => {
-      this.setState({puzzle: null});
-      this.setState({
-        recentUnlistedPid: isPublic ? undefined : pid,
-      });
+      this.setState({puzzle: null, recentUnlistedPid: isPublic ? undefined : pid});
 
       createNewPuzzle(puzzle, pid, {
         isPublic,
         accessToken: this.context?.accessToken,
       })
-        .then(this.renderUploadSuccessModal)
-        .catch(this.renderUploadFailModal);
+        .then((response) => this.handleUploadSuccess(response, isPublic))
+        .catch(this.handleUploadFail);
     });
   };
 
-  // eslint-disable-next-line class-methods-use-this
   fail = () => {
-    swal({
-      title: `Malformed .puz file`,
-      text: `The uploaded .puz file is not a valid puzzle.`,
-      icon: 'warning',
-      buttons: 'OK',
-      dangerMode: true,
-    });
+    this.setState({modal: {type: 'malformed'}});
   };
 
-  renderSuccessModal(puzzle) {
-    const puzzleTitle = puzzle.info?.title || 'Untitled';
-    swal({
-      title: 'Confirm Upload',
-      icon: 'info',
-      buttons: [
-        'Cancel',
-        {
-          text: 'Upload',
-          closeModal: false,
-        },
-      ],
-      content: (
-        <div className="swal-text swal-text--no-margin swal-text--text-align-center">
-          <p>
-            You are about to upload the puzzle &quot;
-            {puzzleTitle}
-            &quot;. This will create a shareable game link, and anyone with the link will be able to solve it.
-            Continue?
-          </p>
-          <div id="unlistedRow">
-            <label>
-              <input type="checkbox" onChange={this.handleChangePublicCheckbox} /> Also post this puzzle on
-              the public site homepage
-            </label>
-          </div>
-        </div>
-      ),
-    }).then(this.handleUpload);
-  }
-
-  handleUpload = (uploadConfirmed) => {
-    if (uploadConfirmed) {
-      return this.create();
-    }
-    return null;
+  handleFileError = ({title, text}) => {
+    this.setState({modal: {type: 'error', title, text}});
   };
 
-  renderUploadSuccessModal = (response) => {
-    swal.close();
+  handleUploadSuccess = (response, isPublic) => {
     if (response && response.duplicate) {
       const url = `/beta/play/${response.pid}${this.props.fencing ? '?fencing=1' : ''}`;
-      swal({
-        title: 'Puzzle Already Exists',
-        icon: 'info',
-        content: (
-          <div className="swal-text swal-text--no-margin swal-text--text-align-center">
-            <p style={{marginTop: 10, marginBottom: 10}}>
-              This puzzle has already been uploaded. You can play it here:{' '}
-              <a href={url} style={{wordBreak: 'break-all'}}>
-                {url}
-              </a>
-            </p>
-          </div>
-        ),
-      });
+      this.setState({modal: {type: 'duplicate', url}, uploading: false});
       return;
     }
-    if (!this.state.recentUnlistedPid) {
+    if (isPublic) {
       this.props.onCreate && this.props.onCreate();
-      swal({
-        title: 'Upload Success!',
-        icon: 'success',
-        text: 'You may now view your puzzle on the home page.',
+      this.setState({
+        modal: {type: 'success', message: 'You may now view your puzzle on the home page.'},
+        uploading: false,
       });
     } else {
       const url = `/beta/play/${this.state.recentUnlistedPid}${this.props.fencing ? '?fencing=1' : ''}`;
-      swal({
-        title: 'Upload Success!',
-        icon: 'success',
-        content: (
-          <div className="swal-text swal-text--no-margin swal-text--text-align-center">
-            <p style={{marginTop: 10, marginBottom: 10}}>
-              Successfully created an unlisted puzzle. You may now visit the link{' '}
-              <a href={url} style={{wordBreak: 'break-all'}}>
-                {url}
-              </a>{' '}
-              to play the new puzzle.
-            </p>
-          </div>
-        ),
-      });
+      this.setState({modal: {type: 'success', url}, uploading: false});
     }
   };
 
-  // eslint-disable-next-line class-methods-use-this
-  renderUploadFailModal = (err) => {
-    swal.close();
-    swal({
-      title: 'Upload Failed!',
-      icon: 'error',
-      content: (
-        <div className="swal-text swal-text--no-margin swal-text--text-align-center">
-          <div>Upload failed. Error message:</div>
-          <i>{err?.message ? err.message : 'Unknown error'}</i>
-        </div>
-      ),
+  handleUploadFail = (err) => {
+    this.setState({
+      modal: {type: 'fail', error: err?.message || 'Unknown error'},
+      uploading: false,
     });
   };
 
   handleChangePublicCheckbox = (e) => {
-    this.setState({
-      publicCheckboxChecked: e.target.checked,
-    });
+    this.setState({publicCheckboxChecked: e.target.checked});
   };
+
+  renderModal() {
+    const {modal, uploading} = this.state;
+    if (!modal) return null;
+
+    switch (modal.type) {
+      case 'confirm':
+        return (
+          <UploadModal
+            open
+            title="Confirm Upload"
+            icon="info"
+            onConfirm={this.create}
+            onCancel={this.closeModal}
+            confirmText="Upload"
+            cancelText="Cancel"
+            loading={uploading}
+          >
+            <p>
+              You are about to upload the puzzle &quot;{modal.puzzleTitle}&quot;. This will create a shareable
+              game link, and anyone with the link will be able to solve it. Continue?
+            </p>
+            <div className="upload-modal--checkbox-row">
+              <label>
+                <input type="checkbox" onChange={this.handleChangePublicCheckbox} /> Also post this puzzle on
+                the public site homepage
+              </label>
+            </div>
+          </UploadModal>
+        );
+
+      case 'success':
+        return (
+          <UploadModal
+            open
+            title="Upload Success!"
+            icon="success"
+            onConfirm={this.closeModal}
+            confirmText="OK"
+          >
+            {modal.url ? (
+              <p>
+                Successfully created an unlisted puzzle. You may now visit the link{' '}
+                <a href={modal.url} style={{wordBreak: 'break-all'}}>
+                  {modal.url}
+                </a>{' '}
+                to play the new puzzle.
+              </p>
+            ) : (
+              <p>{modal.message}</p>
+            )}
+          </UploadModal>
+        );
+
+      case 'duplicate':
+        return (
+          <UploadModal
+            open
+            title="Puzzle Already Exists"
+            icon="info"
+            onConfirm={this.closeModal}
+            confirmText="OK"
+          >
+            <p>
+              This puzzle has already been uploaded. You can play it here:{' '}
+              <a href={modal.url} style={{wordBreak: 'break-all'}}>
+                {modal.url}
+              </a>
+            </p>
+          </UploadModal>
+        );
+
+      case 'fail':
+        return (
+          <UploadModal open title="Upload Failed!" icon="error" onConfirm={this.closeModal} confirmText="OK">
+            <div>Upload failed. Error message:</div>
+            <i>{modal.error}</i>
+          </UploadModal>
+        );
+
+      case 'malformed':
+        return (
+          <UploadModal
+            open
+            title="Malformed .puz file"
+            icon="warning"
+            onConfirm={this.closeModal}
+            confirmText="OK"
+          >
+            <p>The uploaded .puz file is not a valid puzzle.</p>
+          </UploadModal>
+        );
+
+      case 'error':
+        return (
+          <UploadModal
+            open
+            title={modal.title || 'Something went wrong'}
+            icon="warning"
+            onConfirm={this.closeModal}
+            confirmText="OK"
+          >
+            <p>{modal.text}</p>
+          </UploadModal>
+        );
+
+      default:
+        return null;
+    }
+  }
 
   render() {
     const {v2} = this.props;
@@ -173,9 +207,10 @@ export default class Upload extends Component {
       <div className="upload">
         <div className="upload--main">
           <div className="upload--main--upload">
-            <FileUploader success={this.success} fail={this.fail} v2={v2} />
+            <FileUploader success={this.success} fail={this.fail} onError={this.handleFileError} v2={v2} />
           </div>
         </div>
+        {this.renderModal()}
       </div>
     );
   }

--- a/src/components/Upload/UploadModal.js
+++ b/src/components/Upload/UploadModal.js
@@ -1,0 +1,67 @@
+/* eslint-disable react/jsx-no-bind */
+import React from 'react';
+
+export default function UploadModal({
+  open,
+  title,
+  icon,
+  onConfirm,
+  onCancel,
+  confirmText,
+  cancelText,
+  loading,
+  children,
+}) {
+  if (!open) return null;
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget && onCancel) {
+      onCancel();
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape' && onCancel) {
+      onCancel();
+    }
+  };
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className="upload-modal--overlay" onClick={handleOverlayClick} onKeyDown={handleKeyDown}>
+      <div className="upload-modal">
+        {icon && (
+          <div className={`upload-modal--icon upload-modal--icon-${icon}`}>
+            {icon === 'success' && <span>&#10003;</span>}
+            {icon === 'error' && <span>&#10007;</span>}
+            {icon === 'warning' && <span>!</span>}
+            {icon === 'info' && <span>i</span>}
+          </div>
+        )}
+        <div className="upload-modal--title">{title}</div>
+        <div className="upload-modal--content">{children}</div>
+        <div className="upload-modal--buttons">
+          {onCancel && (
+            <button
+              type="button"
+              className="upload-modal--button upload-modal--button-cancel"
+              onClick={onCancel}
+            >
+              {cancelText || 'Cancel'}
+            </button>
+          )}
+          {onConfirm && (
+            <button
+              type="button"
+              className="upload-modal--button upload-modal--button-confirm"
+              onClick={onConfirm}
+              disabled={loading}
+            >
+              {loading ? 'Uploading...' : confirmText || 'OK'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Upload/css/index.css
+++ b/src/components/Upload/css/index.css
@@ -30,3 +30,138 @@
   font-size: 18px;
 }
 
+/* Upload Modal */
+.upload-modal--overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1300;
+}
+
+.upload-modal {
+  background: #fff;
+  border-radius: 5px;
+  padding: 20px 30px;
+  max-width: 480px;
+  width: 90%;
+  text-align: center;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.upload-modal--icon {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  margin: 0 auto 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: bold;
+  border: 3px solid;
+}
+
+.upload-modal--icon-success {
+  color: #4caf50;
+  border-color: #4caf50;
+}
+
+.upload-modal--icon-error {
+  color: #f44336;
+  border-color: #f44336;
+}
+
+.upload-modal--icon-warning {
+  color: #ff9800;
+  border-color: #ff9800;
+}
+
+.upload-modal--icon-info {
+  color: #2196f3;
+  border-color: #2196f3;
+}
+
+.upload-modal--title {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: #333;
+}
+
+.upload-modal--content {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 20px;
+  line-height: 1.5;
+}
+
+.upload-modal--content a {
+  color: #2196f3;
+}
+
+.upload-modal--content p {
+  margin: 8px 0;
+}
+
+.upload-modal--checkbox-row {
+  margin-top: 12px;
+}
+
+.upload-modal--checkbox-row label {
+  cursor: pointer;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.upload-modal--checkbox-row input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.upload-modal--buttons {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.upload-modal--button {
+  padding: 8px 24px;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  min-width: 80px;
+}
+
+.upload-modal--button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.upload-modal--button-confirm {
+  background-color: var(--main-blue, #2196f3);
+  color: #fff;
+}
+
+.upload-modal--button-confirm:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.upload-modal--button-cancel {
+  background-color: #e8e8e8;
+  color: #333;
+}
+
+.upload-modal--button-cancel:hover {
+  background-color: #d5d5d5;
+}

--- a/src/dark.css
+++ b/src/dark.css
@@ -414,6 +414,50 @@
   accent-color: #6aa9f4;
 }
 
+/* Upload Modal */
+.dark .upload-modal {
+  background-color: #1e1e1e;
+  border: 1px solid #444;
+}
+
+.dark .upload-modal--title {
+  color: var(--dark-primary-text);
+}
+
+.dark .upload-modal--content {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.dark .upload-modal--content a {
+  color: #6aa9f4;
+}
+
+.dark .upload-modal--button-confirm {
+  background-color: var(--dark-blue-1);
+  color: var(--dark-primary-text);
+}
+
+.dark .upload-modal--button-confirm:hover:not(:disabled) {
+  background-color: #2d6da3;
+}
+
+.dark .upload-modal--button-cancel {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.dark .upload-modal--button-cancel:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.dark .upload-modal--checkbox-row label {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.dark .upload-modal--checkbox-row input[type='checkbox'] {
+  accent-color: #6aa9f4;
+}
+
 /* Chat header (puzzle instructions / description) */
 .dark .chat--header--subtitle {
   color: rgba(255, 255, 255, 0.6);


### PR DESCRIPTION
## Summary
- Puzzle uploading broke after the React 17 upgrade (#189) because `@sweetalert/with-react` renders JSX via its own `ReactDOM.render()`, creating a separate React tree. React 17 changed event delegation from `document` to the root container, breaking event handlers (like the checkbox `onChange`) in swal-rendered content.
- Replaced all swal modals in `Upload.js` with a new `UploadModal` component driven by React state, keeping events in the main React tree.
- Replaced the swal error call in `FileUploader.js` with an `onError` callback prop.
- Added modal CSS styles and dark mode support.

## Files changed
- `src/components/Upload/UploadModal.js` — **new** simple modal component (overlay + card)
- `src/components/Upload/Upload.js` — replaced 6 swal calls with state-driven `<UploadModal>`
- `src/components/Upload/FileUploader.js` — replaced swal error with `onError` callback
- `src/components/Upload/css/index.css` — modal styles
- `src/dark.css` — dark mode modal styles

## What stays unchanged
- `@sweetalert/with-react` remains in package.json (still used by Nav.js, Toolbar, WelcomeVariantsControl)
- No dependency changes

## Test plan
- [x] Upload a .puz file → confirm modal appears with public checkbox
- [x] Toggle checkbox → state updates correctly
- [x] Click Upload → puzzle created, success modal with link
- [x] Upload malformed file → error modal
- [x] Dark mode styling matches existing theme
- [x] ESLint, Prettier, tests, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)