### PR TITLE
Fix puzzle list not refreshing after upload

### DIFF
--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -35,12 +35,12 @@ export default class Welcome extends Component {
       userHistory: {},
       collapsedFilters: {},
       mobileSidebarOpen: false,
+      uploadedPuzzles: 0,
     };
     this.loading = false;
     this.mobile = isMobile();
     this.searchInput = React.createRef();
     this.nav = React.createRef();
-    this.uploadedPuzzles = 0;
   }
 
   componentDidMount() {
@@ -117,7 +117,7 @@ export default class Welcome extends Component {
     return (
       <PuzzleList
         fencing={this.props.fencing}
-        uploadedPuzzles={this.uploadedPuzzles}
+        uploadedPuzzles={this.state.uploadedPuzzles}
         userHistory={userHistory}
         sizeFilter={this.props.sizeFilter}
         statusFilter={this.props.statusFilter}
@@ -130,7 +130,7 @@ export default class Welcome extends Component {
   }
 
   handleCreatePuzzle = () => {
-    this.uploadedPuzzles += 1;
+    this.setState((prev) => ({uploadedPuzzles: prev.uploadedPuzzles + 1}));
   };
 
   handleFilterChange = (header, name, on) => {


### PR DESCRIPTION
## Summary
- `uploadedPuzzles` was stored as a class instance variable instead of React state
- Incrementing it never triggered a re-render, so the `PuzzleList` component never saw the update and never re-fetched
- Moved to `this.state` so `setState` propagates the change as a prop, triggering the existing `useEffect` re-fetch in `NewPuzzleList`
- Fixes #238

## Test plan
- [ ] Upload a public puzzle on the homepage
- [ ] After the success modal, the puzzle list should refresh automatically showing the new puzzle
- [ ] No manual page refresh needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)