### PR TITLE
Remove utility-types, async, and react-use dependencies

### DIFF
--- a/DEPENDENCY_AUDIT.md
+++ b/DEPENDENCY_AUDIT.md
@@ -1,0 +1,129 @@
+# Dependency Audit — Cross with Friends
+
+**Updated**: 2026-03-02
+
+---
+
+## Previously Completed
+
+- [x] Node.js 20 -> 22
+- [x] Vite 5 -> 7, Vitest 2 -> 4, TypeScript 5.4 -> 5.8 -> 5.9
+- [x] Express 4 -> 5, @types/express -> v5
+- [x] React Router v6 -> v7
+- [x] Removed left-pad, body-parser, querystringify, gaussian, bluebird, classnames, @types/uuid, @types/react-color, @types/ws
+- [x] Moved dev-only packages to devDependencies
+- [x] Bumped clsx v2, lint-staged v16, nodemon v3, uuid v11, @types/pg v8, pg v8.19, and many more semver patches
+- [x] HTML cleanup: removed fullscreen polyfill, XHTML namespace attrs, viewport zoom lock, window.process shim, Google Fonts v1->v2 (PR #338)
+- [x] TypeScript target es2015->es2022 (frontend + server), Docker Postgres 16->18 (PR #339)
+- [x] Removed `utility-types` — inlined `Brand` type in `src/shared/types.ts`
+- [x] Removed `async` — replaced `async.map()` with `Promise.all()` in `src/store/battle.js`
+- [x] Removed `react-use` — wrote custom hooks in `src/hooks/` (useUpdateEffect, usePrevious, useToggle); replaced `useAsync` with plain `useEffect`. Eliminated ~600KB transitive deps (141 packages removed)
+
+---
+
+## Remaining — Ordered Easiest to Hardest
+
+### 3. Small Dependency Removals
+
+| # | Package | Current | Usage | Replacement |
+|---|---|---|---|---|
+| 3c | **`events`** | `^3.3.0` | 4 files in `src/store/` (Battle, User, Game, Puzzle extend `EventEmitter`) | **Not a simple removal** — Vite does NOT auto-polyfill Node built-ins (that's webpack). Options: (a) keep as-is (tiny dep), (b) write a minimal EventEmitter, (c) add `vite-plugin-node-polyfills` |
+
+### 4. Straightforward Major Bumps (drop-in or near-drop-in)
+
+| # | Package | Current | Latest | Notes |
+|---|---|---|---|---|
+| 4a | **`uuid`** | `^11.1.0` | `13.0.0` | 2 majors. API is stable |
+| 4b | **`joi`** | `^17.13.3` | `18.0.2` | 1 major. Check changelog for breaking validation changes |
+| 4c | **`cross-env`** | `^7.0.3` | `10.1.0` | 3 majors. Dev scripts only |
+| 4d | **`react-confetti`** | `^5.1.0` | `6.4.0` | 1 major |
+| 4e | **`react-dropzone`** | `^14.4.1` | `15.0.0` | 1 major |
+| 4f | **`react-simple-keyboard`** | `^1.26.6` | `3.8.165` | 2 majors. Mobile keyboard component |
+| 4g | **`argparse`** + **`@types/argparse`** | `1.0.10` / `1.0.38` | `2.0.1` / remove | v2 ships own types. Only used in `utils/generate_stickers.ts` |
+| 4h | **`esbuild`** | `^0.25.12` | `0.27.3` | 2 minor-as-major (0.x semver). **Also update pnpm override** from `^0.25.12` |
+| 4i | **`jsdom`** | `^26.1.0` | `28.1.0` | 2 majors. Dev-only (Vitest env) |
+
+### 5. Stylelint Upgrade (medium — config changes likely)
+
+| # | Package | Current | Latest | Notes |
+|---|---|---|---|---|
+| 5a | **`stylelint`** | `^16.26.1` | `17.4.0` | 1 major. Check for removed/renamed rules |
+| 5b | **`stylelint-config-standard`** | `^36.0.1` | `40.0.0` | 4 majors. Must upgrade together with stylelint |
+
+### 6. Jest Upgrade (medium — server tests only)
+
+| # | Package | Current | Latest | Notes |
+|---|---|---|---|---|
+| 6a | **`jest`** | `^29.7.0` | `30.2.0` | 1 major. Only affects server tests (frontend uses Vitest) |
+| 6b | **`@types/jest`** | `^29.5.14` | `30.0.0` | Must match jest major |
+| 6c | **`ts-jest`** | `^29.4.6` | needs v30 | Must match jest major |
+
+### 7. ESLint v10 Ecosystem (BLOCKED — waiting on plugins)
+
+| # | Package | Current | Latest | Status |
+|---|---|---|---|---|
+| 7a | **`eslint`** | `^9.39.3` | `10.0.2` | Blocked by plugins below |
+| 7b | **`@eslint/js`** | `^9.39.3` | `10.0.1` | Tied to eslint v10 |
+| 7c | **`eslint-config-prettier`** | `^9.1.2` | `10.1.8` | **Can likely upgrade independently now** |
+| 7d | **`eslint-import-resolver-typescript`** | `^3.10.1` | `4.4.4` | **May be independent of eslint v10** |
+| 7e | **`eslint-plugin-react-hooks`** | `^5.2.0` | `7.0.1` | Check if v7 supports eslint v10 |
+| 7f | **`eslint-plugin-react`** | `^7.37.5` | — | Uses removed `context.getFilename()`. Track jsx-eslint/eslint-plugin-react#3979 |
+| 7g | **`eslint-plugin-import`** | `^2.32.0` | — | Peer deps allow only `^9` |
+| 7h | **`eslint-plugin-jsx-a11y`** | `^6.10.2` | — | Peer deps allow only `^9` |
+
+### 8. Font Awesome 4 CDN -> react-icons (medium — 5 icons, 3 files)
+
+- **CDN**: Font Awesome 4.7.0 (2016, EOL) loaded in `index.html:5-7`
+- **5 icons used**:
+  - `fa fa-info-circle` — `src/components/WelcomeVariantsControl.tsx`
+  - `fa fa-list` — `src/components/Toolbar/index.js`
+  - `fa fa-pencil` — `src/components/Toolbar/index.js`
+  - `fa fa-check-square` — `src/components/Toolbar/index.js`
+  - `fa fa-clone` — `src/components/Chat/Chat.js`
+- **Action**: Replace with `react-icons/fa` equivalents, remove CDN link, check Toolbar CSS for FA styles
+
+### 9. Firebase v7 -> Remove or v12 (LARGE)
+
+- **Current**: `firebase@^7.24.0` — resolves to `7.24.0` — **5 major versions behind** (latest `12.10.0`)
+- **Usage**: 1 direct import (`src/store/firebase.js`), legacy namespaced API
+- **Decision**: If PostgreSQL + Socket.IO fully replaces Firebase Realtime Database, **remove entirely**. Otherwise migrate to modular SDK (tree-shakeable, much smaller bundle).
+
+### 10. Server Build Step — Replace ts-node in Production (LARGE)
+
+- **Dockerfile** (`Dockerfile:26`): `CMD ["npx", "ts-node", ...]` — compiles TS at runtime
+- **Prod scripts** (`package.json:124-125`): `ts-node` + fragile `while true; do ... || true; done` restart loop + `env $(cat .env.prod | xargs)` that breaks on special characters
+- **Action**:
+  1. Add `build:server` script (compile to JS with `tsc`)
+  2. Update Dockerfile: `CMD ["node", "dist/server.js"]`
+  3. Replace restart loop with process manager or `dotenv-cli`
+  4. Move `typescript` and `ts-node` to devDependencies
+
+### 11. Rename 97 `.js` files with JSX to `.jsx` (LARGE)
+
+- Both `vite.config.ts` and `vitest.config.ts` have a custom `treat-js-as-jsx` plugin (CRA legacy)
+- 97 `.js` files in `src/` contain JSX, 0 `.jsx` files exist
+- **Action**: Rename to `.jsx` (or `.tsx` during TS migration), remove custom plugin from both configs
+
+### 12. Lodash Migration (ONGOING — 52 files)
+
+- `lodash@^4.17.23` used across 43 files in `src/`, 9 in `server/`
+- Many have native equivalents (`_.get` -> optional chaining, `_.isEmpty`, `_.flatten`, etc.)
+- Already split into its own vendor chunk
+- **Action**: Gradual migration. Not urgent but reduces bundle size.
+
+---
+
+## Infrastructure & Config Notes
+
+| Item | File | Current | Note |
+|---|---|---|---|
+| **`.npmrc` hoisted mode** | `.npmrc:1` | `node-linker=hoisted` | Legacy compat mode. Consider migrating to pnpm default isolated mode |
+| **`prettier.config.js` format** | `prettier.config.js` | CommonJS `module.exports` | Could migrate to ESM to match eslint/stylelint configs |
+| **pnpm `esbuild` override** | `package.json:54` | `"^0.25.12"` | Must update if esbuild bumped (item 4h) |
+| **pnpm `serialize-javascript` override** | `package.json:55` | `"^7.0.3"` | Security patch for transitive dep. Review periodically |
+| **pnpm `diff` override** | `package.json:56` | `"^5.2.0"` | Security patch. Review periodically |
+| **CI: no E2E test job** | `.github/workflows/ci.yml` | — | Playwright tests exist but aren't in CI. Consider chromium-only job |
+| **CI: 8 parallel installs** | `.github/workflows/ci.yml` | Each job runs `pnpm install` | pnpm store cached but linking still takes time |
+| **Firebase API keys in source** | `src/store/firebase.js:9-25` | Hardcoded | Client keys are public by design, but env vars are best practice |
+| **`@types/node` at `^22`** | `package.json:79` | `22.19.13` (latest `25.3.3`) | Fine — matches Node 22 engine. Bump when moving to Node 24 |
+| **`passport-local@1.0.0`** | `package.json:32` | Released 2014 | No newer version exists. Works fine, just unmaintained |

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@sendgrid/mail": "^8.1.6",
     "@sentry/node": "^10.41.0",
     "@sentry/react": "^10.41.0",
-    "async": "^3.2.6",
     "bcrypt": "^6.0.0",
     "clsx": "^2.1.1",
     "cookie-parser": "^1.4.7",
@@ -40,11 +39,9 @@
     "react-icons": "^5.5.0",
     "react-router": "^7.13.1",
     "react-simple-keyboard": "^1.26.6",
-    "react-use": "^15.3.8",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
     "typescript": "~5.9.3",
-    "utility-types": "^3.11.0",
     "uuid": "^11.1.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,6 @@ importers:
       '@sentry/react':
         specifier: ^10.41.0
         version: 10.41.0(react@19.2.4)
-      async:
-        specifier: ^3.2.6
-        version: 3.2.6
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -114,9 +111,6 @@ importers:
       react-simple-keyboard:
         specifier: ^1.26.6
         version: 1.26.6
-      react-use:
-        specifier: ^15.3.8
-        version: 15.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       socket.io:
         specifier: ^4.8.3
         version: 4.8.3
@@ -126,9 +120,6 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
-      utility-types:
-        specifier: ^3.11.0
-        version: 3.11.0
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -2495,9 +2486,6 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
-  '@types/js-cookie@2.2.6':
-    resolution: {integrity: sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2791,9 +2779,6 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
-
-  '@xobotyi/scrollbar-width@1.9.5':
-    resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -3235,9 +3220,6 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
-  copy-to-clipboard@3.3.3:
-    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
-
   core-js-compat@3.48.0:
     resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
 
@@ -3282,13 +3264,6 @@ packages:
   css-functions-list@3.3.3:
     resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
     engines: {node: '>=12'}
-
-  css-in-js-utils@3.1.0:
-    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
-
-  css-tree@1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
 
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
@@ -3501,9 +3476,6 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
-
-  error-stack-parser@2.1.4:
-    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -3735,18 +3707,12 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-shallow-equal@1.0.0:
-    resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
-
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
-
-  fastest-stable-stringify@2.0.2:
-    resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4058,9 +4024,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  hyphenate-style-name@1.1.0:
-    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
-
   ico-endec@0.1.6:
     resolution: {integrity: sha512-ZdLU38ZoED3g1j3iEyzcQj+wAkY2xfWNkymszfJPoxucIUhK7NayQ+/C4Kv0nDFMIsbtbEHldv3V8PU494/ueQ==}
 
@@ -4114,9 +4077,6 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
-  inline-style-prefixer@7.0.1:
-    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -4458,9 +4418,6 @@ packages:
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4684,9 +4641,6 @@ packages:
   mathml-tag-names@2.1.3:
     resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
 
-  mdn-data@2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
-
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
@@ -4767,12 +4721,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  nano-css@5.6.2:
-    resolution: {integrity: sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -5271,18 +5219,6 @@ packages:
       '@types/react':
         optional: true
 
-  react-universal-interface@0.6.2:
-    resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
-    peerDependencies:
-      react: '*'
-      tslib: '*'
-
-  react-use@15.3.8:
-    resolution: {integrity: sha512-GeGcrmGuUvZrY5wER3Lnph9DSYhZt5nEjped4eKDq8BRGr2CnLf9bDQWG9RFc7oCPphnscUUdOovzq0E5F2c6Q==}
-    peerDependencies:
-      react: ^16.8.0  || ^17.0.0
-      react-dom: ^16.8.0  || ^17.0.0
-
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -5328,9 +5264,6 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
-
-  resize-observer-polyfill@1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -5389,9 +5322,6 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
-  rtl-css-js@1.16.1:
-    resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5422,10 +5352,6 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  screenfull@5.2.0:
-    resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
-    engines: {node: '>=0.10.0'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5458,10 +5384,6 @@ packages:
   set-function-name@2.0.2:
     resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
     engines: {node: '>= 0.4'}
-
-  set-harmonic-interval@1.0.1:
-    resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
-    engines: {node: '>=6.9'}
 
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
@@ -5569,10 +5491,6 @@ packages:
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
-  source-map@0.5.6:
-    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
-    engines: {node: '>=0.10.0'}
-
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -5596,24 +5514,12 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
-  stack-generator@2.0.10:
-    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
-
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-
-  stackframe@1.3.4:
-    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
-
-  stacktrace-gps@3.1.2:
-    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
-
-  stacktrace-js@2.0.2:
-    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -5718,9 +5624,6 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
-  stylis@4.3.6:
-    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
-
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -5768,10 +5671,6 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
-  throttle-debounce@2.3.0:
-    resolution: {integrity: sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==}
-    engines: {node: '>=8'}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -5804,9 +5703,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toggle-selection@1.0.6:
-    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
-
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -5834,9 +5730,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-easing@0.2.0:
-    resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
 
   ts-jest@29.4.6:
     resolution: {integrity: sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==}
@@ -6033,10 +5926,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  utility-types@3.11.0:
-    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
-    engines: {node: '>= 4'}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -8802,8 +8691,6 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
-  '@types/js-cookie@2.2.6': {}
-
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -9124,8 +9011,6 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
-
-  '@xobotyi/scrollbar-width@1.9.5': {}
 
   accepts@1.3.8:
     dependencies:
@@ -9604,10 +9489,6 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  copy-to-clipboard@3.3.3:
-    dependencies:
-      toggle-selection: 1.0.6
-
   core-js-compat@3.48.0:
     dependencies:
       browserslist: 4.28.1
@@ -9658,15 +9539,6 @@ snapshots:
   crypto-random-string@2.0.0: {}
 
   css-functions-list@3.3.3: {}
-
-  css-in-js-utils@3.1.0:
-    dependencies:
-      hyphenate-style-name: 1.1.0
-
-  css-tree@1.1.3:
-    dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
 
   css-tree@3.1.0:
     dependencies:
@@ -9860,10 +9732,6 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
-
-  error-stack-parser@2.1.4:
-    dependencies:
-      stackframe: 1.3.4
 
   es-abstract@1.24.1:
     dependencies:
@@ -10274,13 +10142,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-shallow-equal@1.0.0: {}
-
   fast-uri@3.1.0: {}
 
   fastest-levenshtein@1.0.16: {}
-
-  fastest-stable-stringify@2.0.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -10616,8 +10480,6 @@ snapshots:
 
   husky@9.1.7: {}
 
-  hyphenate-style-name@1.1.0: {}
-
   ico-endec@0.1.6: {}
 
   iconv-lite@0.6.3:
@@ -10665,10 +10527,6 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
-
-  inline-style-prefixer@7.0.1:
-    dependencies:
-      css-in-js-utils: 3.1.0
 
   internal-slot@1.1.0:
     dependencies:
@@ -11207,8 +11065,6 @@ snapshots:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
 
-  js-cookie@2.2.1: {}
-
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -11442,8 +11298,6 @@ snapshots:
 
   mathml-tag-names@2.1.3: {}
 
-  mdn-data@2.0.14: {}
-
   mdn-data@2.12.2: {}
 
   media-typer@1.1.0: {}
@@ -11508,19 +11362,6 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
-
-  nano-css@5.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      css-tree: 1.1.3
-      csstype: 3.2.3
-      fastest-stable-stringify: 2.0.2
-      inline-style-prefixer: 7.0.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      rtl-css-js: 1.16.1
-      stacktrace-js: 2.0.2
-      stylis: 4.3.6
 
   nanoid@3.3.11: {}
 
@@ -11994,30 +11835,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-universal-interface@0.6.2(react@19.2.4)(tslib@2.8.1):
-    dependencies:
-      react: 19.2.4
-      tslib: 2.8.1
-
-  react-use@15.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@types/js-cookie': 2.2.6
-      '@xobotyi/scrollbar-width': 1.9.5
-      copy-to-clipboard: 3.3.3
-      fast-deep-equal: 3.1.3
-      fast-shallow-equal: 1.0.0
-      js-cookie: 2.2.1
-      nano-css: 5.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-universal-interface: 0.6.2(react@19.2.4)(tslib@2.8.1)
-      resize-observer-polyfill: 1.5.1
-      screenfull: 5.2.0
-      set-harmonic-interval: 1.0.1
-      throttle-debounce: 2.3.0
-      ts-easing: 0.2.0
-      tslib: 2.8.1
-
   react@19.2.4: {}
 
   readdirp@3.6.0:
@@ -12075,8 +11892,6 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
-
-  resize-observer-polyfill@1.5.1: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -12161,10 +11976,6 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rtl-css-js@1.16.1:
-    dependencies:
-      '@babel/runtime': 7.28.6
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12199,8 +12010,6 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
-
-  screenfull@5.2.0: {}
 
   semver@6.3.1: {}
 
@@ -12250,8 +12059,6 @@ snapshots:
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
-
-  set-harmonic-interval@1.0.1: {}
 
   set-proto@1.0.0:
     dependencies:
@@ -12418,8 +12225,6 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
-  source-map@0.5.6: {}
-
   source-map@0.6.1: {}
 
   source-map@0.8.0-beta.0:
@@ -12434,28 +12239,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
-  stack-generator@2.0.10:
-    dependencies:
-      stackframe: 1.3.4
-
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
-
-  stackframe@1.3.4: {}
-
-  stacktrace-gps@3.1.2:
-    dependencies:
-      source-map: 0.5.6
-      stackframe: 1.3.4
-
-  stacktrace-js@2.0.2:
-    dependencies:
-      error-stack-parser: 2.1.4
-      stack-generator: 2.0.10
-      stacktrace-gps: 3.1.2
 
   statuses@2.0.2: {}
 
@@ -12618,8 +12406,6 @@ snapshots:
       - supports-color
       - typescript
 
-  stylis@4.3.6: {}
-
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -12673,8 +12459,6 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
-  throttle-debounce@2.3.0: {}
-
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -12700,8 +12484,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toggle-selection@1.0.6: {}
-
   toidentifier@1.0.1: {}
 
   touch@3.1.1: {}
@@ -12723,8 +12505,6 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
-
-  ts-easing@0.2.0: {}
 
   ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.13)(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
@@ -12942,8 +12722,6 @@ snapshots:
       '@types/react': 19.2.14
 
   util-deprecate@1.0.2: {}
-
-  utility-types@3.11.0: {}
 
   utils-merge@1.0.1: {}
 

--- a/src/components/Chat/ColorPicker.tsx
+++ b/src/components/Chat/ColorPicker.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {useToggle} from 'react-use';
+import {useToggle} from '../../hooks/useToggle';
 import {PALETTE_COLORS} from '../../lib/colorAssignment';
 
 interface ColorPickerProps {

--- a/src/components/Fencing/Fencing.tsx
+++ b/src/components/Fencing/Fencing.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import * as uuid from 'uuid';
 import React, {useState, useEffect, useCallback, useMemo} from 'react';
-import {useUpdateEffect} from 'react-use';
+import {useUpdateEffect} from '../../hooks/useUpdateEffect';
 import {Helmet} from 'react-helmet-async';
 import type {Socket} from 'socket.io-client';
 import {useSocket} from '../../sockets/useSocket';

--- a/src/components/RerenderBoundary.tsx
+++ b/src/components/RerenderBoundary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {usePrevious} from 'react-use';
+import {usePrevious} from '../hooks/usePrevious';
 
 const RerenderBoundary: React.FC<{name: string; hash: string; children?: React.ReactNode}> = (props) => {
   const prevChildren = React.useRef<React.ReactNode>(props.children);

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,0 +1,9 @@
+import {useRef} from 'react';
+
+/** Returns the value from the previous render. */
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>(undefined);
+  const prev = ref.current;
+  ref.current = value;
+  return prev;
+}

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,10 @@
+import {useCallback, useState} from 'react';
+
+/** Boolean state with a toggle function. Optionally pass a value to set directly. */
+export function useToggle(initialValue: boolean): [boolean, (nextValue?: boolean) => void] {
+  const [value, setValue] = useState(initialValue);
+  const toggle = useCallback((nextValue?: boolean) => {
+    setValue((prev) => (typeof nextValue === 'boolean' ? nextValue : !prev));
+  }, []);
+  return [value, toggle];
+}

--- a/src/hooks/useUpdateEffect.ts
+++ b/src/hooks/useUpdateEffect.ts
@@ -1,0 +1,14 @@
+import {useEffect, useRef, type DependencyList, type EffectCallback} from 'react';
+
+/** Like useEffect, but skips the initial mount — only runs on dependency updates. */
+export function useUpdateEffect(effect: EffectCallback, deps: DependencyList) {
+  const isFirstMount = useRef(true);
+  useEffect(() => {
+    if (isFirstMount.current) {
+      isFirstMount.current = false;
+      return undefined;
+    }
+    return effect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -1,5 +1,5 @@
 import React, {Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState} from 'react';
-import {useUpdateEffect} from 'react-use';
+import {useUpdateEffect} from '../hooks/useUpdateEffect';
 import _ from 'lodash';
 import {Helmet} from 'react-helmet-async';
 import {useParams} from 'react-router';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,4 @@
-import {Brand} from 'utility-types';
+type Brand<T, B> = T & {__brand: B};
 
 export interface InfoJson {
   type?: string; // this is sometimes set by the frontend, e.g. by the FileUpload module

--- a/src/sockets/useSocket.tsx
+++ b/src/sockets/useSocket.tsx
@@ -1,12 +1,11 @@
-import {useState} from 'react';
-import {useAsync} from 'react-use';
+import {useEffect, useState} from 'react';
 import type {Socket} from 'socket.io-client';
 import {getSocket} from './getSocket';
 
 export const useSocket = () => {
   const [socket, setSocket] = useState<Socket>();
-  useAsync(async () => {
-    setSocket(await getSocket());
-  });
+  useEffect(() => {
+    getSocket().then(setSocket);
+  }, []);
   return socket;
 };

--- a/src/store/battle.js
+++ b/src/store/battle.js
@@ -1,6 +1,5 @@
 import EventEmitter from 'events';
 
-import async from 'async';
 import _ from 'lodash';
 import {db} from './firebase';
 
@@ -141,19 +140,15 @@ export default class Battle extends EventEmitter {
       const powerupTypes = _.keys(powerupData);
       const pickups = _.map(locations, ({i, j}) => ({i, j, type: _.sample(powerupTypes)}));
 
-      async.map(
-        pickups,
-        (pickup, mapCbk) => {
-          this.ref.child('pickups').push(pickup, () => mapCbk());
-        },
-        () => cbk && cbk()
-      );
+      Promise.all(
+        pickups.map(
+          (pickup) => new Promise((resolve) => this.ref.child('pickups').push(pickup, () => resolve()))
+        )
+      ).then(() => cbk && cbk());
     });
   }
 
   initialize(pid, bid, teams = 2) {
-    const shiftCbkArg = (fn) => (args, cbk) => fn(args, (val) => cbk(null, val)); // async style fun
-
     const args = _.map(_.range(teams), (team) => ({
       pid,
       battleData: {bid, team},
@@ -171,7 +166,9 @@ export default class Battle extends EventEmitter {
       puzzle.detach();
 
       // Need to wait for all of these to finish otherwise the redirect on emit(ready) kills things.
-      async.map(args, shiftCbkArg(actions.createGameForBattle), (err, gids) => {
+      Promise.all(
+        args.map((arg) => new Promise((resolve) => actions.createGameForBattle(arg, resolve)))
+      ).then((gids) => {
         this.gids = gids;
         this.ref.child('games').set(gids, () => {
           this.ref.child('powerups').set(powerups, () => {


### PR DESCRIPTION
## Summary
- **`utility-types`** removed — inlined `Brand<T, B>` type directly in `src/shared/types.ts`
- **`async`** removed — replaced `async.map()` with native `Promise.all()` in `src/store/battle.js`
- **`react-use`** removed — wrote 3 custom hooks in `src/hooks/` (`useUpdateEffect`, `usePrevious`, `useToggle`) and replaced `useAsync` with plain `useEffect`
- Updated `DEPENDENCY_AUDIT.md` with completed items and corrected `events` polyfill notes

**141 packages removed** from `node_modules`.

## Test plan
- [x] Frontend TypeScript check passes
- [x] Server TypeScript check passes
- [x] ESLint (zero warnings) passes
- [x] Frontend tests pass (370 tests)
- [x] Server tests pass (160 tests)
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)