### PR TITLE
Add CSS linting with Stylelint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,29 @@ jobs:
       - name: Run ESLint
         run: pnpm eslint --max-warnings 0 src/ server/
 
+  stylelint:
+    name: Stylelint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Stylelint
+        run: pnpm stylelint
+
   format:
     name: Prettier
     runs-on: ubuntu-latest
@@ -145,7 +168,7 @@ jobs:
 
   build:
     name: Build
-    needs: [lint, format, test-frontend, test-server, typecheck-frontend, typecheck-server]
+    needs: [lint, stylelint, format, test-frontend, test-server, typecheck-frontend, typecheck-server]
     runs-on: ubuntu-latest
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ E2E tests live in `e2e/` with two layers. **Smoke tests**: page rendering, navig
 
 ```sh
 pnpm eslint --max-warnings 0 src/ server/  # Lint (CI enforces --max-warnings 0)
+pnpm stylelint                          # CSS lint
+pnpm stylelint:fix                      # CSS lint with autofix
 pnpm prettier --check .                 # Format check
 pnpm prettier --write .                 # Auto-fix formatting
 pnpm tsc --noEmit                       # Frontend type check
@@ -53,12 +55,13 @@ pnpm preview                            # Serve production build locally
 All of these must pass before merging to master:
 
 1. ESLint (zero warnings)
-2. Prettier
-3. Frontend tests
-4. Server tests
-5. Frontend TypeCheck
-6. Server TypeCheck
-7. Build
+2. Stylelint
+3. Prettier
+4. Frontend tests
+5. Server tests
+6. Frontend TypeCheck
+7. Server TypeCheck
+8. Build
 
 ## Architecture
 
@@ -78,7 +81,8 @@ All of these must pass before merging to master:
 - **Dark mode variables**: `--dark-background` (#121212), `--dark-background-1` (rgba 0.05), `--dark-background-2` (rgba 0.12), `--dark-primary-text` (rgba 0.87), `--dark-blue-1`, `--dark-blue-2`.
 - **Styling**: Plain CSS + Radix UI primitives (`@radix-ui/react-dialog`, `@radix-ui/react-tabs`) for accessible Dialog/Tabs. Shared CSS primitives in `src/components/common/css/primitives.css`. `react-icons` for icons. Prettier: 110 char width, single quotes, no bracket spacing.
 - **ESLint**: Flat config (`eslint.config.mjs`). Many a11y rules are warnings (not errors) due to legacy code. `--max-warnings 0` in CI means new warnings fail the build.
-- **Pre-commit hook**: lint-staged runs ESLint + Prettier on staged files automatically.
+- **Stylelint**: Config in `stylelint.config.mjs`, extends `stylelint-config-standard`. `selector-class-pattern` and `no-descending-specificity` are disabled for project conventions.
+- **Pre-commit hook**: lint-staged runs ESLint + Prettier on staged JS/TS files, and Stylelint + Prettier on staged CSS files.
 - **Package manager**: pnpm (managed via corepack). Run `corepack enable` once, then use `pnpm install`.
 
 ## Deployment

--- a/package.json
+++ b/package.json
@@ -109,6 +109,8 @@
     "jsdom": "^26",
     "lint-staged": "^10.5.3",
     "prettier": "^3",
+    "stylelint": "^16.26.1",
+    "stylelint-config-standard": "^36.0.1",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript-eslint": "^8",
@@ -134,7 +136,9 @@
     "test:e2e:headed": "npx playwright test --config=e2e/playwright.config.ts --headed",
     "test:e2e:ui": "npx playwright test --config=e2e/playwright.config.ts --ui",
     "test:e2e:chromium": "npx playwright test --config=e2e/playwright.config.ts --project=chromium",
-    "test:e2e:report": "npx playwright show-report e2e/playwright-report"
+    "test:e2e:report": "npx playwright show-report e2e/playwright-report",
+    "stylelint": "stylelint \"src/**/*.css\"",
+    "stylelint:fix": "stylelint \"src/**/*.css\" --fix"
   },
   "lint-staged": {
     "!(backfills|utils|e2e)/**/*.{js,jsx,ts,tsx}": [
@@ -142,6 +146,10 @@
       "prettier --write"
     ],
     "(backfills|utils)/**/*.{js,jsx,ts,tsx}": [
+      "prettier --write"
+    ],
+    "src/**/*.css": [
+      "stylelint --max-warnings=0",
       "prettier --write"
     ]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,12 @@ importers:
       prettier:
         specifier: ^3
         version: 3.8.1
+      stylelint:
+        specifier: ^16.26.1
+        version: 16.26.1(typescript@5.4.5)
+      stylelint-config-standard:
+        specifier: ^36.0.1
+        version: 36.0.1(stylelint@16.26.1(typescript@5.4.5))
       ts-jest:
         specifier: ^29.4.6
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@14.14.22)(ts-node@10.9.2(@types/node@14.14.22)(typescript@5.4.5)))(typescript@5.4.5)
@@ -812,6 +818,12 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@cacheable/memory@2.0.8':
+    resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
+
+  '@cacheable/utils@2.4.0':
+    resolution: {integrity: sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==}
+
   '@canvas/image-data@1.1.0':
     resolution: {integrity: sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA==}
 
@@ -843,9 +855,28 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-syntax-patches-for-csstree@1.0.28':
+    resolution: {integrity: sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==}
+
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@csstools/media-query-list-parser@4.0.3':
+    resolution: {integrity: sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/selector-specificity@5.0.0':
+    resolution: {integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss-selector-parser: ^7.0.0
+
+  '@dual-bundle/import-meta-resolve@4.2.1':
+    resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -1435,8 +1466,29 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
@@ -2493,6 +2545,10 @@ packages:
     resolution: {integrity: sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==}
     engines: {node: '>=0.10.0'}
 
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
   array-uniq@1.0.3:
     resolution: {integrity: sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==}
     engines: {node: '>=0.10.0'}
@@ -2631,6 +2687,9 @@ packages:
   balanced-match@1.0.0:
     resolution: {integrity: sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==}
 
+  balanced-match@2.0.0:
+    resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2705,6 +2764,10 @@ packages:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2745,6 +2808,9 @@ packages:
   cacheable-request@6.1.0:
     resolution: {integrity: sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==}
     engines: {node: '>=8'}
+
+  cacheable@2.3.3:
+    resolution: {integrity: sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2887,6 +2953,9 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -2978,6 +3047,15 @@ packages:
     resolution: {integrity: sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==}
     engines: {node: '>=10'}
 
+  cosmiconfig@9.0.0:
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2999,12 +3077,25 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  css-functions-list@3.3.3:
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
+    engines: {node: '>=12'}
+
   css-in-js-utils@2.0.1:
     resolution: {integrity: sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==}
 
   css-tree@1.1.2:
     resolution: {integrity: sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==}
     engines: {node: '>=8.0.0'}
+
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
@@ -3187,6 +3278,10 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -3295,6 +3390,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -3573,6 +3672,10 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -3588,8 +3691,15 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
   fastest-stable-stringify@2.0.2:
     resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   faye-websocket@0.11.3:
     resolution: {integrity: sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==}
@@ -3611,6 +3721,9 @@ packages:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
 
+  file-entry-cache@11.1.2:
+    resolution: {integrity: sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3628,6 +3741,10 @@ packages:
 
   fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
   finalhandler@1.3.1:
@@ -3672,6 +3789,9 @@ packages:
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
+
+  flat-cache@6.1.20:
+    resolution: {integrity: sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==}
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
@@ -3891,9 +4011,17 @@ packages:
     resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
     engines: {node: '>=0.10.0'}
 
+  global-modules@2.0.0:
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    engines: {node: '>=6'}
+
   global-prefix@1.0.2:
     resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
+
+  global-prefix@3.0.0:
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    engines: {node: '>=6'}
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3910,6 +4038,13 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
+  globjoin@0.1.4:
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
 
   globule@0.1.0:
     resolution: {integrity: sha512-3eIcA2OjPCm4VvwIwZPzIxCVssA8HSpM2C6c6kK5ufJH4FGwWoyqL3In19uuX4oe+TwH3w2P1nQDmW56iehO4A==}
@@ -4057,6 +4192,10 @@ packages:
   hash-stream-validation@0.2.4:
     resolution: {integrity: sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ==}
 
+  hashery@1.5.0:
+    resolution: {integrity: sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==}
+    engines: {node: '>=20'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -4069,12 +4208,19 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-tags@3.3.1:
+    resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
+    engines: {node: '>=8'}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -4384,6 +4530,10 @@ packages:
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
@@ -4775,6 +4925,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
   kind-of@3.2.2:
     resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
     engines: {node: '>=0.10.0'}
@@ -4794,6 +4947,9 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  known-css-properties@0.37.0:
+    resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -4941,6 +5097,9 @@ packages:
   lodash.templatesettings@3.1.1:
     resolution: {integrity: sha512-TcrlEr31tDYnWkHFWDCV3dHYroKEXpJZ2YJYvJdhN+y4AkWMDZ5I4I8XDtUKqSAyG81N7w+I1mFEJtcED+tGqQ==}
 
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
   lodash@1.0.2:
     resolution: {integrity: sha512-0VSEDVec/Me2eATuoiQd8IjyBMMX0fahob8YJ96V1go2RjvCk1m1GxmtfXn8RNSaLaTtop7fsuhhu9oLk3hUgA==}
     engines: {'0': node, '1': rhino}
@@ -5027,18 +5186,32 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mathml-tag-names@2.1.3:
+    resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
+
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
+
+  meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -5050,6 +5223,10 @@ packages:
 
   micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
@@ -5525,6 +5702,22 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-resolve-nested-selector@0.1.6:
+    resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
+
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5627,6 +5820,10 @@ packages:
   puzjs@1.0.2:
     resolution: {integrity: sha512-o3gDiR5PSLYMrVUXT+xQM6WvjrjVURBsjulVWScLnxXF5WwFwb6ZF9yMZuYfYteYjVrhiQhLWHBsKwPcj59rzw==}
 
+  qified@0.6.0:
+    resolution: {integrity: sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==}
+    engines: {node: '>=20'}
+
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
@@ -5645,6 +5842,9 @@ packages:
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -5919,6 +6119,10 @@ packages:
     resolution: {integrity: sha512-QnRZUpuPNgX0+D1xVxul6DbJ9slvo4Rm6iV/dn63e048MvGbUZiKySVt6Tenp04JqmchxjiLltGerOJys7kJYQ==}
     engines: {node: '>=8.10.0'}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rollup@2.80.0:
     resolution: {integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==}
     engines: {node: '>=10.0.0'}
@@ -5934,6 +6138,9 @@ packages:
 
   rtl-css-js@1.14.0:
     resolution: {integrity: sha512-Dl5xDTeN3e7scU1cWX8c9b6/Nqz3u/HgR4gePc1kWXYiQWVQbKCEyK6+Hxve9LbcJ5EieHy1J9nJCN3grTtGwg==}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rxjs@6.6.3:
     resolution: {integrity: sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==}
@@ -6349,6 +6556,23 @@ packages:
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
+  stylelint-config-recommended@14.0.1:
+    resolution: {integrity: sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      stylelint: ^16.1.0
+
+  stylelint-config-standard@36.0.1:
+    resolution: {integrity: sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      stylelint: ^16.1.0
+
+  stylelint@16.26.1:
+    resolution: {integrity: sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
   stylis@4.0.6:
     resolution: {integrity: sha512-1igcUEmYFBEO14uQHAJhCUelTR5jPztfdVKrYxRnDa5D5Dn3w0NxXupJNPr/VV/yRfZYEAco8sTIRZzH3sRYKg==}
 
@@ -6368,12 +6592,23 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-tags@1.0.0:
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   teeny-request@6.0.3:
     resolution: {integrity: sha512-TZG/dfd2r6yeji19es1cUIwAlVD8y+/svB1kAC2Y0bjEyysrfbO8EZvJBRwIE6WkwmUoB7uvWLwTIhJbMXZ1Dw==}
@@ -7046,6 +7281,10 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -7833,6 +8072,18 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@cacheable/memory@2.0.8':
+    dependencies:
+      '@cacheable/utils': 2.4.0
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.4.0':
+    dependencies:
+      hashery: 1.5.0
+      keyv: 5.6.0
+
   '@canvas/image-data@1.1.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -7857,7 +8108,20 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-syntax-patches-for-csstree@1.0.28': {}
+
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@csstools/media-query-list-parser@4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.1)':
+    dependencies:
+      postcss-selector-parser: 7.1.1
+
+  '@dual-bundle/import-meta-resolve@4.2.1': {}
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -8550,12 +8814,32 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
 
@@ -9542,6 +9826,8 @@ snapshots:
 
   array-slice@1.1.0: {}
 
+  array-union@2.1.0: {}
+
   array-uniq@1.0.3: {}
 
   array-unique@0.3.2: {}
@@ -9718,6 +10004,8 @@ snapshots:
 
   balanced-match@1.0.0: {}
 
+  balanced-match@2.0.0: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -9819,6 +10107,10 @@ snapshots:
     dependencies:
       fill-range: 7.0.1
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.19
@@ -9872,6 +10164,14 @@ snapshots:
       lowercase-keys: 2.0.0
       normalize-url: 4.5.0
       responselike: 1.0.2
+
+  cacheable@2.3.3:
+    dependencies:
+      '@cacheable/memory': 2.0.8
+      '@cacheable/utils': 2.4.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.6.0
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -10015,6 +10315,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  colord@2.9.3: {}
+
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -10101,6 +10403,15 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
+  cosmiconfig@9.0.0(typescript@5.4.5):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.4.5
+
   create-jest@29.7.0(@types/node@14.14.22)(ts-node@10.9.2(@types/node@14.14.22)(typescript@5.4.5)):
     dependencies:
       '@jest/types': 29.6.3
@@ -10130,6 +10441,8 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  css-functions-list@3.3.3: {}
+
   css-in-js-utils@2.0.1:
     dependencies:
       hyphenate-style-name: 1.0.4
@@ -10139,6 +10452,13 @@ snapshots:
     dependencies:
       mdn-data: 2.0.14
       source-map: 0.6.1
+
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  cssesc@3.0.0: {}
 
   cssstyle@4.6.0:
     dependencies:
@@ -10304,6 +10624,10 @@ snapshots:
 
   diff@4.0.2: {}
 
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -10432,6 +10756,8 @@ snapshots:
     optional: true
 
   entities@6.0.1: {}
+
+  env-paths@2.2.1: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -10917,6 +11243,14 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -10927,7 +11261,13 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fastest-levenshtein@1.0.16: {}
+
   fastest-stable-stringify@2.0.2: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   faye-websocket@0.11.3:
     dependencies:
@@ -10944,6 +11284,10 @@ snapshots:
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  file-entry-cache@11.1.2:
+    dependencies:
+      flat-cache: 6.1.20
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -10965,6 +11309,10 @@ snapshots:
       to-regex-range: 2.1.1
 
   fill-range@7.0.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
@@ -11050,6 +11398,12 @@ snapshots:
     dependencies:
       flatted: 3.3.3
       keyv: 4.5.4
+
+  flat-cache@6.1.20:
+    dependencies:
+      cacheable: 2.3.3
+      flatted: 3.3.3
+      hookified: 1.15.1
 
   flatted@3.3.3: {}
 
@@ -11312,12 +11666,22 @@ snapshots:
       is-windows: 1.0.2
       resolve-dir: 1.0.1
 
+  global-modules@2.0.0:
+    dependencies:
+      global-prefix: 3.0.0
+
   global-prefix@1.0.2:
     dependencies:
       expand-tilde: 2.0.2
       homedir-polyfill: 1.0.3
       ini: 1.3.8
       is-windows: 1.0.2
+      which: 1.3.1
+
+  global-prefix@3.0.0:
+    dependencies:
+      ini: 1.3.8
+      kind-of: 6.0.3
       which: 1.3.1
 
   globals@11.12.0: {}
@@ -11330,6 +11694,17 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.2.4
+      merge2: 1.4.1
+      slash: 3.0.0
+
+  globjoin@0.1.4: {}
 
   globule@0.1.0:
     dependencies:
@@ -11556,6 +11931,10 @@ snapshots:
   hash-stream-validation@0.2.4:
     optional: true
 
+  hashery@1.5.0:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -11566,11 +11945,15 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
+  hookified@1.15.1: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  html-tags@3.3.1: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -11862,6 +12245,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -12512,6 +12897,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
   kind-of@3.2.2:
     dependencies:
       is-buffer: 1.1.6
@@ -12525,6 +12914,8 @@ snapshots:
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
+
+  known-css-properties@0.37.0: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -12687,6 +13078,8 @@ snapshots:
       lodash._reinterpolate: 3.0.0
       lodash.escape: 3.2.0
 
+  lodash.truncate@4.4.2: {}
+
   lodash@1.0.2: {}
 
   lodash@4.17.23: {}
@@ -12762,13 +13155,21 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mathml-tag-names@2.1.3: {}
+
   mdn-data@2.0.14: {}
 
+  mdn-data@2.12.2: {}
+
   media-typer@0.3.0: {}
+
+  meow@13.2.0: {}
 
   merge-descriptors@1.0.3: {}
 
   merge-stream@2.0.0: {}
+
+  merge2@1.4.1: {}
 
   methods@1.1.2: {}
 
@@ -12793,6 +13194,11 @@ snapshots:
   micromatch@4.0.5:
     dependencies:
       braces: 3.0.2
+      picomatch: 2.3.1
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
       picomatch: 2.3.1
 
   mime-db@1.52.0: {}
@@ -13252,6 +13658,19 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-resolve-nested-selector@0.1.6: {}
+
+  postcss-safe-parser@7.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -13356,6 +13775,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  qified@0.6.0:
+    dependencies:
+      hookified: 1.15.1
+
   qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
@@ -13367,6 +13790,8 @@ snapshots:
   querystring@0.2.0: {}
 
   querystringify@2.2.0: {}
+
+  queue-microtask@1.2.3: {}
 
   randombytes@2.1.0:
     dependencies:
@@ -13686,6 +14111,8 @@ snapshots:
       - supports-color
     optional: true
 
+  reusify@1.1.0: {}
+
   rollup@2.80.0:
     optionalDependencies:
       fsevents: 2.3.3
@@ -13726,6 +14153,10 @@ snapshots:
   rtl-css-js@1.14.0:
     dependencies:
       '@babel/runtime': 7.21.0
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   rxjs@6.6.3:
     dependencies:
@@ -14245,6 +14676,60 @@ snapshots:
   stubs@3.0.0:
     optional: true
 
+  stylelint-config-recommended@14.0.1(stylelint@16.26.1(typescript@5.4.5)):
+    dependencies:
+      stylelint: 16.26.1(typescript@5.4.5)
+
+  stylelint-config-standard@36.0.1(stylelint@16.26.1(typescript@5.4.5)):
+    dependencies:
+      stylelint: 16.26.1(typescript@5.4.5)
+      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(typescript@5.4.5))
+
+  stylelint@16.26.1(typescript@5.4.5):
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-syntax-patches-for-csstree': 1.0.28
+      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
+      '@dual-bundle/import-meta-resolve': 4.2.1
+      balanced-match: 2.0.0
+      colord: 2.9.3
+      cosmiconfig: 9.0.0(typescript@5.4.5)
+      css-functions-list: 3.3.3
+      css-tree: 3.1.0
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      fastest-levenshtein: 1.0.16
+      file-entry-cache: 11.1.2
+      global-modules: 2.0.0
+      globby: 11.1.0
+      globjoin: 0.1.4
+      html-tags: 3.3.1
+      ignore: 7.0.5
+      imurmurhash: 0.1.4
+      is-plain-object: 5.0.0
+      known-css-properties: 0.37.0
+      mathml-tag-names: 2.1.3
+      meow: 13.2.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-resolve-nested-selector: 0.1.6
+      postcss-safe-parser: 7.0.1(postcss@8.5.6)
+      postcss-selector-parser: 7.1.1
+      postcss-value-parser: 4.2.0
+      resolve-from: 5.0.0
+      string-width: 4.2.3
+      supports-hyperlinks: 3.2.0
+      svg-tags: 1.0.0
+      table: 6.9.0
+      write-file-atomic: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   stylis@4.0.6: {}
 
   supports-color@2.0.0: {}
@@ -14261,9 +14746,24 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-tags@1.0.0: {}
+
   symbol-tree@3.2.4: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.18.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   teeny-request@6.0.3:
     dependencies:
@@ -15059,6 +15559,11 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
 
   ws@8.18.3: {}
 

--- a/src/components/Auth/css/loginModal.css
+++ b/src/components/Auth/css/loginModal.css
@@ -4,7 +4,7 @@
 .login-modal--overlay {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgb(0 0 0 / 50%);
   z-index: 1300;
 }
 
@@ -21,8 +21,10 @@
   max-height: 85vh;
   overflow-y: auto;
   z-index: 1300;
-  box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14),
-    0px 9px 46px 8px rgba(0, 0, 0, 0.12);
+  box-shadow:
+    0 11px 15px -7px rgb(0 0 0 / 20%),
+    0 24px 38px 3px rgb(0 0 0 / 14%),
+    0 9px 46px 8px rgb(0 0 0 / 12%);
 }
 
 .dark .login-modal--panel {
@@ -47,17 +49,17 @@
   font-family: inherit;
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.02857em;
+  letter-spacing: 0.0286em;
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: rgba(0, 0, 0, 0.54);
+  color: rgb(0 0 0 / 54%);
   cursor: pointer;
   text-align: center;
 }
 
 .login-modal--tab:hover {
-  color: rgba(0, 0, 0, 0.87);
+  color: rgb(0 0 0 / 87%);
 }
 
 .login-modal--tab[data-state='active'] {
@@ -66,7 +68,7 @@
 }
 
 .dark .login-modal--tab {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .login-modal--tab:hover {

--- a/src/components/Chat/css/index.css
+++ b/src/components/Chat/css/index.css
@@ -12,7 +12,7 @@
 }
 
 .chat.mobile {
-  padding: 0px;
+  padding: 0;
 }
 
 .chat--header {
@@ -84,7 +84,9 @@
 .chat--messages {
   /* flex: 1; */
   overflow: auto;
+
   /* width: 100%; */
+
   /* max-height: 550px; */
   min-height: 1px;
   display: flex;
@@ -113,6 +115,7 @@
   white-space: nowrap;
   margin-left: 10px;
   color: var(--main-gray-2);
+
   /* background-color: var(--main-gray-1); */
 }
 
@@ -145,7 +148,7 @@
 
 .chat--bar {
   width: 100%;
-  padding: 20px 0px 20px 0px;
+  padding: 20px 0;
   position: relative;
 }
 
@@ -155,7 +158,7 @@
 
 .chat--bar--input--mobile {
   width: 100%;
-  border: 1px solid #dddddd;
+  border: 1px solid #ddd;
   height: 24px;
   font-size: 14px;
 }
@@ -167,7 +170,6 @@
 
 .copyButton:hover {
   cursor: pointer;
-  -webkit-filter: brightness(70%);
   filter: brightness(70%);
 }
 
@@ -178,10 +180,12 @@
 .flashBlue {
   animation: flash-blue-keyframes 0.5s;
 }
+
 @keyframes flash-blue-keyframes {
   0% {
     color: var(--main-blue);
   }
+
   100% {
     color: var(--main-gray-1);
   }

--- a/src/components/Grid/css/cell.css
+++ b/src/components/Grid/css/cell.css
@@ -4,16 +4,14 @@
   top: 0;
   width: 100%;
   height: 100%;
+
   /* z-index: -1; */
   transition: background-color 0.12s ease;
   display: flex;
   flex-direction: column;
   user-select: none;
-  -moz-user-select: none;
-  -khtml-user-select: none;
-  -webkit-user-select: none;
-  -o-user-select: none;
   background-color: white;
+  box-sizing: border-box;
 }
 
 .cell--wrapper {
@@ -22,10 +20,6 @@
   box-sizing: border-box;
   width: 100%;
   height: 100%;
-}
-
-.cell {
-  box-sizing: border-box;
 }
 
 .cell.black {
@@ -76,11 +70,8 @@ div:focus .cell.referenced {
 
 .cell.selected {
   background-color: #4aeba1;
-  /*background-color: #98ee99;*/
-}
 
-.cell--value {
-  background-color: transparent;
+  /* background-color: #98ee99; */
 }
 
 .cell.pencil .cell--value {
@@ -125,11 +116,12 @@ div:focus .cell.referenced {
   vertical-align: middle;
   font-size: 350%;
   z-index: 11;
+  background-color: transparent;
 }
 
 .tiny .cell--number {
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
 }
 
 .small .cell--number {
@@ -143,7 +135,7 @@ div:focus .cell.referenced {
   top: 0;
   width: 100%;
   height: 100%;
-  z-index: 2; /* may go up to 9*/
+  z-index: 2; /* may go up to 9 */
 }
 
 .cell--cursor {
@@ -154,6 +146,7 @@ div:focus .cell.referenced {
   height: 100%;
   box-sizing: border-box;
   border-style: solid;
+
   /* The below styles will be overwritten in code */
   border-color: blue;
   border-width: 1px;
@@ -179,6 +172,7 @@ div:focus .cell.referenced {
     transform: scale(0.2);
     opacity: 1;
   }
+
   to {
     transform: scale(3);
     opacity: 0;
@@ -207,7 +201,7 @@ div:focus .cell.referenced {
   top: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: rgb(0 0 0 / 30%);
   z-index: 10;
 }
 

--- a/src/components/Grid/css/index.css
+++ b/src/components/Grid/css/index.css
@@ -5,8 +5,8 @@
 
 .grid--cell {
   position: relative;
-  padding: 0px;
-  margin: 0px;
-  border: 1px solid #aaaaaa;
+  padding: 0;
+  margin: 0;
+  border: 1px solid #aaa;
   box-sizing: border-box;
 }

--- a/src/components/ListView/css/listView.css
+++ b/src/components/ListView/css/listView.css
@@ -35,8 +35,7 @@
 
 .list-view--list--clue {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
   padding-top: 5px;
   padding-bottom: 5px;
   border-left: 5px solid transparent;

--- a/src/components/Player/css/clues.css
+++ b/src/components/Player/css/clues.css
@@ -1,7 +1,7 @@
 .clues {
   position: relative;
   display: flex;
-  padding: 0px 20px 0px 20px;
+  padding: 0 20px;
 }
 
 .clues--secret {
@@ -61,7 +61,6 @@
 
 .clues--list--scroll--clue--number {
   margin-left: 5px;
-  font-weight: 400;
   line-height: 19px;
   font-weight: bold;
 }

--- a/src/components/Player/css/editor.css
+++ b/src/components/Player/css/editor.css
@@ -6,15 +6,11 @@
 
 .editor--main--clue-bar {
   background-color: var(--main-blue-3);
-  padding: 10px 20px 10px 20px;
+  padding: 10px 20px;
   display: flex;
   font-size: 15px;
   height: 70px;
   align-items: center;
-}
-
-.editor--main--clue-bar {
-  opacity: 2;
 }
 
 .editor--main--clue-bar--number {
@@ -49,6 +45,7 @@
 
 .editor--right {
   display: flex;
+
   /* justify-content: space-between; */
   flex-direction: column;
 }
@@ -56,7 +53,7 @@
 .editor--main--clues {
   flex: 1;
   display: flex;
-  padding: 0px 20px 0px 20px;
+  padding: 0 20px;
 }
 
 .editor--main--clues--list {
@@ -103,7 +100,6 @@
 
 .editor--main--clues--list--scroll--clue--number {
   margin-left: 5px;
-  font-weight: 400;
   line-height: 19px;
   font-weight: bold;
 }

--- a/src/components/Player/css/gridControls.css
+++ b/src/components/Player/css/gridControls.css
@@ -17,7 +17,7 @@
   position: absolute;
   bottom: 3px;
   left: 0;
-  padding: 10px 10px 0px 10px;
+  padding: 10px 10px 0;
   color: #444;
   font-weight: bold;
   font-size: 12px;
@@ -26,9 +26,9 @@
 
 .grid-controls:focus .grid--cover {
   display: none;
+
   /* just to be safe */
   z-index: -3;
   font-size: 1px;
-
   opacity: 0;
 }

--- a/src/components/Player/css/index.css
+++ b/src/components/Player/css/index.css
@@ -14,9 +14,10 @@
 
 .player--main--clue-bar {
   background-color: var(--main-blue-3);
-  padding: 10px 20px 10px 20px;
+  padding: 10px 20px;
   display: flex;
   font-size: 15px;
+
   /* width: 486px; */
   height: 40px;
   align-items: stretch;
@@ -68,9 +69,10 @@
 
 .player--main--vim-bar {
   background-color: var(--main-blue-3);
-  padding: 10px 10px 10px 10px;
+  padding: 10px;
   display: flex;
   font-size: 15px;
+
   /* width: 486px; */
   height: 20px;
   align-items: center;
@@ -125,7 +127,7 @@
 
 .player--mobile--clue-bar {
   background-color: var(--main-blue-3);
-  padding: 10px 20px 10px 20px;
+  padding: 10px 20px;
   display: flex;
   font-size: 15px;
   flex: 1;

--- a/src/components/Player/css/mobileKeyboard.css
+++ b/src/components/Player/css/mobileKeyboard.css
@@ -17,6 +17,7 @@
   background-color: #888;
   width: 40px;
 }
+
 .simple-keyboard .hg-button.hg-button-x {
   width: 30px;
   opacity: 0;
@@ -30,7 +31,7 @@
 .simple-keyboard .hg-button.hg-button-emoji span {
   width: 100%;
   height: 100%;
-  background-image: url(https://scontent-sjc3-1.xx.fbcdn.net/v/t39.1997-6/p200x200/851575_392309627533016_444569512_n.png?_nc_cat=1&_nc_ht=scontent-sjc3-1.xx&oh=a0a2b47e4baffc248516c9bf6ba0015d&oe=5CD29CB4);
+  background-image: url('https://scontent-sjc3-1.xx.fbcdn.net/v/t39.1997-6/p200x200/851575_392309627533016_444569512_n.png?_nc_cat=1&_nc_ht=scontent-sjc3-1.xx&oh=a0a2b47e4baffc248516c9bf6ba0015d&oe=5CD29CB4');
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/src/components/PuzzleList/css/puzzleList.css
+++ b/src/components/PuzzleList/css/puzzleList.css
@@ -6,6 +6,7 @@
 .entry--icon {
   fill: #6aa9f4;
 }
+
 .entry--icon.fencing {
   fill: #353d46;
   margin-left: 4px;
@@ -61,7 +62,7 @@
 
 .dark .puzzlelist--error--message,
 .dark .puzzlelist--error--discord {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgb(255 255 255 / 70%);
 }
 
 .dark .puzzlelist--error--retry {

--- a/src/components/Toolbar/css/ActionMenu.css
+++ b/src/components/Toolbar/css/ActionMenu.css
@@ -35,7 +35,7 @@
 
 .action-menu--list--action:hover {
   color: #111;
-  background-color: #dddddd;
+  background-color: #ddd;
 }
 
 .toolbar--mobile--top .action-menu--list {

--- a/src/components/Toolbar/css/Popup.css
+++ b/src/components/Toolbar/css/Popup.css
@@ -7,7 +7,7 @@
 }
 
 .popup-menu--content tr:nth-child(even) {
-  background-color: #ffffff;
+  background-color: #fff;
 }
 
 .popup-menu table > th > td {
@@ -41,7 +41,7 @@
 }
 
 .popup-menu--content li:last-child {
-  padding-bottom: 0px;
+  padding-bottom: 0;
 }
 
 .active .popup-menu--content {

--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -1,6 +1,6 @@
 code {
   font-family: monospace;
-  background-color: rgb(223, 223, 223);
+  background-color: rgb(223 223 223);
 }
 
 .toolbar {
@@ -10,7 +10,6 @@ code {
   border-top: 1px solid #e2e2e2;
   border-left: 1px solid #e2e2e2;
   border-bottom: 1px solid #e2e2e2;
-
   display: flex;
   flex-direction: row;
   justify-content: space-around;
@@ -21,7 +20,7 @@ code {
 
 .toolbar button {
   color: var(--main-gray-1);
-  padding: 7px 10px 7px 10px;
+  padding: 7px 10px;
   border-radius: 5px;
   background-color: white;
   border: none;
@@ -105,13 +104,14 @@ code {
 .toolbar--mobile .toolbar--autocheck {
   color: var(--main-gray-2);
 }
+
 .toolbar--mobile .toolbar--autocheck.on .fa-check-square {
   color: white !important;
 }
 
 .toolbar--mobile {
   height: 48px;
-  padding: 0 16px 0 16px;
+  padding: 0 16px;
   background-color: var(--main-blue);
   justify-content: space-between;
   font-size: 14pt;
@@ -175,7 +175,7 @@ code {
 }
 
 .toolbar--mobile .toolbar--save-replay {
-  background: rgba(255, 255, 255, 0.2);
+  background: rgb(255 255 255 / 20%);
   color: white;
   font-size: 12px;
   padding: 6px 12px;
@@ -184,7 +184,7 @@ code {
 }
 
 .toolbar--mobile .toolbar--replay-saved {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgb(255 255 255 / 70%);
   font-size: 11px;
 }
 
@@ -219,7 +219,7 @@ code {
 }
 
 .toolbar--mobile .toolbar--mark-solved {
-  background: rgba(76, 175, 80, 0.9);
+  background: rgb(76 175 80 / 90%);
   font-size: 12px;
   padding: 6px 12px;
   height: auto;
@@ -228,7 +228,7 @@ code {
 }
 
 .toolbar--mobile .toolbar--unmark-solved {
-  background: rgba(255, 255, 255, 0.2);
+  background: rgb(255 255 255 / 20%);
   font-size: 12px;
   padding: 6px 12px;
   height: auto;

--- a/src/components/Upload/css/fileUploader.css
+++ b/src/components/Upload/css/fileUploader.css
@@ -3,9 +3,11 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  outline: 3px solid rgba(0, 0, 0, 0);
+  outline: 3px solid rgb(0 0 0 / 0%);
   outline-offset: -5px;
-  transition: outline-color 0.1s ease-in-out, outline-offset 0.1s ease-in-out;
+  transition:
+    outline-color 0.1s ease-in-out,
+    outline-offset 0.1s ease-in-out;
 }
 
 .file-uploader--wrapper {

--- a/src/components/Upload/css/index.css
+++ b/src/components/Upload/css/index.css
@@ -9,12 +9,14 @@
   display: flex;
   flex-direction: row;
   justify-content: space-around;
+
   /* width: 150px; [> TODO: remove this non-flex layout <] */
 }
 
 .upload--main--upload {
   display: flex;
   flex-direction: column;
+
   /* flex-basis: 150px; */
 }
 
@@ -33,11 +35,8 @@
 /* Upload Modal */
 .upload-modal--overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.4);
+  inset: 0;
+  background-color: rgb(0 0 0 / 40%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -51,7 +50,7 @@
   max-width: 480px;
   width: 90%;
   text-align: center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 20px rgb(0 0 0 / 15%);
 }
 
 .upload-modal--icon {

--- a/src/components/common/css/confirmDialog.css
+++ b/src/components/common/css/confirmDialog.css
@@ -3,7 +3,7 @@
 .confirm-dialog--overlay {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgb(0 0 0 / 50%);
   z-index: 1300;
 }
 
@@ -17,8 +17,10 @@
   width: calc(100% - 32px);
   max-width: 420px;
   z-index: 1300;
-  box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14),
-    0px 9px 46px 8px rgba(0, 0, 0, 0.12);
+  box-shadow:
+    0 11px 15px -7px rgb(0 0 0 / 20%),
+    0 24px 38px 3px rgb(0 0 0 / 14%),
+    0 9px 46px 8px rgb(0 0 0 / 12%);
   padding: 20px 24px;
 }
 
@@ -28,7 +30,7 @@
 }
 
 .dark .confirm-dialog--panel code {
-  background-color: rgba(255, 255, 255, 0.15);
+  background-color: rgb(255 255 255 / 15%);
   color: var(--dark-primary-text);
 }
 

--- a/src/components/common/css/editableSpan.css
+++ b/src/components/common/css/editableSpan.css
@@ -1,8 +1,8 @@
 .editable-span:hover {
-  background-color: rgba(255, 255, 255, 0.7);
+  background-color: rgb(255 255 255 / 70%);
 }
 
 .editable-span:focus {
-  background-color: rgba(255, 255, 255, 0.99);
+  background-color: rgb(255 255 255 / 99%);
   outline: none;
 }

--- a/src/components/common/css/footer.css
+++ b/src/components/common/css/footer.css
@@ -27,9 +27,9 @@
 /* Dark mode */
 .dark .footer {
   border-top-color: #444;
-  color: rgba(255, 255, 255, 0.35);
+  color: rgb(255 255 255 / 35%);
 }
 
 .dark .footer a {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }

--- a/src/components/common/css/nav.css
+++ b/src/components/common/css/nav.css
@@ -3,10 +3,10 @@
   min-height: 17px;
   display: flex;
   height: max-content;
-  align-content: center;
-  justify-content: space-between;
+  place-content: center space-between;
   background-color: var(--main-blue);
 }
+
 .nav.mobile {
   padding-top: 10px;
   padding-bottom: 10px;
@@ -34,7 +34,7 @@
 }
 
 .nav.mobile .nav--right {
-  margin-right: 0px;
+  margin-right: 0;
 }
 
 .nav--left a {
@@ -66,7 +66,7 @@
   min-width: 180px;
   background: white;
   border-radius: 6px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 15%);
   z-index: 100;
   padding: 4px 0;
   font-size: 14px;
@@ -113,16 +113,16 @@
 /* Dark mode overrides */
 .dark .nav--user-menu--dropdown {
   background: #2a2a2a;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 40%);
 }
 
 .dark .nav--user-menu--header {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgb(255 255 255 / 60%);
   border-bottom-color: #444;
 }
 
 .dark .nav--user-menu--item {
-  color: rgba(255, 255, 255, 0.87);
+  color: rgb(255 255 255 / 87%);
 }
 
 .dark .nav--user-menu--item:hover {
@@ -134,7 +134,7 @@
 }
 
 /* Mobile responsive */
-@media (max-width: 480px) {
+@media (width <= 480px) {
   .nav {
     padding: 12px 10px;
   }
@@ -176,5 +176,5 @@
   margin-top: 1rem;
   margin-bottom: 1rem;
   border: 0;
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-top: 1px solid rgb(0 0 0 / 10%);
 }

--- a/src/components/common/css/powerups.css
+++ b/src/components/common/css/powerups.css
@@ -9,7 +9,6 @@
   justify-content: center;
   color: #c87e25;
   font-weight: bold;
-
   writing-mode: vertical-lr;
 }
 
@@ -30,7 +29,6 @@
   justify-self: center;
   margin-left: 20px;
   margin-right: 20px;
-
   flex-direction: column;
 }
 
@@ -49,8 +47,8 @@
   width: 20px;
   height: 20px;
   text-align: center;
-  top: 0px;
-  right: 0px;
+  top: 0;
+  right: 0;
   vertical-align: middle;
   color: white;
 }
@@ -72,6 +70,6 @@ span {
   border-radius: 50%;
   padding-bottom: 0.2px;
   padding-right: 0.1px;
-  border: 10px solid #339966 !important;
+  border: 10px solid #396 !important;
   box-sizing: border-box;
 }

--- a/src/components/common/css/primitives.css
+++ b/src/components/common/css/primitives.css
@@ -11,7 +11,7 @@
   display: inline-block;
   width: 40px;
   height: 40px;
-  border: 3px solid rgba(0, 0, 0, 0.1);
+  border: 3px solid rgb(0 0 0 / 10%);
   border-top-color: #1976d2;
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
@@ -24,7 +24,7 @@
 }
 
 .dark .spinner {
-  border-color: rgba(255, 255, 255, 0.1);
+  border-color: rgb(255 255 255 / 10%);
   border-top-color: #6aa9f4;
 }
 
@@ -38,19 +38,19 @@
   font-family: inherit;
   font-weight: 500;
   line-height: 1.75;
-  letter-spacing: 0.02857em;
+  letter-spacing: 0.0286em;
   text-transform: uppercase;
   border: none;
   border-radius: 4px;
   cursor: pointer;
   background: transparent;
-  color: rgba(0, 0, 0, 0.87);
+  color: rgb(0 0 0 / 87%);
   transition: background-color 0.15s;
   min-width: 64px;
 }
 
 .btn:hover {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: rgb(0 0 0 / 4%);
 }
 
 .btn:disabled {
@@ -65,8 +65,8 @@
 
 .btn--contained {
   background-color: #e0e0e0;
-  color: rgba(0, 0, 0, 0.87);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  color: rgb(0 0 0 / 87%);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 12%);
 }
 
 .btn--contained:hover {
@@ -83,17 +83,17 @@
 }
 
 .btn--contained.btn--primary:disabled {
-  background-color: rgba(0, 0, 0, 0.12);
-  color: rgba(0, 0, 0, 0.26);
+  background-color: rgb(0 0 0 / 12%);
+  color: rgb(0 0 0 / 26%);
 }
 
 .btn--outlined {
-  border: 1px solid rgba(0, 0, 0, 0.23);
+  border: 1px solid rgb(0 0 0 / 23%);
   background: transparent;
 }
 
 .btn--outlined:hover {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: rgb(0 0 0 / 4%);
 }
 
 .btn--danger {
@@ -115,7 +115,7 @@
 }
 
 .dark .btn:hover {
-  background-color: rgba(255, 255, 255, 0.08);
+  background-color: rgb(255 255 255 / 8%);
 }
 
 .dark .btn--contained.btn--primary {
@@ -123,12 +123,12 @@
 }
 
 .dark .btn--contained.btn--primary:disabled {
-  background-color: rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.3);
+  background-color: rgb(255 255 255 / 12%);
+  color: rgb(255 255 255 / 30%);
 }
 
 .dark .btn--outlined {
-  border-color: rgba(255, 255, 255, 0.3);
+  border-color: rgb(255 255 255 / 30%);
 }
 
 /* ===== Form fields (replaces MUI TextField) ===== */
@@ -141,7 +141,7 @@
 .form-field label {
   display: block;
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.54);
+  color: rgb(0 0 0 / 54%);
   margin-bottom: 4px;
 }
 
@@ -151,11 +151,11 @@
   font-size: 16px;
   font-family: inherit;
   border: none;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.42);
+  border-bottom: 1px solid rgb(0 0 0 / 42%);
   outline: none;
   background: transparent;
   box-sizing: border-box;
-  color: rgba(0, 0, 0, 0.87);
+  color: rgb(0 0 0 / 87%);
 }
 
 .form-field input:focus {
@@ -165,7 +165,7 @@
 
 .form-field--helper {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.54);
+  color: rgb(0 0 0 / 54%);
   margin-top: 3px;
 }
 
@@ -176,12 +176,12 @@
 
 /* Dark mode form fields */
 .dark .form-field label {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .form-field input {
   color: var(--dark-primary-text);
-  border-bottom-color: rgba(255, 255, 255, 0.3);
+  border-bottom-color: rgb(255 255 255 / 30%);
 }
 
 .dark .form-field input:focus {
@@ -189,7 +189,7 @@
 }
 
 .dark .form-field--helper {
-  color: rgba(255, 255, 255, 0.4);
+  color: rgb(255 255 255 / 40%);
 }
 
 /* ===== Typography utilities (replaces MUI Typography) ===== */
@@ -198,7 +198,7 @@
 }
 
 .text-secondary {
-  color: rgba(0, 0, 0, 0.54);
+  color: rgb(0 0 0 / 54%);
 }
 
 .text-success {
@@ -223,7 +223,7 @@
 }
 
 .dark .text-secondary {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .text-success {
@@ -231,6 +231,7 @@
 }
 
 /* ===== Flex utilities (replaces react-flexview) ===== */
+
 /* min-width/min-height: 0 matches react-flexview default behavior,
    allowing flex children to shrink below content size (enables text-overflow: ellipsis etc.) */
 .flex {

--- a/src/components/css/welcomeVariantsControl.css
+++ b/src/components/css/welcomeVariantsControl.css
@@ -27,7 +27,7 @@
 }
 
 .dark .welcome-variants--option {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .welcome-variants--option.selected {

--- a/src/dark.css
+++ b/src/dark.css
@@ -83,11 +83,12 @@
 }
 
 .dark .cell--shade {
-  background-color: rgba(255, 255, 255, 0.25);
+  background-color: rgb(255 255 255 / 25%);
 }
 
 .dark .clues--list--scroll {
   background-color: var(--dark-background-1);
+  border-top-color: #555;
 }
 
 .dark .clues--list--scroll--clue.selected {
@@ -104,15 +105,11 @@
 }
 
 .dark .chat--system-message {
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.dark .clues--list--scroll {
-  border-top-color: #555;
+  color: rgb(255 255 255 / 60%);
 }
 
 .dark .clues--list--scroll--clue.complete {
-  color: rgba(255, 255, 255, 0.47);
+  color: rgb(255 255 255 / 47%);
 }
 
 .dark .list-view--list--title {
@@ -124,7 +121,7 @@
 }
 
 .dark .toolbar button {
-  background-color: rgba(0, 0, 0, 0);
+  background-color: rgb(0 0 0 / 0%);
   color: var(--dark-primary-text);
 }
 
@@ -156,7 +153,7 @@
 }
 
 .dark .cell.selected .cell--wrapper {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgb(0 0 0 / 10%);
 }
 
 .dark .cell.good .cell--value {
@@ -164,11 +161,11 @@
 }
 
 .dark .cell.bad .cell--value {
-  color: rgb(244, 67, 54);
+  color: rgb(244 67 54);
 }
 
 .dark .cell.revealed .cell--value {
-  color: rgb(102, 187, 106);
+  color: rgb(102 187 106);
 }
 
 .dark input {
@@ -181,6 +178,7 @@
 
 .dark ::selection {
   background-color: #555;
+
   /* WebKit/Blink Browsers */
 }
 
@@ -210,19 +208,16 @@
 
 .dark .entry {
   color: var(--dark-primary-text);
+  background-color: var(--dark-background-1);
+  border-color: rgb(255 255 255 / 30%);
 }
 
 .dark .file-uploader--wrapper.v2 {
-  background-color: rgba(0, 0, 0, 0);
+  background-color: rgb(0 0 0 / 0%);
 }
 
 .dark .filters .checkmark {
   background-color: transparent !important;
-}
-
-.dark .entry {
-  background-color: var(--dark-background-1);
-  border-color: rgba(255, 255, 255, 0.3);
 }
 
 .dark .mobile-sidebar {
@@ -243,7 +238,7 @@
 }
 
 .dark .filter-quick-toggle {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .filter-quick-toggle--link {
@@ -271,7 +266,7 @@
 }
 
 .dark .upload-modal--content {
-  color: rgba(255, 255, 255, 0.75);
+  color: rgb(255 255 255 / 75%);
 }
 
 .dark .upload-modal--content a {
@@ -288,16 +283,16 @@
 }
 
 .dark .upload-modal--button-cancel {
-  background-color: rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.75);
+  background-color: rgb(255 255 255 / 12%);
+  color: rgb(255 255 255 / 75%);
 }
 
 .dark .upload-modal--button-cancel:hover {
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: rgb(255 255 255 / 20%);
 }
 
 .dark .upload-modal--checkbox-row label {
-  color: rgba(255, 255, 255, 0.75);
+  color: rgb(255 255 255 / 75%);
 }
 
 .dark .upload-modal--checkbox-row input[type='checkbox'] {
@@ -306,11 +301,11 @@
 
 /* Chat header (puzzle instructions / description) */
 .dark .chat--header--subtitle {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgb(255 255 255 / 60%);
 }
 
 .dark .chat--header--description {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgb(255 255 255 / 70%);
 }
 
 /* Toolbar Popup Menu */
@@ -320,11 +315,11 @@
 }
 
 .dark .popup-menu--content tr:nth-child(even) {
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgb(255 255 255 / 5%);
 }
 
 .dark .popup-menu--content code {
-  background-color: rgba(255, 255, 255, 0.15);
+  background-color: rgb(255 255 255 / 15%);
   color: var(--dark-primary-text);
 }
 
@@ -339,7 +334,7 @@
 
 /* Toolbar Action Menu */
 .dark .action-menu {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .action-menu--button {
@@ -362,11 +357,11 @@
 
 /* Toolbar extras */
 .dark .toolbar code {
-  background-color: rgba(255, 255, 255, 0.12);
+  background-color: rgb(255 255 255 / 12%);
 }
 
 .dark .toolbar button:hover {
-  background-color: rgba(255, 255, 255, 0.12);
+  background-color: rgb(255 255 255 / 12%);
 }
 
 /* Contest puzzle buttons */
@@ -397,8 +392,8 @@
 
 /* File Uploader */
 .dark .file-uploader--wrapper {
-  background-color: rgba(255, 255, 255, 0.05);
-  outline-color: rgba(255, 255, 255, 0.3);
+  background-color: rgb(255 255 255 / 5%);
+  outline-color: rgb(255 255 255 / 30%);
 }
 
 .dark .file-uploader--box {
@@ -407,7 +402,7 @@
 
 /* Powerups */
 .dark .powerups--main {
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgb(255 255 255 / 5%);
 }
 
 .dark .powerups--count {
@@ -420,19 +415,19 @@
 }
 
 .dark input::placeholder {
-  color: rgba(255, 255, 255, 0.3);
+  color: rgb(255 255 255 / 30%);
 }
 
 /* Misc */
 .dark .info--hr {
-  border-top-color: rgba(255, 255, 255, 0.1);
+  border-top-color: rgb(255 255 255 / 10%);
 }
 
 :root {
-  --dark-blue-1: rgb(36, 79, 115);
+  --dark-blue-1: rgb(36 79 115);
   --dark-blue-2: #183a60;
-  --dark-primary-text: rgba(255, 255, 255, 0.87);
+  --dark-primary-text: rgb(255 255 255 / 87%);
   --dark-background: #121212;
-  --dark-background-1: rgba(255, 255, 255, 0.05);
-  --dark-background-2: rgba(255, 255, 255, 0.12);
+  --dark-background-1: rgb(255 255 255 / 5%);
+  --dark-background-2: rgb(255 255 255 / 12%);
 }

--- a/src/pages/css/account.css
+++ b/src/pages/css/account.css
@@ -89,7 +89,7 @@
 }
 
 .dark .account-verify-banner {
-  background-color: rgba(230, 81, 0, 0.15);
+  background-color: rgb(230 81 0 / 15%);
   color: #ffb74d;
 }
 
@@ -98,7 +98,7 @@
 }
 
 .dark .account--main a {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgb(255 255 255 / 70%);
 }
 
 .dark .account--main a:hover {

--- a/src/pages/css/battle.css
+++ b/src/pages/css/battle.css
@@ -33,11 +33,9 @@
   border-radius: 5px;
   padding: 10px;
   border: 1px solid var(--main-blue);
-
   justify-self: center;
   margin-left: 20px;
   margin-right: 20px;
-
   font-weight: bold;
   font-size: 75px;
   color: var(--main-blue);
@@ -60,12 +58,10 @@
 
 .battle--input {
   padding: 10px;
-
   justify-self: center;
   margin-top: 20px;
   margin-left: 20px;
   margin-right: 20px;
-
   font-weight: bold;
   font-size: 30px;
 }
@@ -102,6 +98,6 @@
 }
 
 .dark .battle--button.disabled {
-  color: rgba(255, 255, 255, 0.2);
-  border-color: rgba(255, 255, 255, 0.2);
+  color: rgb(255 255 255 / 20%);
+  border-color: rgb(255 255 255 / 20%);
 }

--- a/src/pages/css/legal.css
+++ b/src/pages/css/legal.css
@@ -65,11 +65,11 @@
 
 .dark .legal--content p,
 .dark .legal--content li {
-  color: rgba(255, 255, 255, 0.75);
+  color: rgb(255 255 255 / 75%);
 }
 
 .dark .legal--effective-date {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .legal--content a {

--- a/src/pages/css/profile.css
+++ b/src/pages/css/profile.css
@@ -140,7 +140,7 @@
   display: none;
 }
 
-@media (max-width: 480px) {
+@media (width <= 480px) {
   .profile--actions {
     white-space: nowrap;
     font-size: 12px;
@@ -216,12 +216,12 @@
 }
 
 .dark .profile--member-since {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .profile--stat-card {
   border-color: #444;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgb(255 255 255 / 5%);
 }
 
 .dark .profile--stat-card--value {
@@ -229,15 +229,15 @@
 }
 
 .dark .profile--stat-card--label {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .profile--stat-card--sub {
-  color: rgba(255, 255, 255, 0.35);
+  color: rgb(255 255 255 / 35%);
 }
 
 .dark .profile--stats-section-title {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .profile--history h3 {
@@ -245,17 +245,17 @@
 }
 
 .dark .profile--history-table th {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
   border-bottom-color: #444;
 }
 
 .dark .profile--history-table td {
   color: var(--dark-primary-text);
-  border-bottom-color: rgba(255, 255, 255, 0.1);
+  border-bottom-color: rgb(255 255 255 / 10%);
 }
 
 .dark .profile--history-table tr:hover td {
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgb(255 255 255 / 5%);
 }
 
 .dark .profile--collab-tag {
@@ -276,7 +276,7 @@
 
 .dark .profile--empty,
 .dark .profile--not-found {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 /* Verification warning banner */
@@ -295,7 +295,7 @@
 }
 
 .dark .profile--verify-banner {
-  background-color: rgba(230, 81, 0, 0.15);
+  background-color: rgb(230 81 0 / 15%);
   color: #ffb74d;
 }
 

--- a/src/pages/css/replay.css
+++ b/src/pages/css/replay.css
@@ -65,6 +65,7 @@
   color: var(--main-gray-1);
   margin-left: 10px;
 }
+
 .scrub--speed--option.selected {
   color: var(--main-blue);
 }
@@ -117,7 +118,7 @@
 }
 
 .dark .replay .header--subtitle {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgb(255 255 255 / 60%);
 }
 
 .dark .replay .scrub.active {
@@ -130,11 +131,11 @@
 }
 
 .dark .replay--control-icons {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .scrub--speed--option {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .scrub--speed--option.selected {
@@ -142,9 +143,9 @@
 }
 
 .dark .replay--unavailable {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }
 
 .dark .replay--save-status {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(255 255 255 / 50%);
 }

--- a/src/pages/css/replays.css
+++ b/src/pages/css/replays.css
@@ -1,5 +1,5 @@
 .replays {
-  font-family: 'avenir next', avenir, 'Nunito', 'helvetica neue', 'Helvetica', 'arial', sans-serif;
+  font-family: 'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, sans-serif;
   height: 100%;
   width: 100%;
   min-width: min-content;
@@ -28,7 +28,7 @@
 }
 
 .replays .limit--container {
-  margin: 35px 0 0 0;
+  margin: 35px 0 0;
 }
 
 .replays .limit--text {
@@ -36,10 +36,10 @@
 }
 
 .replays .limit--button {
-  margin: 0 5px 0 5px;
+  margin: 0 5px;
   text-align: left;
   border-radius: 3px;
-  padding: 8px 15px 8px 15px;
+  padding: 8px 15px;
   border-top: 1px solid var(--main-gray-2);
   border-left: 1px solid var(--main-gray-2);
   border-bottom: 1px solid var(--main-gray-2);
@@ -50,7 +50,7 @@
 .replays .limit--button:hover {
   transition: all ease-in 0.2s;
   color: #111;
-  background-color: #dddddd;
+  background-color: #ddd;
 }
 
 .replays .scrub.active {
@@ -87,7 +87,7 @@
 
 .replays .main-table td {
   border-bottom: 1px solid #e2e2e2;
-  padding: 12px 0 12px 0;
+  padding: 12px 0;
 }
 
 .replays .main-table td a {
@@ -104,7 +104,7 @@
 }
 
 .dark .replays .header--subtitle {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgb(255 255 255 / 60%);
 }
 
 .dark .replays .scrub.active {
@@ -122,7 +122,7 @@
 }
 
 .dark .replays .main-table tr:hover {
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgb(255 255 255 / 5%);
 }
 
 .dark .replays .main-table td {

--- a/src/pages/css/room.css
+++ b/src/pages/css/room.css
@@ -16,7 +16,7 @@
 }
 
 .room--total-users-paren {
-  color: #dddddd;
+  color: #ddd;
 }
 
 .room--footer {

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -1,5 +1,5 @@
 .welcome {
-  background-color: #ffffff;
+  background-color: #fff;
   color: var(--main-gray-1);
 }
 
@@ -40,10 +40,7 @@
 
 .welcome--searchbar {
   font-size: 16px;
-  padding-right: 5px;
-  padding-left: 40px;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding: 10px 5px 10px 40px;
   width: 100%;
   border-radius: 3px;
   border: 1px solid silver;
@@ -89,7 +86,7 @@
 
 .filter-quick-toggle {
   font-size: 11px;
-  margin: 4px 0 2px 0;
+  margin: 4px 0 2px;
   color: #666;
 }
 
@@ -133,7 +130,7 @@
 .entry--top--left {
   font-size: 15px;
   font-weight: 400;
-  color: rgba(0, 0, 0, 0.7);
+  color: rgb(0 0 0 / 70%);
   justify-content: space-between;
 }
 
@@ -184,6 +181,7 @@
   width: 2px; /* remove scrollbar space */
   background: transparent; /* optional: just make scrollbar invisible */
 }
+
 /* optional: show position indicator in red */
 ::-webkit-scrollbar-thumb {
   background: var(--main-gray-3);
@@ -220,14 +218,13 @@ p {
 
 .mobile-sidebar-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  inset: 0;
+  background-color: rgb(0 0 0 / 50%);
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.3s, visibility 0.3s;
+  transition:
+    opacity 0.3s,
+    visibility 0.3s;
   z-index: 200;
 }
 
@@ -243,11 +240,11 @@ p {
   bottom: 0;
   width: 280px;
   max-width: 80vw;
-  background-color: #ffffff;
+  background-color: #fff;
   transform: translateX(-100%);
   transition: transform 0.3s ease-in-out;
   z-index: 300;
-  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 2px 0 8px rgb(0 0 0 / 20%);
 }
 
 .mobile-sidebar.open {

--- a/src/style.css
+++ b/src/style.css
@@ -13,15 +13,15 @@ input,
   flex: 1;
   min-height: 0;
   margin: 0;
-  font-family: 'avenir next', avenir, 'Nunito', 'helvetica neue', 'Helvetica', 'arial', sans-serif;
+  font-family: 'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, sans-serif;
 }
 
 button {
   margin: 0;
-  font-family: 'avenir next', avenir, 'Nunito', 'helvetica neue', 'Helvetica', 'arial', sans-serif;
+  font-family: 'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, sans-serif;
 }
 
-@media only screen and (max-width: 768px) {
+@media only screen and (width <= 768px) {
   body,
   html {
     overflow: hidden;
@@ -37,17 +37,17 @@ button {
   --main-gray-2: #ccc;
   --main-gray-3: #f0f0f0;
   --main-blue: #6aa9f4;
-  --main-blue-2: rgba(110, 198, 255, 1);
+  --main-blue-2: rgb(110 198 255 / 100%);
   --main-blue-3: #dcefff;
-  --main-green-1: rgba(31, 255, 61, 0.3);
-  --main-green-2: rgba(31, 255, 61, 1);
-  --pencil-color: #888888; /* must be 3 or 6 digit hex */
+  --main-green-1: rgb(31 255 61 / 30%);
+  --main-green-2: rgb(31 255 61 / 100%);
+  --pencil-color: #888; /* must be 3 or 6 digit hex */
 }
 
-#unlistedRow {
+#unlisted-row {
   margin-top: 10px;
 }
 
-#unlistedRow input {
+#unlisted-row input {
   display: inline-block;
 }

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,0 +1,9 @@
+export default {
+  extends: ['stylelint-config-standard'],
+  rules: {
+    // Project uses BEM with double-dash: .chat--header--title
+    'selector-class-pattern': null,
+    // Selectors are intentionally ordered by logical grouping, not specificity
+    'no-descending-specificity': null,
+  },
+};


### PR DESCRIPTION
## Summary
- Adds Stylelint with `stylelint-config-standard` for CSS linting
- Fixes all existing CSS violations across 30+ files (duplicate selectors/properties, modern color notation, redundant shorthands, etc.)
- Integrates into pre-commit hook (lint-staged) and GitHub Actions CI
- `selector-class-pattern` and `no-descending-specificity` disabled to match project conventions (BEM with `--` and logical selector ordering)

Closes #284

## Test plan
- [ ] Load a puzzle in light and dark mode — verify grid, clues, chat, toolbar look normal
- [ ] CI passes all checks including new Stylelint job
- [ ] Stage a CSS file with a violation, verify pre-commit hook catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)