### PR TITLE
Fix E2E toolbar tests for Radix ConfirmDialog selectors

### DIFF
--- a/e2e/tests/toolbar-actions.spec.ts
+++ b/e2e/tests/toolbar-actions.spec.ts
@@ -65,9 +65,9 @@ test.describe('Toolbar actions', () => {
     await openActionMenu('Reveal');
     await clickAction('Square');
 
-    // SweetAlert confirmation dialog appears — confirm it
-    await expect(page.locator('.swal-overlay')).toBeVisible({timeout: 5_000});
-    await page.locator('.swal-button--confirm').click();
+    // Radix ConfirmDialog appears — confirm it
+    await expect(page.locator('.confirm-dialog--overlay')).toBeVisible({timeout: 5_000});
+    await page.locator('.btn--danger').click();
 
     // Wait for reveal to propagate — cell gets .revealed or .good class
     const cellDiv = gamePage.cellLocator(r, c).locator('.cell');
@@ -191,23 +191,17 @@ test.describe('Toolbar actions', () => {
     await openActionMenu('Reset');
     await clickAction('Puzzle');
 
-    // SweetAlert dialog should appear
-    await expect(page.locator('.swal-overlay')).toBeVisible({timeout: 5_000});
-    await expect(page.locator('.swal-title')).toContainText('reset');
+    // Radix ConfirmDialog should appear
+    await expect(page.locator('.confirm-dialog--overlay')).toBeVisible({timeout: 5_000});
+    await expect(page.locator('.confirm-dialog--title')).toContainText('reset');
 
     // Cancel to avoid actually resetting
-    const cancelBtn = page.locator('.swal-button--cancel');
-    if (await cancelBtn.isVisible()) {
-      await cancelBtn.click();
-    } else {
-      // Some swal versions use different button structure — press Escape
-      await page.keyboard.press('Escape');
-    }
+    await page.locator('.btn--outlined').click();
 
     await page.waitForTimeout(300);
 
     // Dialog should be gone
-    await expect(page.locator('.swal-overlay--show-modal')).not.toBeVisible();
+    await expect(page.locator('.confirm-dialog--overlay')).not.toBeVisible();
 
     assertNoFatalErrors(consoleErrors);
   });


### PR DESCRIPTION
## Summary
- Updated E2E toolbar action tests to use Radix UI `ConfirmDialog` selectors (`.confirm-dialog--*`, `.btn--danger`, `.btn--outlined`) instead of old SweetAlert v1 selectors (`.swal-overlay`, `.swal-button--*`, `.swal-title`)
- Fixes 6 test failures (2 tests × 3 browsers) caused by the SweetAlert → Radix migration

## Test plan
- [x] Full E2E suite passes against `testing.crosswithfriends.com` (105/105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)