### PR TITLE
Split monolithic JS bundle into vendor chunks and lazy-loaded routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# MCP config (contains auth tokens)
+.mcp.json
+
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # Lock files (project uses pnpm)

--- a/src/index.js
+++ b/src/index.js
@@ -25,24 +25,23 @@ import {HelmetProvider} from 'react-helmet-async';
 import useMediaQuery from './lib/hooks/useMediaQuery';
 import {BrowserRouter as Router, Route, Routes, Navigate, useLocation} from 'react-router-dom';
 import {isMobile} from './lib/jsUtils';
-import {
-  Account,
-  Battle,
-  Game,
-  Play,
-  Privacy,
-  Profile,
-  Replay,
-  Replays,
-  Room,
-  Fencing,
-  Terms,
-  WrappedWelcome,
-  VerifyEmail,
-  ForgotPassword,
-  ResetPassword,
-  Help,
-} from './pages';
+// Eager-loaded pages (critical path)
+import {Game, Room, WrappedWelcome} from './pages';
+
+// Lazy-loaded pages (loaded on demand when route is visited)
+const Account = React.lazy(() => import('./pages/Account'));
+const Battle = React.lazy(() => import('./pages/Battle'));
+const Fencing = React.lazy(() => import('./pages/Fencing'));
+const ForgotPassword = React.lazy(() => import('./pages/ForgotPassword'));
+const Help = React.lazy(() => import('./pages/Help'));
+const Play = React.lazy(() => import('./pages/Play'));
+const Privacy = React.lazy(() => import('./pages/Privacy'));
+const Profile = React.lazy(() => import('./pages/Profile'));
+const Replay = React.lazy(() => import('./pages/Replay'));
+const Replays = React.lazy(() => import('./pages/Replays'));
+const ResetPassword = React.lazy(() => import('./pages/ResetPassword'));
+const Terms = React.lazy(() => import('./pages/Terms'));
+const VerifyEmail = React.lazy(() => import('./pages/VerifyEmail'));
 import GlobalContext from './lib/GlobalContext';
 import AuthContext, {AuthProvider} from './lib/AuthContext';
 import GoogleCallback from './components/Auth/GoogleCallback';
@@ -118,36 +117,38 @@ const Root = () => {
           <GlobalContext value={{toggleMolesterMoons, darkModePreference}}>
             <div className={classnames('router-wrapper', {mobile: isMobile(), dark: darkMode})}>
               <VerificationGate>
-                <Routes>
-                  <Route path="/auth/google/callback" element={<GoogleCallback />} />
-                  <Route path="/verify-email" element={<VerifyEmail />} />
-                  <Route path="/forgot-password" element={<ForgotPassword />} />
-                  <Route path="/reset-password" element={<ResetPassword />} />
-                  <Route path="/" element={<WrappedWelcome />} />
-                  <Route path="/fencing" element={<WrappedWelcome fencing />} />
-                  {/* <Route path="/stats" element={<Stats />} /> */}
-                  <Route path="/game/:gid" element={<Game />} />
-                  <Route path="/embed/game/:gid" element={<Game />} />
-                  <Route path="/room/:rid" element={<Room />} />
-                  <Route path="/embed/room/:rid" element={<Room />} />
-                  <Route path="/replay/:gid" element={<Replay />} />
-                  <Route path="/beta/replay/:gid" element={<Replay />} />
-                  <Route path="/replays/:pid" element={<Replays />} />
-                  <Route path="/replays" element={<Replays />} />
-                  <Route path="/beta" element={<WrappedWelcome />} />
-                  <Route path="/beta/game/:gid" element={<Game />} />
-                  <Route path="/beta/battle/:bid" element={<Battle />} />
-                  <Route path="/beta/play/:pid" element={<Play />} />
-                  <Route path="/privacy" element={<Privacy />} />
-                  <Route path="/terms" element={<Terms />} />
-                  <Route path="/help" element={<Help />} />
-                  <Route path="/account" element={<Account />} />
-                  <Route path="/profile" element={<Profile />} />
-                  <Route path="/profile/:userId" element={<Profile />} />
-                  <Route path="/fencing/:gid" element={<Fencing />} />
-                  <Route path="/beta/fencing/:gid" element={<Fencing />} />
-                  <Route path="/discord" element={<DiscordRedirect />} />
-                </Routes>
+                <React.Suspense fallback={null}>
+                  <Routes>
+                    <Route path="/auth/google/callback" element={<GoogleCallback />} />
+                    <Route path="/verify-email" element={<VerifyEmail />} />
+                    <Route path="/forgot-password" element={<ForgotPassword />} />
+                    <Route path="/reset-password" element={<ResetPassword />} />
+                    <Route path="/" element={<WrappedWelcome />} />
+                    <Route path="/fencing" element={<WrappedWelcome fencing />} />
+                    {/* <Route path="/stats" element={<Stats />} /> */}
+                    <Route path="/game/:gid" element={<Game />} />
+                    <Route path="/embed/game/:gid" element={<Game />} />
+                    <Route path="/room/:rid" element={<Room />} />
+                    <Route path="/embed/room/:rid" element={<Room />} />
+                    <Route path="/replay/:gid" element={<Replay />} />
+                    <Route path="/beta/replay/:gid" element={<Replay />} />
+                    <Route path="/replays/:pid" element={<Replays />} />
+                    <Route path="/replays" element={<Replays />} />
+                    <Route path="/beta" element={<WrappedWelcome />} />
+                    <Route path="/beta/game/:gid" element={<Game />} />
+                    <Route path="/beta/battle/:bid" element={<Battle />} />
+                    <Route path="/beta/play/:pid" element={<Play />} />
+                    <Route path="/privacy" element={<Privacy />} />
+                    <Route path="/terms" element={<Terms />} />
+                    <Route path="/help" element={<Help />} />
+                    <Route path="/account" element={<Account />} />
+                    <Route path="/profile" element={<Profile />} />
+                    <Route path="/profile/:userId" element={<Profile />} />
+                    <Route path="/fencing/:gid" element={<Fencing />} />
+                    <Route path="/beta/fencing/:gid" element={<Fencing />} />
+                    <Route path="/discord" element={<DiscordRedirect />} />
+                  </Routes>
+                </React.Suspense>
               </VerificationGate>
             </div>
           </GlobalContext>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,39 +1,5 @@
-import Welcome from './Welcome';
-import Account from './Account';
-import Replay from './Replay';
-import Replays from './Replays';
 import Game from './Game';
-import Battle from './Battle';
-import Play from './Play';
-import Stats from './Stats';
 import Room from './Room';
-import Fencing from './Fencing';
 import WrappedWelcome from './WrappedWelcome';
-import Profile from './Profile';
-import Privacy from './Privacy';
-import Terms from './Terms';
-import VerifyEmail from './VerifyEmail';
-import ForgotPassword from './ForgotPassword';
-import ResetPassword from './ResetPassword';
-import Help from './Help';
 
-export {
-  Welcome,
-  Account,
-  Replays,
-  Game,
-  Play,
-  Replay,
-  Battle,
-  Stats,
-  Room,
-  Fencing,
-  WrappedWelcome,
-  Profile,
-  Privacy,
-  Terms,
-  VerifyEmail,
-  ForgotPassword,
-  ResetPassword,
-  Help,
-};
+export {Game, Room, WrappedWelcome};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -82,6 +82,30 @@ export default defineConfig({
   build: {
     outDir: 'build',
     sourcemap: 'hidden',
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined;
+          if (id.includes('node_modules/firebase/') || id.includes('node_modules/@firebase/'))
+            return 'vendor-firebase';
+          if (id.includes('/lodash/')) return 'vendor-lodash';
+          if (
+            id.includes('/react-dom/') ||
+            id.includes('/react/') ||
+            id.includes('/react-router-dom/') ||
+            id.includes('/react-router/') ||
+            id.includes('/react-helmet-async/') ||
+            id.includes('/classnames/')
+          ) {
+            return 'vendor-react';
+          }
+          if (id.includes('/@sentry/')) return 'vendor-sentry';
+          if (id.includes('/socket.io-client/') || id.includes('/engine.io-')) return 'vendor-socketio';
+          if (id.includes('/@radix-ui/')) return 'vendor-radix';
+          return 'vendor-misc';
+        },
+      },
+    },
   },
   define: {
     // Bridge: partyParrot.js has 108 occurrences of process.env.PUBLIC_URL


### PR DESCRIPTION
## Summary
- Split single 1,763 KB render-blocking JS bundle into cacheable vendor chunks via Rollup `manualChunks`
- Lazy-load 13 non-critical page routes via `React.lazy()` + `Suspense`
- Initial critical-path app code reduced to ~274 KB

Fixes JAVASCRIPT-REACT-5

## Test plan
- [x] `pnpm build` produces multiple named vendor chunks
- [x] `pnpm test` — 370 tests pass
- [x] ESLint, TypeScript, Prettier all clean
- [x] Manual testing: homepage, game page, lazy routes (privacy, help, account), back/forward nav, hard refresh on lazy routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)