### PR TITLE
Fix colored/shaded cells blocking typing and image bleed

### DIFF
--- a/server/gameUtils.js
+++ b/server/gameUtils.js
@@ -382,7 +382,7 @@ export const makeGrid = (textGrid, images) => {
         edits: [],
         value: '',
         number: null,
-        ...(images && images[flatIdx] ? {isImage: true} : {}),
+        ...(images && images[flatIdx] && cell === '' ? {isImage: true} : {}),
       };
     })
   );

--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -155,14 +155,6 @@ export default class Cell extends React.Component<Props> {
     return null;
   }
 
-  renderImage() {
-    const {image} = this.props;
-    if (image) {
-      return <img src={image} alt="" className="cell--image--bg" draggable={false} />;
-    }
-    return null;
-  }
-
   renderPickup() {
     const {pickupType} = this.props;
     if (pickupType) {
@@ -186,18 +178,21 @@ export default class Cell extends React.Component<Props> {
     return <div style={divStyle} />;
   }
 
-  getStyle() {
-    const {attributionColor, cellStyle, selected, highlighted, frozen} = this.props;
+  getStyle(): React.CSSProperties {
+    const {attributionColor, cellStyle, selected, highlighted, frozen, image} = this.props;
+    const imageStyle: React.CSSProperties = image
+      ? {backgroundImage: `url(${image})`, backgroundSize: 'cover'}
+      : {};
     if (selected) {
-      return cellStyle.selected;
+      return {...imageStyle, ...cellStyle.selected};
     }
     if (highlighted) {
       if (frozen) {
-        return cellStyle.frozen;
+        return {...imageStyle, ...cellStyle.frozen};
       }
-      return cellStyle.highlighted;
+      return {...imageStyle, ...cellStyle.highlighted};
     }
-    return {backgroundColor: attributionColor};
+    return {...imageStyle, backgroundColor: attributionColor};
   }
 
   handleClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
@@ -235,6 +230,11 @@ export default class Cell extends React.Component<Props> {
       frozen,
     } = this.props;
     if (black || isHidden) {
+      const blackImage = black && this.props.image;
+      const blackStyle: React.CSSProperties = {
+        ...(selected ? {borderColor: myColor} : {}),
+        ...(blackImage ? {backgroundImage: `url(${blackImage})`, backgroundSize: 'cover'} : {}),
+      };
       return (
         <div
           className={clsx('cell', {
@@ -242,14 +242,13 @@ export default class Cell extends React.Component<Props> {
             black,
             hidden: isHidden,
           })}
-          style={selected ? {borderColor: myColor} : undefined}
+          style={blackStyle}
           role="button"
           tabIndex={0}
           onClick={this.handleClick}
           onKeyDown={this.handleKeyDown}
           onContextMenu={this.handleRightClick}
         >
-          {black && this.renderImage()}
           {this.renderPings()}
         </div>
       );
@@ -295,10 +294,9 @@ export default class Cell extends React.Component<Props> {
           {this.renderFlipButton()}
           {this.renderCircle()}
           {this.renderShade()}
-          {this.renderImage()}
           {this.renderPickup()}
           {this.renderSolvedBy()}
-          {!this.props.image && (
+          {!this.props.isImage && (
             <div
               className="cell--value"
               style={{

--- a/src/components/Grid/css/cell.css
+++ b/src/components/Grid/css/cell.css
@@ -210,13 +210,3 @@ div:focus .cell.referenced {
   background-color: rgba(0, 0, 0, 0.3);
   z-index: 10;
 }
-
-.cell--image--bg {
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  z-index: 10;
-}

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -188,7 +188,10 @@ export default class Player extends Component {
       return;
     }
     if (this.props.grid[selected.r][selected.c].isImage) {
-      return;
+      const sol = this.props.solution;
+      const hasSolutionLetter =
+        sol && sol[selected.r] && sol[selected.r][selected.c] !== '' && sol[selected.r][selected.c] !== '.';
+      if (!hasSolutionLetter) return;
     }
     if (this.isValidDirection(this.state.direction, selected)) {
       if (selected.r !== this.selected.r || selected.c !== this.selected.c) {
@@ -371,6 +374,7 @@ export default class Player extends Component {
       onToggleSkipFilledSquares,
       autoAdvanceCursor,
       grid,
+      solution,
       clues,
       circles,
       shades,
@@ -412,7 +416,21 @@ export default class Player extends Component {
     const {direction} = this.state;
     const selected = this.selected;
 
-    const gridWithColors = grid.map((row) =>
+    // Override isImage for cells that have a real solution letter — they should be typeable
+    // even if they have a background image (decorative coloring). This works at runtime for
+    // all games, including ones with stale isImage flags in stored data.
+    const correctedGrid = solution
+      ? grid.map((row, r) =>
+          row.map((cell, c) => {
+            if (cell.isImage && solution[r] && solution[r][c] !== '' && solution[r][c] !== '.') {
+              return {...cell, isImage: false};
+            }
+            return cell;
+          })
+        )
+      : grid;
+
+    const gridWithColors = correctedGrid.map((row) =>
       row.map((cell) => ({
         ...cell,
         attributionColor: cell.value && colorAttributionMode ? lightenHsl(users[cell.user_id]?.color) : '',
@@ -474,7 +492,7 @@ export default class Player extends Component {
               onSetSelected={this._setSelected}
               updateGrid={updateGrid}
               size={size}
-              grid={grid}
+              grid={correctedGrid}
               clues={clues}
               onSetCursorLock={this.handleSetCursorLock}
               enableDebug={window.location.search.indexOf('debug') !== -1}
@@ -507,7 +525,7 @@ export default class Player extends Component {
             onSetSelected={this._setSelected}
             updateGrid={updateGrid}
             size={size}
-            grid={grid}
+            grid={correctedGrid}
             clues={clues}
             onSetCursorLock={this.handleSetCursorLock}
             enableDebug={window.location.search.indexOf('debug') !== -1}
@@ -550,7 +568,7 @@ export default class Player extends Component {
             canSetDirection={this._canSetDirection}
             onSetSelected={this._setSelected}
             updateGrid={updateGrid}
-            grid={grid}
+            grid={correctedGrid}
             clues={clues}
             beta={beta}
             onCheck={this.props.onCheck}
@@ -588,7 +606,7 @@ export default class Player extends Component {
           canSetDirection={this._canSetDirection}
           onSetSelected={this._setSelected}
           updateGrid={updateGrid}
-          grid={grid}
+          grid={correctedGrid}
           clues={clues}
           beta={beta}
           onCheck={this.props.onCheck}

--- a/src/lib/__tests__/clientGameUtils.test.js
+++ b/src/lib/__tests__/clientGameUtils.test.js
@@ -88,6 +88,22 @@ describe('makeGrid', () => {
     expect(grid.grid[1][0].isImage).toBeUndefined();
   });
 
+  it('does not set isImage on letter cells with background images', () => {
+    const textGrid = [
+      ['A', 'B', 'C'],
+      ['D', '', '.'],
+    ];
+    const images = {
+      0: 'data:image/png;base64,bg',
+      1: 'data:image/png;base64,bg',
+      4: 'data:image/png;base64,bg',
+    };
+    const grid = makeGrid(textGrid, false, images);
+    expect(grid.grid[0][0].isImage).toBeUndefined(); // letter cell — typeable
+    expect(grid.grid[0][1].isImage).toBeUndefined(); // letter cell — typeable
+    expect(grid.grid[1][1].isImage).toBe(true); // decorative cell — non-typeable
+  });
+
   it('does not set isImage when images is empty', () => {
     const textGrid = [
       ['A', 'B'],

--- a/src/lib/gameUtils.js
+++ b/src/lib/gameUtils.js
@@ -48,7 +48,7 @@ export const makeGrid = (textGrid, fillWithSol, images) => {
         edits: [],
         value: fillWithSol ? cell : '',
         number: null,
-        ...(images && images[flatIdx] ? {isImage: true} : {}),
+        ...(images && images[flatIdx] && cell === '' ? {isImage: true} : {}),
       };
     })
   );


### PR DESCRIPTION
## Summary
- Cells with decorative background images (colored/shaded cells from iPuz puzzles like NYT Flying Colors) were incorrectly marked as `isImage`, blocking click, selection, and typing
- Background images rendered as child `<img>` elements bled past cell boundaries due to collapsed table border rendering quirks
- Fixes at three levels: `makeGrid` prevention, runtime `isImage` override in Player.js using the solution array, and CSS background-image rendering on the cell div itself

## Test plan
- [x] Upload iPuz puzzle with colored cells (e.g. NYT June 4 2023 Flying Colors) — colored backgrounds render correctly
- [x] Cells with colored backgrounds are clickable and typeable
- [x] No image bleed at bottom of colored cells
- [x] Existing games with stale `isImage` flags work correctly (runtime override)
- [x] Black cells with embedded images (e.g. NYT Dec 31 2025) still render correctly
- [x] Regular puzzles without images unaffected
- [x] All 361 frontend tests pass
- [x] All 160 server tests pass
- [x] TypeScript and ESLint clean

Fixes #288, fixes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)