### PR TITLE
Improve player cursor color selection algorithm

### DIFF
--- a/src/components/Chat/ColorPicker.tsx
+++ b/src/components/Chat/ColorPicker.tsx
@@ -1,26 +1,6 @@
 import React, {useCallback} from 'react';
 import {useToggle} from 'react-use';
-
-const SWATCH_COLORS = [
-  'hsl(4,90%,58%)',
-  'hsl(340,82%,52%)',
-  'hsl(291,47%,51%)',
-  'hsl(262,52%,47%)',
-  'hsl(231,48%,48%)',
-  'hsl(207,90%,54%)',
-  'hsl(199,98%,48%)',
-  'hsl(187,100%,42%)',
-  'hsl(174,100%,29%)',
-  'hsl(122,39%,49%)',
-  'hsl(88,50%,53%)',
-  'hsl(66,70%,54%)',
-  'hsl(54,100%,62%)',
-  'hsl(45,100%,51%)',
-  'hsl(36,100%,50%)',
-  'hsl(14,100%,57%)',
-  'hsl(16,25%,38%)',
-  'hsl(200,18%,46%)',
-];
+import {PALETTE_COLORS} from '../../lib/colorAssignment';
 
 interface ColorPickerProps {
   color: string;
@@ -64,7 +44,7 @@ const ColorPicker: React.FC<ColorPickerProps> = (props) => {
       {isActive ? (
         <>
           <div style={{display: 'flex', flexWrap: 'wrap', gap: 6, padding: '8px 0'}}>
-            {SWATCH_COLORS.map((c) => (
+            {PALETTE_COLORS.map((c) => (
               <button
                 key={c}
                 type="button"

--- a/src/lib/__tests__/colorAssignment.test.ts
+++ b/src/lib/__tests__/colorAssignment.test.ts
@@ -1,0 +1,61 @@
+import {PALETTE_COLORS, pickDistinctColor} from '../colorAssignment';
+
+describe('PALETTE_COLORS', () => {
+  it('contains 18 colors', () => {
+    expect(PALETTE_COLORS).toHaveLength(18);
+  });
+
+  it('all colors are valid hsl strings', () => {
+    for (const color of PALETTE_COLORS) {
+      expect(color).toMatch(/^hsl\(\d+,\d+%,\d+%\)$/);
+    }
+  });
+});
+
+describe('pickDistinctColor', () => {
+  it('returns a palette color when no existing colors', () => {
+    const color = pickDistinctColor([]);
+    expect(PALETTE_COLORS).toContain(color);
+  });
+
+  it('returns a palette color when one color exists', () => {
+    const color = pickDistinctColor(['hsl(4,90%,58%)']);
+    expect(PALETTE_COLORS).toContain(color);
+  });
+
+  it('avoids colors near existing hue', () => {
+    // Red is hue 4 — should pick something far away
+    const color = pickDistinctColor(['hsl(4,90%,58%)']);
+    const hue = parseInt(color.match(/^hsl\((\d+)/)?.[1] || '0', 10);
+    const dist = Math.abs(hue - 4) % 360;
+    const angularDist = dist > 180 ? 360 - dist : dist;
+    expect(angularDist).toBeGreaterThan(60);
+  });
+
+  it('picks maximally distinct from multiple existing colors', () => {
+    const color = pickDistinctColor(['hsl(4,90%,58%)', 'hsl(207,90%,54%)']);
+    expect(PALETTE_COLORS).toContain(color);
+    expect(color).not.toBe('hsl(4,90%,58%)');
+    expect(color).not.toBe('hsl(207,90%,54%)');
+  });
+
+  it('handles non-hsl strings gracefully', () => {
+    const color = pickDistinctColor(['#ff0000', 'rgb(0,0,255)']);
+    expect(PALETTE_COLORS).toContain(color);
+  });
+
+  it('handles all palette colors being taken', () => {
+    const color = pickDistinctColor([...PALETTE_COLORS]);
+    expect(PALETTE_COLORS).toContain(color);
+  });
+
+  it('handles legacy rand_color format', () => {
+    // Old rand_color() produced hsl(h,40%,60-80%)
+    const color = pickDistinctColor(['hsl(147,40%,73%)']);
+    expect(PALETTE_COLORS).toContain(color);
+    const hue = parseInt(color.match(/^hsl\((\d+)/)?.[1] || '0', 10);
+    const dist = Math.abs(hue - 147) % 360;
+    const angularDist = dist > 180 ? 360 - dist : dist;
+    expect(angularDist).toBeGreaterThan(30);
+  });
+});

--- a/src/lib/colorAssignment.ts
+++ b/src/lib/colorAssignment.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared color palette and distinct color selection for player cursors.
+ *
+ * Curated palette of 18 visually distinct HSL colors, used by both
+ * auto-assignment (when joining a game) and the manual ColorPicker swatch.
+ */
+
+export const PALETTE_COLORS: readonly string[] = [
+  'hsl(4,90%,58%)',
+  'hsl(340,82%,52%)',
+  'hsl(291,47%,51%)',
+  'hsl(262,52%,47%)',
+  'hsl(231,48%,48%)',
+  'hsl(207,90%,54%)',
+  'hsl(199,98%,48%)',
+  'hsl(187,100%,42%)',
+  'hsl(174,100%,29%)',
+  'hsl(122,39%,49%)',
+  'hsl(88,50%,53%)',
+  'hsl(66,70%,54%)',
+  'hsl(54,100%,62%)',
+  'hsl(45,100%,51%)',
+  'hsl(36,100%,50%)',
+  'hsl(14,100%,57%)',
+  'hsl(16,25%,38%)',
+  'hsl(200,18%,46%)',
+];
+
+function parseHue(hslString: string): number | null {
+  const match = hslString.match(/^hsla?\((\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function hueDistance(h1: number, h2: number): number {
+  const diff = Math.abs(h1 - h2) % 360;
+  return diff > 180 ? 360 - diff : diff;
+}
+
+/**
+ * Pick the palette color most visually distinct from all existing colors.
+ *
+ * For each palette color, computes its minimum angular hue distance to any
+ * existing color, then returns the one with the largest minimum distance.
+ * Falls back to a random palette color if no existing colors are parseable.
+ */
+export function pickDistinctColor(existingColors: string[]): string {
+  const existingHues = existingColors.map(parseHue).filter((h): h is number => h !== null);
+
+  if (existingHues.length === 0) {
+    return PALETTE_COLORS[Math.floor(Math.random() * PALETTE_COLORS.length)];
+  }
+
+  let bestColor = PALETTE_COLORS[0];
+  let bestMinDistance = -1;
+
+  for (const candidate of PALETTE_COLORS) {
+    const candidateHue = parseHue(candidate);
+    if (candidateHue === null) continue;
+
+    const minDist = Math.min(...existingHues.map((h) => hueDistance(candidateHue, h)));
+
+    if (minDist > bestMinDistance) {
+      bestMinDistance = minDist;
+      bestColor = candidate;
+    }
+  }
+
+  return bestColor;
+}

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -11,7 +11,8 @@ import GameComponent from '../components/Game';
 import MobilePanel from '../components/common/MobilePanel';
 import Chat from '../components/Chat';
 import Powerups from '../components/common/Powerups';
-import {isMobile, rand_color} from '../lib/jsUtils';
+import {isMobile} from '../lib/jsUtils';
+import {pickDistinctColor} from '../lib/colorAssignment';
 
 import * as powerupLib from '../lib/powerups';
 import {recordSolve} from '../api/puzzle.ts';
@@ -279,10 +280,20 @@ class Game extends Component {
     return `user_color`;
   }
 
-  //TODO (jackz): this is how color is persisted
   get userColor() {
-    const color =
-      this.game.users[this.props.id]?.color || localStorage.getItem(this.userColorKey) || rand_color();
+    const existingColor = this.game.users[this.props.id]?.color || localStorage.getItem(this.userColorKey);
+
+    if (existingColor) {
+      localStorage.setItem(this.userColorKey, existingColor);
+      return existingColor;
+    }
+
+    const otherColors = Object.entries(this.game.users)
+      .filter(([uid]) => uid !== this.props.id)
+      .map(([, user]) => user?.color)
+      .filter(Boolean);
+
+    const color = pickDistinctColor(otherColors);
     localStorage.setItem(this.userColorKey, color);
     return color;
   }

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import firebase, {db, getTime} from './firebase';
 import getLocalId from '../localAuth';
-import {rand_color} from '../lib/jsUtils';
+import {pickDistinctColor} from '../lib/colorAssignment';
 
 const disableFbLogin = true;
 
@@ -10,7 +10,7 @@ export default class User extends EventEmitter {
     super();
     this.auth = firebase.auth();
     this.attached = false;
-    this.color = rand_color();
+    this.color = pickDistinctColor([]);
   }
 
   attach() {


### PR DESCRIPTION
## Summary
- Replaces random `rand_color()` with `pickDistinctColor()` that selects from a curated 18-color palette based on maximum hue distance from existing players' colors
- Consolidates the color palette into a shared `colorAssignment.ts` module, reused by both auto-assignment and the manual `ColorPicker` swatch
- Gracefully handles legacy HSL colors, non-HSL strings, and edge cases (all colors taken, no other players)

Closes #282

## Test plan
- [x] Unit tests for `pickDistinctColor()` — palette validity, hue distance avoidance, edge cases (9 tests passing)
- [x] Join a game in multiple tabs — verify each player gets a visually distinct cursor color
- [x] Verify manual ColorPicker swatch still works and shows the same palette
- [x] Verify color attribution mode displays correctly
- [x] Existing games with legacy `rand_color()` colors render without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)