### PR TITLE
Fix mobile homepage scrolling past viewport

### DIFF
--- a/src/components/common/css/primitives.css
+++ b/src/components/common/css/primitives.css
@@ -236,11 +236,13 @@
 .flex {
   display: flex;
   min-width: 0;
+  min-height: 0;
 }
 
 .flex--column {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   min-height: 0;
 }
 


### PR DESCRIPTION
## Summary
- Add `min-height: 0` to `.flex` and `min-width: 0` to `.flex--column` CSS utilities to match `react-flexview` default behavior
- Without this, row flex containers inside column layouts can't shrink below content size, causing the puzzle list to push the page past the viewport on mobile

The `react-flexview` → CSS flex migration split `min-width`/`min-height: 0` between `.flex` and `.flex--column`, but `react-flexview` set both on all elements.

## Test plan
- [ ] Mobile: homepage should not scroll past the puzzle list
- [ ] Mobile: puzzle list should scroll internally
- [ ] Desktop: no layout regressions on homepage, game page, or other pages using flex utilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)