### PR TITLE
Fix pencil color not applying in dark mode

### DIFF
--- a/src/dark.css
+++ b/src/dark.css
@@ -79,7 +79,7 @@
 }
 
 .dark .cell.pencil .cell--value {
-  color: rgba(255, 255, 255, 0.47);
+  color: var(--pencil-color);
 }
 
 .dark .clues--list--scroll {


### PR DESCRIPTION
## Summary
- Dark mode was hardcoding pencil text color to `rgba(255, 255, 255, 0.47)`, ignoring the user-selected color from the color picker
- Now uses the `--pencil-color` CSS variable so the picker works in both light and dark mode
- Fixes #227

## Test plan
- [ ] Enable dark mode and pencil mode
- [ ] Change the pencil color via the color picker in the toolbar
- [ ] Type letters in pencil mode — they should use the selected color
- [ ] Verify default pencil color (#888888) is still visible on dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)