### PR TITLE
Fix null reference crash in mobile clue bar touch handler

### DIFF
--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -172,6 +172,7 @@ export default class MobileGridControls extends GridControls {
   }
 
   handleClueBarTouchEnd = (e) => {
+    if (!this.touchingClueBarStart) return;
     const countAsTapBuffer = 4; // px
     const touch = e.changedTouches ? e.changedTouches[0] : e;
     const touchTravelDist = Math.abs(touch.pageY - this.touchingClueBarStart.pageY);


### PR DESCRIPTION
## Summary
- Fixes Sentry [JAVASCRIPT-REACT-G](https://cross-with-friends.sentry.io/issues/JAVASCRIPT-REACT-G) — crash on iOS Mobile Safari when `touchend` fires on the clue bar without a matching `touchstart`
- Adds a null guard to `handleClueBarTouchEnd` to bail out early when `this.touchingClueBarStart` is null, matching the pattern already used in `handleClueBarTouchMove`

## Test plan
- [ ] Play a game on mobile and tap/swipe the clue bar — verify direction toggle still works
- [ ] Confirm no crash when quickly tapping the clue bar area during component transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)