### PR TITLE
Preserve iPuz cell colors and fix typing in shaded/image cells

### DIFF
--- a/server/gameUtils.js
+++ b/server/gameUtils.js
@@ -382,7 +382,7 @@ export const makeGrid = (textGrid, images) => {
         edits: [],
         value: '',
         number: null,
-        ...(images && images[flatIdx] ? {isImage: true} : {}),
+        ...(images && images[flatIdx] && cell === '' ? {isImage: true} : {}),
       };
     })
   );

--- a/src/components/Fencing/transformGameToPlayerProps.ts
+++ b/src/components/Fencing/transformGameToPlayerProps.ts
@@ -2,7 +2,7 @@
  * Perhaps this whole file could live elsewhere, e.g. Player/transformGameToPlayerProps?
  * */
 import _ from 'lodash';
-import {CluesJson, GameJson, Cursor, GridData, UserJson, CellIndex} from '../../shared/types';
+import {CluesJson, GameJson, Cursor, GridData, UserJson, CellIndex, ShadeEntry} from '../../shared/types';
 import {CellCoords, Ping} from '../Grid/types';
 import {PlayerActions} from './usePlayerActions';
 
@@ -12,7 +12,7 @@ interface PlayerProps {
   grid: GridData;
   solution: string[][];
   circles?: CellIndex[];
-  shades?: CellIndex[];
+  shades?: ShadeEntry[];
   pings?: Ping[];
   cursors: Cursor[];
   clues: CluesJson;

--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -22,7 +22,7 @@ export interface EnhancedCellData extends CellData {
   highlighted: boolean;
   frozen: boolean;
   circled: boolean;
-  shaded: boolean;
+  shaded: string | boolean;
   image?: string;
   referenced: boolean;
   canFlipColor: boolean;
@@ -150,7 +150,8 @@ export default class Cell extends React.Component<Props> {
   renderShade() {
     const {shaded} = this.props;
     if (shaded) {
-      return <div className="cell--shade" />;
+      const style = typeof shaded === 'string' ? {backgroundColor: shaded} : undefined;
+      return <div className="cell--shade" style={style} />;
     }
     return null;
   }
@@ -235,6 +236,10 @@ export default class Cell extends React.Component<Props> {
       frozen,
     } = this.props;
     if (black || isHidden) {
+      const blackStyle: React.CSSProperties = {
+        ...(selected ? {borderColor: myColor} : {}),
+        ...(black && typeof shaded === 'string' ? {backgroundColor: shaded} : {}),
+      };
       return (
         <div
           className={clsx('cell', {
@@ -242,7 +247,7 @@ export default class Cell extends React.Component<Props> {
             black,
             hidden: isHidden,
           })}
-          style={selected ? {borderColor: myColor} : undefined}
+          style={blackStyle}
           role="button"
           tabIndex={0}
           onClick={this.handleClick}
@@ -298,7 +303,7 @@ export default class Cell extends React.Component<Props> {
           {this.renderImage()}
           {this.renderPickup()}
           {this.renderSolvedBy()}
-          {!this.props.image && (
+          {!this.props.isImage && (
             <div
               className="cell--value"
               style={{

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -7,7 +7,7 @@ import RerenderBoundary from '../RerenderBoundary';
 import {hashGridRow} from './hashGridRow';
 import Cell from './Cell';
 import {GridDataWithColor, CellCoords, ClueCoords, BattlePickup, CellStyles, Ping} from './types';
-import {CellIndex, Cursor, GridData, toCellIndex} from '../../shared/types';
+import {CellIndex, ColoredShade, Cursor, GridData, ShadeEntry, toCellIndex} from '../../shared/types';
 
 export interface GridProps {
   // Grid data
@@ -21,7 +21,7 @@ export interface GridProps {
 
   // Cell annotations
   circles?: CellIndex[];
-  shades?: CellIndex[];
+  shades?: ShadeEntry[];
   images?: Record<number, string>;
   pings?: Ping[];
   cursors: Cursor[];
@@ -79,10 +79,18 @@ export default class Grid extends React.PureComponent<GridProps> {
     );
   }
 
-  isShaded(r: number, c: number) {
+  isShaded(r: number, c: number): string | boolean {
     const {grid, shades} = this.props;
     const idx = toCellIndex(r, c, grid[0].length);
-    return (shades || []).indexOf(idx) !== -1 || this.isDoneByOpponent(r, c);
+    for (const entry of shades || []) {
+      if (typeof entry === 'object' && (entry as ColoredShade).index === idx) {
+        return (entry as ColoredShade).color;
+      }
+      if (entry === idx) {
+        return true;
+      }
+    }
+    return this.isDoneByOpponent(r, c);
   }
 
   getImage(r: number, c: number): string | undefined {

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -188,7 +188,10 @@ export default class Player extends Component {
       return;
     }
     if (this.props.grid[selected.r][selected.c].isImage) {
-      return;
+      const sol = this.props.solution;
+      const hasSolutionLetter =
+        sol && sol[selected.r] && sol[selected.r][selected.c] !== '' && sol[selected.r][selected.c] !== '.';
+      if (!hasSolutionLetter) return;
     }
     if (this.isValidDirection(this.state.direction, selected)) {
       if (selected.r !== this.selected.r || selected.c !== this.selected.c) {
@@ -371,6 +374,7 @@ export default class Player extends Component {
       onToggleSkipFilledSquares,
       autoAdvanceCursor,
       grid,
+      solution,
       clues,
       circles,
       shades,
@@ -412,7 +416,18 @@ export default class Player extends Component {
     const {direction} = this.state;
     const selected = this.selected;
 
-    const gridWithColors = grid.map((row) =>
+    const correctedGrid = solution
+      ? grid.map((row, r) =>
+          row.map((cell, c) => {
+            if (cell.isImage && solution[r] && solution[r][c] !== '' && solution[r][c] !== '.') {
+              return {...cell, isImage: false};
+            }
+            return cell;
+          })
+        )
+      : grid;
+
+    const gridWithColors = correctedGrid.map((row) =>
       row.map((cell) => ({
         ...cell,
         attributionColor: cell.value && colorAttributionMode ? lightenHsl(users[cell.user_id]?.color) : '',
@@ -474,7 +489,7 @@ export default class Player extends Component {
               onSetSelected={this._setSelected}
               updateGrid={updateGrid}
               size={size}
-              grid={grid}
+              grid={correctedGrid}
               clues={clues}
               onSetCursorLock={this.handleSetCursorLock}
               enableDebug={window.location.search.indexOf('debug') !== -1}
@@ -507,7 +522,7 @@ export default class Player extends Component {
             onSetSelected={this._setSelected}
             updateGrid={updateGrid}
             size={size}
-            grid={grid}
+            grid={correctedGrid}
             clues={clues}
             onSetCursorLock={this.handleSetCursorLock}
             enableDebug={window.location.search.indexOf('debug') !== -1}
@@ -550,7 +565,7 @@ export default class Player extends Component {
             canSetDirection={this._canSetDirection}
             onSetSelected={this._setSelected}
             updateGrid={updateGrid}
-            grid={grid}
+            grid={correctedGrid}
             clues={clues}
             beta={beta}
             onCheck={this.props.onCheck}
@@ -588,7 +603,7 @@ export default class Player extends Component {
           canSetDirection={this._canSetDirection}
           onSetSelected={this._setSelected}
           updateGrid={updateGrid}
-          grid={grid}
+          grid={correctedGrid}
           clues={clues}
           beta={beta}
           onCheck={this.props.onCheck}

--- a/src/lib/converter/__tests__/iPUZtoJSON.test.js
+++ b/src/lib/converter/__tests__/iPUZtoJSON.test.js
@@ -142,7 +142,7 @@ describe('iPUZtoJSON', () => {
     expect(result.circles).toHaveLength(1);
   });
 
-  it('detects shades from style.color', () => {
+  it('preserves hex color from style.color', () => {
     const ipuz = makeMinimalIPUZ({
       puzzle: [
         [{cell: 1, style: {color: 'dcdcdc'}}, {cell: 2}],
@@ -150,8 +150,7 @@ describe('iPUZtoJSON', () => {
       ],
     });
     const result = iPUZtoJSON(makeBuffer(ipuz));
-    expect(result.shades).toContain(0);
-    expect(result.shades).toHaveLength(1);
+    expect(result.shades).toEqual([{index: 0, color: '#dcdcdc'}]);
   });
 
   it('detects shades from style.highlight', () => {
@@ -179,6 +178,20 @@ describe('iPUZtoJSON', () => {
     const result = iPUZtoJSON(makeBuffer(ipuz));
     expect(result.circles).toEqual([0]);
     expect(result.shades).toEqual([1]);
+  });
+
+  it('stores multiple colors in shades array', () => {
+    const ipuz = makeMinimalIPUZ({
+      puzzle: [
+        [
+          {cell: 1, style: {color: 'a65c32'}},
+          {cell: 2, style: {color: 'ffffff'}},
+        ],
+        [{cell: 3, style: {highlight: true}}, '#'],
+      ],
+    });
+    const result = iPUZtoJSON(makeBuffer(ipuz));
+    expect(result.shades).toEqual([{index: 0, color: '#a65c32'}, {index: 1, color: '#ffffff'}, 2]);
   });
 
   it('returns empty circles and shades by default', () => {

--- a/src/lib/converter/iPUZtoJSON.js
+++ b/src/lib/converter/iPUZtoJSON.js
@@ -50,7 +50,9 @@ export default function iPUZtoJSON(readerResult) {
         if (cell.style.shapebg === 'circle') {
           circles.push(flatIdx);
         }
-        if (cell.style.color || cell.style.highlight) {
+        if (cell.style.color) {
+          shades.push({index: flatIdx, color: '#' + cell.style.color});
+        } else if (cell.style.highlight) {
           shades.push(flatIdx);
         }
         if (

--- a/src/lib/gameUtils.js
+++ b/src/lib/gameUtils.js
@@ -48,7 +48,7 @@ export const makeGrid = (textGrid, fillWithSol, images) => {
         edits: [],
         value: fillWithSol ? cell : '',
         number: null,
-        ...(images && images[flatIdx] ? {isImage: true} : {}),
+        ...(images && images[flatIdx] && cell === '' ? {isImage: true} : {}),
       };
     })
   );

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -36,6 +36,8 @@ export type GridData = CellData[][];
 
 export type CellIndex = Brand<number, 'CellIndex'>;
 export const toCellIndex = (r: number, c: number, cols: number) => (r * cols + c) as CellIndex;
+export type ColoredShade = {index: CellIndex; color: string};
+export type ShadeEntry = CellIndex | ColoredShade;
 
 export interface GameJson {
   info: InfoJson;
@@ -51,7 +53,7 @@ export interface GameJson {
   solution: string[][];
   clues: CluesJson;
   circles?: CellIndex[];
-  shades?: CellIndex[];
+  shades?: ShadeEntry[];
   images?: Record<number, string>;
   contest?: boolean;
 }
@@ -85,7 +87,7 @@ export interface PuzzleJson {
   solution: string[][];
   info: InfoJson;
   circles: string[];
-  shades: string[];
+  shades: (string | {index: string; color: string})[];
   images?: Record<number, string>;
   clues: CluesJson;
   private?: boolean;


### PR DESCRIPTION
## Summary
- iPuz converter now stores `{index, color}` objects in the `shades` array when `style.color` is present, preserving actual hex colors (e.g. brown, white, dark brown for football puzzles) instead of rendering a generic gray overlay. Fixes #293.
- Black cells with shade colors also render the specified `backgroundColor`.
- Fixes cells with decorative background images (`isImage`) blocking typing by only setting `isImage` when the cell has no solution letter. Fixes #288 and #249.
- Runtime `correctedGrid` in Player.js overrides stale `isImage` flags for existing games.

## Test plan
- [ ] Upload a football iPuz — cells show brown, white, dark brown colors instead of gray
- [ ] Upload a PUZ with shading — renders default gray as before
- [ ] Upload a normal puzzle — no shading regressions
- [ ] Typing works in cells with background images and shade colors
- [ ] Black cells with shade colors display correctly
- [ ] `pnpm test` passes (361 tests)
- [ ] `pnpm tsc --noEmit` clean
- [ ] `pnpm eslint --max-warnings 0 src/ server/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)