### PR TITLE
Skip Check/Reveal e2e tests in contest mode

### DIFF
--- a/e2e/fixtures/game.ts
+++ b/e2e/fixtures/game.ts
@@ -3,6 +3,8 @@ import {test as base, expect, Page, Locator} from '@playwright/test';
 export interface GameHelpers {
   page: Page;
   consoleErrors: string[];
+  /** True when the puzzle is a contest (Check/Reveal buttons are hidden) */
+  isContest: boolean;
   /** Click a cell by row and column (space-separated in data-rc attr) */
   clickCell: (r: number, c: number) => Promise<void>;
   /** Get the text content of the .cell--value inside a cell */
@@ -103,6 +105,9 @@ export const test = base.extend<{gamePage: GameHelpers}>({
       await page.locator(`.active.action-menu .action-menu--list--action[data-action-key="${key}"]`).click();
     };
 
+    // Detect contest mode — contest puzzles show "Mark as Solved" instead of Check/Reveal
+    const isContest = (await page.locator('.toolbar--mark-solved').count()) > 0;
+
     // Click the first white cell to activate the grid input
     const firstWhite = await findFirstWhiteCell();
     await clickCell(firstWhite.r, firstWhite.c);
@@ -110,6 +115,7 @@ export const test = base.extend<{gamePage: GameHelpers}>({
     await use({
       page,
       consoleErrors,
+      isContest,
       clickCell,
       getCellValue,
       cellHasClass,

--- a/e2e/tests/toolbar-actions.spec.ts
+++ b/e2e/tests/toolbar-actions.spec.ts
@@ -10,8 +10,11 @@ test.describe('Toolbar actions', () => {
       cellHasClass,
       findFirstWhiteCell,
       consoleErrors,
+      isContest,
       page,
     } = gamePage;
+
+    test.skip(isContest, 'Check is hidden in contest mode');
 
     const {r, c} = await findFirstWhiteCell();
     await clickCell(r, c);
@@ -47,8 +50,11 @@ test.describe('Toolbar actions', () => {
       clickAction,
       findFirstWhiteCell,
       consoleErrors,
+      isContest,
       page,
     } = gamePage;
+
+    test.skip(isContest, 'Reveal is hidden in contest mode');
 
     const {r, c} = await findFirstWhiteCell();
     await clickCell(r, c);
@@ -152,8 +158,11 @@ test.describe('Toolbar actions', () => {
       clickAction,
       findFirstWhiteCell,
       consoleErrors,
+      isContest,
       page,
     } = gamePage;
+
+    test.skip(isContest, 'Check is hidden in contest mode');
 
     const {r, c} = await findFirstWhiteCell();
     await clickCell(r, c);


### PR DESCRIPTION
## Summary
- Contest puzzles hide Check and Reveal toolbar buttons, causing 3 e2e tests to time out when the daily puzzle is a contest
- Added `isContest` detection to the game fixture (checks for `.toolbar--mark-solved` button)
- Tests for Check Square, Reveal Square, and Check Word now skip gracefully in contest mode

## Test plan
- [x] `pnpm test:e2e:chromium` — 35 passed locally (non-contest daily)
- [ ] Verify tests skip correctly when run against a contest puzzle on testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)