### PR TITLE
Add Docker image publishing to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/scaleovenstove/crosswithfriends
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VITE_SELF_HOSTED=true

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,0 +1,65 @@
+# Standalone compose file using pre-built images from GHCR.
+# No need to clone the repo — just download this file and run:
+#
+#   docker compose -f docker-compose.ghcr.yml up
+
+services:
+  # Ephemeral service that copies DB init files from the app image
+  # to shared volumes so postgres can use them on first start.
+  init-db:
+    image: ghcr.io/scaleovenstove/crosswithfriends:latest
+    volumes:
+      - db-sql:/target/sql
+      - db-init:/target/initdb
+    entrypoint:
+      [
+        'sh',
+        '-c',
+        'cp -r /app/server/sql/* /target/sql/ && cp /app/docker/init-db.sh /target/initdb/01-init-db.sh',
+      ]
+    restart: 'no'
+
+  app:
+    image: ghcr.io/scaleovenstove/crosswithfriends:latest
+    ports:
+      - '3021:3021'
+    environment:
+      - NODE_ENV=production
+      - PORT=3021
+      - SERVE_STATIC=true
+      - PGHOST=db
+      - PGPORT=5432
+      - PGDATABASE=dfac
+      - PGUSER=postgres
+      - PGPASSWORD=postgres
+      - JWT_SECRET=change-me-to-a-random-secret
+      - FRONTEND_URL=http://localhost:3021
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16
+    environment:
+      - POSTGRES_DB=dfac
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - db-sql:/sql
+      - db-init:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d dfac']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      init-db:
+        condition: service_completed_successfully
+
+volumes:
+  pgdata:
+  db-sql:
+  db-init:


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow to build and push Docker images to `ghcr.io/scaleovenstove/crosswithfriends` on pushes to master and `v*` tags
- Adds a standalone `docker-compose.ghcr.yml` so users can run the full stack with just `docker compose -f docker-compose.ghcr.yml up` — no repo clone needed
- Images tagged as `latest` on master, semver on release tags, plus `sha-` for traceability

Closes #208

## Test plan
- [ ] Merge to master and verify the workflow runs successfully
- [ ] Confirm image appears at `ghcr.io/scaleovenstove/crosswithfriends`
- [ ] Set GHCR package visibility to Public if desired
- [ ] Test `docker compose -f docker-compose.ghcr.yml up` on a clean machine
- [ ] Verify DB initializes correctly and app is accessible at `http://localhost:3021`

🤖 Generated with [Claude Code](https://claude.com/claude-code)