### PR TITLE
Fix XSS in username edit field

### DIFF
--- a/src/components/common/EditableSpan.js
+++ b/src/components/common/EditableSpan.js
@@ -68,7 +68,7 @@ export default class EditableSpan extends PureComponent {
     if (this.props.hidden) return;
     if (this.text === val) return;
     // set text while retaining cursor position
-    this.span.current.innerHTML = val;
+    this.span.current.textContent = val;
   }
 
   handleFocus = () => {


### PR DESCRIPTION
## Summary
- Fix cross-site scripting vulnerability in `EditableSpan` component (used for username editing in Fencing mode)
- `innerHTML` was used to set user-controlled displayName text, allowing script injection (e.g. `<img src=x onerror="alert('xss')">`)
- Changed to `textContent` which treats input as plain text, preventing HTML/JS execution
- The `displayValue` getter already uses actual nbsp characters (char code 160), not HTML entities, so `textContent` works correctly

## Investigation
Audited all ~20 locations where displayName is rendered in the UI. All other locations use React JSX text rendering which auto-escapes. Only `EditableSpan.js:71` was vulnerable via direct `innerHTML` assignment.

## Test plan
- [x] Verify username editing still works (spaces display correctly via nbsp)
- [x] Verify `<script>alert('xss')</script>` in username is rendered as literal text, not executed
- [x] All tests pass (360 frontend)

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)