### PR TITLE
Improve vim mode visibility and add help dialog

### DIFF
--- a/src/components/Player/VimCommandBar.tsx
+++ b/src/components/Player/VimCommandBar.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import {MdHelpOutline} from 'react-icons/md';
+import InfoDialog from '../common/InfoDialog';
 
 interface VimCommandBarProps {
   isVimCommandMode: boolean;
@@ -16,6 +18,7 @@ export const VimCommandBar: React.FC<VimCommandBarProps> = ({
   onEscape,
 }) => {
   const [command, setCommand] = React.useState('');
+  const [helpOpen, setHelpOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
 
   const handleChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -49,6 +52,11 @@ export const VimCommandBar: React.FC<VimCommandBarProps> = ({
     }
   }, [isVimCommandMode]);
 
+  const handleHelpClick = React.useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setHelpOpen(true);
+  }, []);
+
   return (
     <div className="player--main--vim-bar">
       {isVimInsertMode && <>-- INSERT --</>}
@@ -64,6 +72,132 @@ export const VimCommandBar: React.FC<VimCommandBarProps> = ({
           onKeyDown={handleKeydown}
         />
       )}
+      {!isVimInsertMode && !isVimCommandMode && <span>-- NORMAL --</span>}
+      <button
+        type="button"
+        className="player--main--vim-bar--help"
+        onClick={handleHelpClick}
+        title="Vim keybindings"
+      >
+        <MdHelpOutline />
+      </button>
+      <InfoDialog open={helpOpen} onOpenChange={setHelpOpen} title="Vim Mode Keybindings" icon={null}>
+        <h4>Normal Mode</h4>
+        <table>
+          <tbody>
+            <tr>
+              <th>Key</th>
+              <th>Action</th>
+            </tr>
+            <tr>
+              <td>
+                <code>h</code> <code>j</code> <code>k</code> <code>l</code>
+              </td>
+              <td>Move left / down / up / right</td>
+            </tr>
+            <tr>
+              <td>
+                <code>w</code>
+              </td>
+              <td>Next clue</td>
+            </tr>
+            <tr>
+              <td>
+                <code>b</code>
+              </td>
+              <td>Previous clue</td>
+            </tr>
+            <tr>
+              <td>
+                <code>^</code>
+              </td>
+              <td>Start of clue</td>
+            </tr>
+            <tr>
+              <td>
+                <code>$</code>
+              </td>
+              <td>End of clue</td>
+            </tr>
+            <tr>
+              <td>
+                <code>i</code>
+              </td>
+              <td>Enter insert mode</td>
+            </tr>
+            <tr>
+              <td>
+                <code>s</code>
+              </td>
+              <td>Delete cell and enter insert mode</td>
+            </tr>
+            <tr>
+              <td>
+                <code>x</code>
+              </td>
+              <td>Delete cell</td>
+            </tr>
+            <tr>
+              <td>
+                <code>:</code>
+              </td>
+              <td>Enter command mode</td>
+            </tr>
+          </tbody>
+        </table>
+        <h4>Insert Mode</h4>
+        <table>
+          <tbody>
+            <tr>
+              <th>Key</th>
+              <th>Action</th>
+            </tr>
+            <tr>
+              <td>Letters</td>
+              <td>Fill in cell</td>
+            </tr>
+            <tr>
+              <td>
+                <code>Escape</code>
+              </td>
+              <td>Return to normal mode</td>
+            </tr>
+          </tbody>
+        </table>
+        <h4>Command Mode</h4>
+        <table>
+          <tbody>
+            <tr>
+              <th>Key</th>
+              <th>Action</th>
+            </tr>
+            <tr>
+              <td>
+                <code>:42a</code>
+              </td>
+              <td>Jump to 42 across</td>
+            </tr>
+            <tr>
+              <td>
+                <code>:7d</code>
+              </td>
+              <td>Jump to 7 down</td>
+            </tr>
+            <tr>
+              <td>
+                <code>Enter</code>
+              </td>
+              <td>Execute command</td>
+            </tr>
+            <tr>
+              <td>
+                <code>Escape</code>
+              </td>
+              <td>Cancel</td>
+            </tr>
+          </tbody>
+        </table>
+      </InfoDialog>
     </div>
   );
 };

--- a/src/components/Player/css/index.css
+++ b/src/components/Player/css/index.css
@@ -73,16 +73,34 @@
   font-size: 15px;
   /* width: 486px; */
   height: 20px;
-  align-items: stretch;
+  align-items: center;
 }
 
 .player--main--vim-bar--input {
   background-color: transparent;
   border: none;
+  flex: 1;
 }
 
 .player--main--vim-bar--input:focus {
   outline: none;
+}
+
+.player--main--vim-bar--help {
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  font-size: 18px;
+  opacity: 0.6;
+  color: inherit;
+}
+
+.player--main--vim-bar--help:hover {
+  opacity: 1;
 }
 
 .player--mobile--wrapper {

--- a/src/components/common/css/confirmDialog.css
+++ b/src/components/common/css/confirmDialog.css
@@ -27,6 +27,11 @@
   color: var(--dark-primary-text);
 }
 
+.dark .confirm-dialog--panel code {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: var(--dark-primary-text);
+}
+
 .confirm-dialog--title {
   margin: 0 0 12px;
   font-size: 18px;

--- a/src/dark.css
+++ b/src/dark.css
@@ -26,6 +26,15 @@
   background-color: var(--dark-blue-2) !important;
 }
 
+.dark .player--main--vim-bar {
+  background-color: var(--dark-blue-2);
+  color: var(--dark-primary-text);
+}
+
+.dark .player--main--vim-bar--input {
+  color: var(--dark-primary-text);
+}
+
 .dark .mobile-grid-controls--clue-bar {
   background-color: var(--dark-blue-2);
 }


### PR DESCRIPTION
## Summary
- Add dark mode styles for vim command bar (fixes #228)
- Show current mode label (-- NORMAL -- / -- INSERT --) so users know what mode they're in
- Add a help icon (?) in the vim bar that opens a keybinding reference dialog
- Fix dark mode `code` tag styling in dialogs

## Test plan
- [x] Enable vim mode via Extras menu
- [x] Verify vim bar is visible in both light and dark mode
- [x] Click the ? icon — keybinding dialog should open with all shortcuts
- [x] Verify dialog looks correct in both light and dark mode
- [ ] Test vim keybindings still work (hjkl, i, :, Escape, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)