### PR TITLE
Retain home page filters when navigating back via nav link

### DIFF
--- a/src/components/common/Nav.js
+++ b/src/components/common/Nav.js
@@ -204,7 +204,8 @@ export default function Nav({hidden, mobile, linkStyle, divRef}) {
   const cleanHome = fencing ? '/fencing' : '/';
   const isHome = window.location.pathname === cleanHome;
   // On the home page, link resets filters. Everywhere else, return to last filter state.
-  const homePath = isHome ? cleanHome : sessionStorage.getItem('cwf:homeUrl') || cleanHome;
+  const storageKey = fencing ? 'cwf:homeUrl:fencing' : 'cwf:homeUrl';
+  const homePath = isHome ? cleanHome : sessionStorage.getItem(storageKey) || cleanHome;
   return (
     <div className={classnames('nav', {mobile})} ref={divRef}>
       <div className="nav--left" style={linkStyle}>

--- a/src/pages/WrappedWelcome.tsx
+++ b/src/pages/WrappedWelcome.tsx
@@ -135,8 +135,10 @@ const WrappedWelcome = (props: UseFencing) => {
 
   // Persist the home page URL (with filter query params) so the nav link
   // can return users to their last filter state instead of bare "/"
+  // Keyed by variant so normal and fencing modes don't cross-contaminate.
+  const storageKey = props.fencing ? 'cwf:homeUrl:fencing' : 'cwf:homeUrl';
   useEffect(() => {
-    sessionStorage.setItem('cwf:homeUrl', window.location.pathname + window.location.search);
+    sessionStorage.setItem(storageKey, window.location.pathname + window.location.search);
   });
 
   const welcomeProps = {


### PR DESCRIPTION
## Summary
- Saves the home page URL (with filter query params) to `sessionStorage` so clicking "Cross with Friends" from game pages returns to the user's last filter state instead of bare `/`
- On the home page itself, the nav link resets to a clean `/` (clears filters)

Closes #206

## Test plan
- [ ] Set filters on home page, click into a game, click "Cross with Friends" → returns to home with filters intact
- [ ] On the home page with filters active, click "Cross with Friends" → filters reset
- [ ] Open a game directly (no prior home page visit) → nav link falls back to `/`
- [ ] Fencing mode: same behavior with `/fencing` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)