### PR TITLE
Upgrade React 18 to 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "@types/morgan": "^1.9.2",
     "@types/node": "^14.14.14",
     "@types/querystringify": "^2.0.0",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
     "async": "^3.2.0",
     "aws-sdk": "^2.496.0",
     "bcrypt": "^6.0.0",
@@ -44,11 +44,11 @@
     "pg": "^8.3.3",
     "puzjs": "^1.0.2",
     "querystringify": "^2.2.0",
-    "react": "^18.0.0",
+    "react": "^19",
     "react-confetti": "^5.0.1",
-    "react-dom": "^18.0.0",
+    "react-dom": "^19",
     "react-dropzone": "^14",
-    "react-helmet": "^5.2.0",
+    "react-helmet-async": "^2.0.5",
     "react-icons": "^5",
     "react-router-dom": "^6",
     "react-simple-keyboard": "^1.15.2",
@@ -62,8 +62,8 @@
     "uuid": "^8.3.2"
   },
   "resolutions": {
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0"
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",
@@ -81,7 +81,6 @@
     "@types/passport-local": "^1.0.38",
     "@types/pg": "^7.14.7",
     "@types/react-color": "^3.0.4",
-    "@types/react-helmet": "^6.1.11",
     "@types/uuid": "^8.3.0",
     "@types/ws": "^8.5.4",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/src/components/Fencing/Fencing.tsx
+++ b/src/components/Fencing/Fencing.tsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import * as uuid from 'uuid';
 import React, {useState, useEffect, useCallback} from 'react';
 import {useUpdateEffect} from 'react-use';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import type {Socket} from 'socket.io-client';
 import {useSocket} from '../../sockets/useSocket';
 import {emitAsync} from '../../sockets/emitAsync';

--- a/src/components/Player/ClueText.ts
+++ b/src/components/Player/ClueText.ts
@@ -1,4 +1,5 @@
 import {createElement, Fragment, ReactNode} from 'react';
+import type {JSX} from 'react';
 
 type Tree = {name?: string; children: Tree[]} | {name: 'text'; value: string};
 

--- a/src/components/Player/Clues.js
+++ b/src/components/Player/Clues.js
@@ -55,7 +55,7 @@ export default class Clues extends Component {
             <div key={dir} className="clues--list">
               <div className="clues--list--title">{dir.toUpperCase()}</div>
 
-              <div className={`clues--list--scroll ${dir}`} ref={`clues--list--${dir}`}>
+              <div className={`clues--list--scroll ${dir}`}>
                 {clues[dir].map(
                   (clue, clueIndex) =>
                     clue && (

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 import classnames from 'classnames';
 import {createRoot} from 'react-dom/client';
 import React from 'react';
+import {HelmetProvider} from 'react-helmet-async';
 
 import useMediaQuery from './lib/hooks/useMediaQuery';
 import {BrowserRouter as Router, Route, Routes, Navigate, useLocation} from 'react-router-dom';
@@ -93,46 +94,48 @@ const Root = () => {
   }, [darkMode]);
 
   return (
-    <Router>
-      <AuthProvider>
-        <GlobalContext.Provider value={{toggleMolesterMoons, darkModePreference}}>
-          <div className={classnames('router-wrapper', {mobile: isMobile(), dark: darkMode})}>
-            <VerificationGate>
-              <Routes>
-                <Route path="/auth/google/callback" element={<GoogleCallback />} />
-                <Route path="/verify-email" element={<VerifyEmail />} />
-                <Route path="/forgot-password" element={<ForgotPassword />} />
-                <Route path="/reset-password" element={<ResetPassword />} />
-                <Route path="/" element={<WrappedWelcome />} />
-                <Route path="/fencing" element={<WrappedWelcome fencing />} />
-                {/* <Route path="/stats" element={<Stats />} /> */}
-                <Route path="/game/:gid" element={<Game />} />
-                <Route path="/embed/game/:gid" element={<Game />} />
-                <Route path="/room/:rid" element={<Room />} />
-                <Route path="/embed/room/:rid" element={<Room />} />
-                <Route path="/replay/:gid" element={<Replay />} />
-                <Route path="/beta/replay/:gid" element={<Replay />} />
-                <Route path="/replays/:pid" element={<Replays />} />
-                <Route path="/replays" element={<Replays />} />
-                <Route path="/beta" element={<WrappedWelcome />} />
-                <Route path="/beta/game/:gid" element={<Game />} />
-                <Route path="/beta/battle/:bid" element={<Battle />} />
-                <Route path="/beta/play/:pid" element={<Play />} />
-                <Route path="/privacy" element={<Privacy />} />
-                <Route path="/terms" element={<Terms />} />
-                <Route path="/help" element={<Help />} />
-                <Route path="/account" element={<Account />} />
-                <Route path="/profile" element={<Profile />} />
-                <Route path="/profile/:userId" element={<Profile />} />
-                <Route path="/fencing/:gid" element={<Fencing />} />
-                <Route path="/beta/fencing/:gid" element={<Fencing />} />
-                <Route path="/discord" element={<DiscordRedirect />} />
-              </Routes>
-            </VerificationGate>
-          </div>
-        </GlobalContext.Provider>
-      </AuthProvider>
-    </Router>
+    <HelmetProvider>
+      <Router>
+        <AuthProvider>
+          <GlobalContext value={{toggleMolesterMoons, darkModePreference}}>
+            <div className={classnames('router-wrapper', {mobile: isMobile(), dark: darkMode})}>
+              <VerificationGate>
+                <Routes>
+                  <Route path="/auth/google/callback" element={<GoogleCallback />} />
+                  <Route path="/verify-email" element={<VerifyEmail />} />
+                  <Route path="/forgot-password" element={<ForgotPassword />} />
+                  <Route path="/reset-password" element={<ResetPassword />} />
+                  <Route path="/" element={<WrappedWelcome />} />
+                  <Route path="/fencing" element={<WrappedWelcome fencing />} />
+                  {/* <Route path="/stats" element={<Stats />} /> */}
+                  <Route path="/game/:gid" element={<Game />} />
+                  <Route path="/embed/game/:gid" element={<Game />} />
+                  <Route path="/room/:rid" element={<Room />} />
+                  <Route path="/embed/room/:rid" element={<Room />} />
+                  <Route path="/replay/:gid" element={<Replay />} />
+                  <Route path="/beta/replay/:gid" element={<Replay />} />
+                  <Route path="/replays/:pid" element={<Replays />} />
+                  <Route path="/replays" element={<Replays />} />
+                  <Route path="/beta" element={<WrappedWelcome />} />
+                  <Route path="/beta/game/:gid" element={<Game />} />
+                  <Route path="/beta/battle/:bid" element={<Battle />} />
+                  <Route path="/beta/play/:pid" element={<Play />} />
+                  <Route path="/privacy" element={<Privacy />} />
+                  <Route path="/terms" element={<Terms />} />
+                  <Route path="/help" element={<Help />} />
+                  <Route path="/account" element={<Account />} />
+                  <Route path="/profile" element={<Profile />} />
+                  <Route path="/profile/:userId" element={<Profile />} />
+                  <Route path="/fencing/:gid" element={<Fencing />} />
+                  <Route path="/beta/fencing/:gid" element={<Fencing />} />
+                  <Route path="/discord" element={<DiscordRedirect />} />
+                </Routes>
+              </VerificationGate>
+            </div>
+          </GlobalContext>
+        </AuthProvider>
+      </Router>
+    </HelmetProvider>
   );
 };
 /*

--- a/src/lib/AuthContext.js
+++ b/src/lib/AuthContext.js
@@ -82,7 +82,7 @@ export function AuthProvider({children}) {
     refreshUser,
   };
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return <AuthContext value={value}>{children}</AuthContext>;
 }
 
 export default AuthContext;

--- a/src/pages/Account.js
+++ b/src/pages/Account.js
@@ -2,7 +2,7 @@
 import './css/account.css';
 
 import React, {useContext, useState, useEffect} from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import {useLocation, useNavigate, Link} from 'react-router-dom';
 import Nav from '../components/common/Nav';
 import Footer from '../components/common/Footer';

--- a/src/pages/Battle.js
+++ b/src/pages/Battle.js
@@ -2,7 +2,7 @@ import './css/battle.css';
 
 import React, {Component} from 'react';
 import _ from 'lodash';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classnames from 'classnames';
 import {BattleModel} from '../store';

--- a/src/pages/ForgotPassword.js
+++ b/src/pages/ForgotPassword.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 import React, {useState} from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import {Link} from 'react-router-dom';
 import Nav from '../components/common/Nav';
 import Footer from '../components/common/Footer';

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react';
 import _ from 'lodash';
 import querystring from 'querystring';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import Nav from '../components/common/Nav';
 
 import {GameModel, getUser, BattleModel} from '../store';

--- a/src/pages/Help.js
+++ b/src/pages/Help.js
@@ -1,7 +1,7 @@
 import './css/legal.css';
 
 import React from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import {Link} from 'react-router-dom';
 import Nav from '../components/common/Nav';
 import Footer from '../components/common/Footer';

--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import _ from 'lodash';
 import querystring from 'querystring';
 import {formatTimestamp} from '../lib/formatTimestamp';

--- a/src/pages/Privacy.js
+++ b/src/pages/Privacy.js
@@ -1,7 +1,7 @@
 import './css/legal.css';
 
 import React from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import Nav from '../components/common/Nav';
 import Footer from '../components/common/Footer';
 

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -1,7 +1,7 @@
 import './css/profile.css';
 
 import React, {useContext, useState, useEffect} from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import {useParams, useNavigate, Link} from 'react-router-dom';
 
 import {MdPeople} from 'react-icons/md';

--- a/src/pages/Replay.js
+++ b/src/pages/Replay.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line max-classes-per-file
 import './css/replay.css';
 import React, {Component} from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import {MdPlayArrow, MdPause, MdChevronLeft, MdChevronRight} from 'react-icons/md';
 import _ from 'lodash';
 

--- a/src/pages/Replays.js
+++ b/src/pages/Replays.js
@@ -1,6 +1,6 @@
 import './css/replays.css';
 
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import _ from 'lodash';
 import React, {Component} from 'react';
 import Promise from 'bluebird';

--- a/src/pages/ResetPassword.js
+++ b/src/pages/ResetPassword.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 import React, {useState} from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import {useLocation, Link} from 'react-router-dom';
 import Nav from '../components/common/Nav';
 import Footer from '../components/common/Footer';

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -1,7 +1,7 @@
 import React, {Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState} from 'react';
 import {useUpdateEffect} from 'react-use';
 import _ from 'lodash';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import {useParams} from 'react-router-dom';
 
 import type {Socket} from 'socket.io-client';

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import {fetchStats} from '../api/stats';
 import {ListPuzzleStatsResponse} from '../shared/types';
 import {getUser} from '../store/user';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import Nav from '../components/common/Nav';
 import {formatMilliseconds} from '../components/Toolbar/Clock';
 

--- a/src/pages/Terms.js
+++ b/src/pages/Terms.js
@@ -1,7 +1,7 @@
 import './css/legal.css';
 
 import React from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import Nav from '../components/common/Nav';
 import Footer from '../components/common/Footer';
 

--- a/src/pages/VerifyEmail.js
+++ b/src/pages/VerifyEmail.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind, consistent-return, no-nested-ternary */
 import React, {useContext, useState, useEffect, useRef} from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import {useLocation, useNavigate, Link} from 'react-router-dom';
 import Nav from '../components/common/Nav';
 import Footer from '../components/common/Footer';

--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -1,7 +1,7 @@
 import './css/welcome.css';
 
 import React, {Component} from 'react';
-import {Helmet} from 'react-helmet';
+import {Helmet} from 'react-helmet-async';
 import {
   MdSearch,
   MdCheckBoxOutlineBlank,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,11 +2579,6 @@
     "@types/node" "*"
     pg-types "^2.2.0"
 
-"@types/prop-types@*":
-  version "15.7.3"
-  resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz"
-  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
-
 "@types/qs@*":
   version "6.9.5"
   resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz"
@@ -2607,24 +2602,16 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@^18.0.0":
-  version "18.3.7"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
-  integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
+"@types/react-dom@^19", "@types/react-dom@^19.0.0":
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.3.tgz#c1e305d15a52a3e508d54dca770d202cb63abf2c"
+  integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react-helmet@^6.1.11":
-  version "6.1.11"
-  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.11.tgz#8cafcafff38f75361f451563ba7b406b0c5d3907"
-  integrity sha512-0QcdGLddTERotCXo3VFlUSWO3ztraw8nZ6e3zJSgG7apwV5xt+pJUS8ewPBqT4NYB1optGLprNQzFleIY84u/g==
+"@types/react@*", "@types/react@^19", "@types/react@^19.0.0":
+  version "19.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
+  integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
   dependencies:
-    "@types/react" "*"
-
-"@types/react@*", "@types/react@^18.0.0":
-  version "18.3.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.28.tgz#0a85b1a7243b4258d9f626f43797ba18eb5f8781"
-  integrity sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==
-  dependencies:
-    "@types/prop-types" "*"
     csstype "^3.2.2"
 
 "@types/reactcss@*":
@@ -6491,6 +6478,13 @@ interpret@^1.0.0:
   resolved "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
@@ -8005,7 +7999,7 @@ long@^4.0.0:
   resolved "https://registry.npmjs.org/long/-/long-4.0.0.tgz"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9083,15 +9077,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.4:
-  version "15.7.2"
-  resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
 prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
@@ -9248,13 +9233,12 @@ react-confetti@^5.0.1:
   dependencies:
     tween-functions "^1.2.0"
 
-react-dom@^18.0.0:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
-  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
+react-dom@^19:
+  version "19.2.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
+  integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
   dependencies:
-    loose-envify "^1.1.0"
-    scheduler "^0.23.2"
+    scheduler "^0.27.0"
 
 react-dropzone@^14:
   version "14.4.1"
@@ -9265,27 +9249,26 @@ react-dropzone@^14:
     file-selector "^2.1.0"
     prop-types "^15.8.1"
 
-react-fast-compare@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz"
-  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+react-fast-compare@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
-react-helmet@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.1.tgz"
-  integrity sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==
+react-helmet-async@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-2.0.5.tgz#cfc70cd7bb32df7883a8ed55502a1513747223ec"
+  integrity sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==
   dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.5.4"
-    react-fast-compare "^2.0.2"
-    react-side-effect "^1.1.0"
+    invariant "^2.2.4"
+    react-fast-compare "^3.2.2"
+    shallowequal "^1.1.0"
 
 react-icons@^5:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.5.0.tgz#8aa25d3543ff84231685d3331164c00299cdfaf2"
   integrity sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==
 
-react-is@^16.13.1, react-is@^16.8.1:
+react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9334,13 +9317,6 @@ react-router@6.30.3:
   dependencies:
     "@remix-run/router" "1.23.2"
 
-react-side-effect@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.2.0.tgz"
-  integrity sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==
-  dependencies:
-    shallowequal "^1.0.1"
-
 react-simple-keyboard@^1.15.2:
   version "1.26.6"
   resolved "https://registry.npmjs.org/react-simple-keyboard/-/react-simple-keyboard-1.26.6.tgz"
@@ -9379,12 +9355,10 @@ react-use@^15.3.4:
     ts-easing "^0.2.0"
     tslib "^2.0.0"
 
-react@^18.0.0:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
-  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
-  dependencies:
-    loose-envify "^1.1.0"
+react@^19:
+  version "19.2.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.4.tgz#438e57baa19b77cb23aab516cf635cd0579ee09a"
+  integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
 
 "readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
@@ -9828,12 +9802,10 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.23.2:
-  version "0.23.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
-  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
-  dependencies:
-    loose-envify "^1.1.0"
+scheduler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 screenfull@^5.0.0:
   version "5.1.0"
@@ -9957,9 +9929,9 @@ setprototypeof@1.2.0:
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shallowequal@^1.0.1:
+shallowequal@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^2.0.0:


### PR DESCRIPTION
## Summary
- Bump `react` and `react-dom` to **19.2.4**, `@types/react` and `@types/react-dom` to **^19**
- Replace `react-helmet` with `react-helmet-async` across 17 files (fixes deprecated `componentWillMount` lifecycle)
- Add `<HelmetProvider>` wrapper at app root
- Simplify `<Context.Provider>` → `<Context>` in 2 files (new React 19 shorthand)
- Remove unused string ref in `Clues.js` (string refs removed in React 19)
- Add `JSX` namespace type import in `ClueText.ts` (global JSX namespace removed in `@types/react@19`)

**23 files changed, net -25 lines. All mechanical changes.**

## Test plan
- [x] Frontend tests (347 passed)
- [x] Server tests (158 passed)
- [x] TypeCheck frontend + server
- [x] ESLint + Prettier
- [x] Production build
- [x] Manual: game page loads, grid interaction, clue navigation
- [x] Manual: page titles update on navigation (Helmet)
- [x] Manual: dark mode toggle (GlobalContext)
- [x] Manual: no `componentWillMount` console warning
- [x] Manual: full-stack local dev (frontend + backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)