### PR TITLE
Fix .puz files not handling UTF-8 special characters

### DIFF
--- a/src/lib/converter/PUZtoJSON.js
+++ b/src/lib/converter/PUZtoJSON.js
@@ -1,8 +1,7 @@
 /* eslint no-plusplus: "off", no-bitwise: "off" */
 
 // Windows-1252 bytes 0x80-0x9F map to different Unicode code points than
-// String.fromCharCode gives. This lookup avoids depending on TextDecoder
-// (unavailable in Jest/jsdom) and handles curly quotes, em dashes, etc.
+// String.fromCharCode gives. This lookup handles curly quotes, em dashes, etc.
 const CP1252 = {
   0x80: 0x20ac,
   0x82: 0x201a,
@@ -42,6 +41,17 @@ function decodeWindows1252(byteArray) {
   return result;
 }
 
+// Some modern .puz files use UTF-8 encoding for clue text (e.g., box-drawing
+// characters, special symbols). Try UTF-8 first; fall back to Windows-1252.
+function decodeString(byteArray) {
+  try {
+    const decoder = new TextDecoder('utf-8', {fatal: true});
+    return decoder.decode(new Uint8Array(byteArray));
+  } catch {
+    return decodeWindows1252(byteArray);
+  }
+}
+
 function getExtension(bytes, code) {
   // struct byte format is 4S H H
   let i = 0;
@@ -72,7 +82,7 @@ function getRebus(bytes) {
     return undefined; // no rebus
   }
   const solbytes = getExtension(bytes, rtbl);
-  const solstring = decodeWindows1252(solbytes);
+  const solstring = decodeString(solbytes);
   if (!solstring) {
     return undefined;
   }
@@ -193,7 +203,7 @@ export default function PUZtoJSON(buffer) {
     while (ibyte < bytes.length && bytes[ibyte] !== 0) {
       ibyte++;
     }
-    const str = decodeWindows1252(bytes.slice(start, ibyte));
+    const str = decodeString(bytes.slice(start, ibyte));
     ibyte++; // skip null terminator
     return str;
   }

--- a/src/lib/converter/__tests__/PUZtoJSON.test.js
+++ b/src/lib/converter/__tests__/PUZtoJSON.test.js
@@ -230,6 +230,37 @@ describe('PUZtoJSON', () => {
     expect(acrossClues[0]).toBe('\u201CA\u201D\u2014B'); // "A"—B
   });
 
+  it('decodes UTF-8 encoded special characters in clues', () => {
+    // Some modern .puz files use UTF-8 for clue text containing Unicode chars
+    // like box-drawing symbols (□ = U+25A1 = UTF-8 bytes E2 96 A1)
+    const solution = [
+      ['A', 'B'],
+      ['C', '.'],
+    ];
+    const buffer = buildPuzBuffer({
+      nrow: 2,
+      ncol: 2,
+      solution,
+      clues: ['placeholder', 'placeholder'],
+    });
+
+    const bytes = new Uint8Array(buffer);
+    const gridEnd = 52 + 2 * 2 * 2;
+    const clueStart = gridEnd + 3;
+
+    // Write UTF-8 bytes for "A□B" where □ is U+25A1 (E2 96 A1)
+    bytes[clueStart] = 0x41; // A
+    bytes[clueStart + 1] = 0xe2; // □ byte 1
+    bytes[clueStart + 2] = 0x96; // □ byte 2
+    bytes[clueStart + 3] = 0xa1; // □ byte 3
+    bytes[clueStart + 4] = 0x42; // B
+    bytes[clueStart + 5] = 0x00; // null terminator
+
+    const result = PUZtoJSON(bytes.buffer);
+    const acrossClues = result.across.filter(Boolean);
+    expect(acrossClues[0]).toBe('A\u25A1B'); // A□B
+  });
+
   it('returns empty circles and shades when no extensions', () => {
     const solution = [
       ['A', 'B'],


### PR DESCRIPTION
## Summary
- .puz parser now tries UTF-8 decoding first for clue text, falling back to Windows-1252 for legacy files
- Fixes special characters (box symbols, etc.) rendering as garbled text in .puz files while working fine in .ipuz
- Added test for UTF-8 encoded clues alongside existing CP1252 test
- Fixes #212

## Test plan
- [x] Upload a .puz file with special characters in clues (e.g., box symbols)
- [x] Verify clues render correctly (compare with .ipuz version of same puzzle)
- [x] Upload a legacy .puz file with curly quotes / em dashes — verify those still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)