### PR TITLE
Improve cell shading contrast in light and dark mode

### DIFF
--- a/src/components/Grid/css/cell.css
+++ b/src/components/Grid/css/cell.css
@@ -207,6 +207,6 @@ div:focus .cell.referenced {
   top: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.22);
+  background-color: rgba(0, 0, 0, 0.3);
   z-index: 10;
 }

--- a/src/dark.css
+++ b/src/dark.css
@@ -82,6 +82,10 @@
   color: var(--pencil-color);
 }
 
+.dark .cell--shade {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
 .dark .clues--list--scroll {
   background-color: var(--dark-background-1);
 }


### PR DESCRIPTION
## Summary
- Light mode: increased shade overlay opacity from 0.22 to 0.30 for better contrast
- Dark mode: switched from black overlay (invisible on dark cells) to white overlay at 0.25 opacity
- Fixes #222

## Test plan
- [ ] Open a puzzle with shaded cells (e.g., themed puzzles with highlighted squares)
- [ ] Verify shaded cells are clearly distinguishable in light mode
- [ ] Switch to dark mode — shaded cells should stand out as brighter than regular cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)