### PR TITLE
Remove vendor-misc catch-all to fix production white screen

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,7 +103,7 @@ export default defineConfig({
           if (id.includes('/@sentry/')) return 'vendor-sentry';
           if (id.includes('/socket.io-client/') || id.includes('/engine.io-')) return 'vendor-socketio';
           if (id.includes('/@radix-ui/')) return 'vendor-radix';
-          return 'vendor-misc';
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
## Summary
- PR #305 only merged the `scheduler` fix but missed the critical second commit
- The catch-all `return 'vendor-misc'` forces all remaining `node_modules` into one chunk, creating circular dependencies with the named chunks (vendor-react, etc.)
- This causes a TDZ error (`Cannot access '_o' before initialization`) and white screen in production
- Fix: return `undefined` instead, letting Rollup handle remaining modules naturally

## Test plan
- [ ] Deploy to testing and verify no white screen / no console errors
- [ ] Run `BASE_URL=https://testing.crosswithfriends.com pnpm test:e2e:chromium`

🤖 Generated with [Claude Code](https://claude.com/claude-code)