### PR TITLE
Replace Font Awesome 4 CDN with react-icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css"
-    />
     <link href="https://fonts.googleapis.com/css2?family=Nunito&display=swap" rel="stylesheet" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import Linkify from 'linkify-react';
 import {Link} from 'react-router';
 import {MdClose} from 'react-icons/md';
+import {FaClone} from 'react-icons/fa6';
 import Emoji from '../common/Emoji';
 import * as emojiLib from '../../lib/emoji';
 import nameGenerator, {isFromNameGenerator} from '../../lib/nameGenerator';
@@ -458,8 +459,8 @@ export default class Chat extends Component {
                   {this.url}
                 </b>
 
-                <i
-                  className="fa fa-clone copyButton"
+                <FaClone
+                  className="copyButton"
                   title="Copy to Clipboard"
                   role="button"
                   tabIndex={0}
@@ -484,7 +485,7 @@ export default class Chat extends Component {
                     <wbr />
                   </i>
 
-                  <i className="fa fa-clone copyButton" title="Copy to Clipboard" />
+                  <FaClone className="copyButton" title="Copy to Clipboard" />
                 </div>
               </div>
             )}

--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import clsx from 'clsx';
+import {FaNoteSticky} from 'react-icons/fa6';
 import Emoji from '../common/Emoji';
 import powerups from '../../lib/powerups';
 
@@ -109,13 +110,13 @@ export default class Cell extends React.Component<Props> {
     );
   }
 
-  handleFlipClick: React.MouseEventHandler<HTMLElement> = (e) => {
+  handleFlipClick: React.MouseEventHandler<Element> = (e) => {
     e.stopPropagation();
     const {onFlipColor} = this.props;
     if (onFlipColor) onFlipColor(this.props.r, this.props.c);
   };
 
-  handleFlipKeyDown: React.KeyboardEventHandler<HTMLElement> = (e) => {
+  handleFlipKeyDown: React.KeyboardEventHandler<Element> = (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.stopPropagation();
       const {onFlipColor} = this.props;
@@ -127,8 +128,8 @@ export default class Cell extends React.Component<Props> {
     const {canFlipColor} = this.props;
     if (canFlipColor) {
       return (
-        <i
-          className="cell--flip fa fa-small fa-sticky-note"
+        <FaNoteSticky
+          className="cell--flip"
           role="button"
           tabIndex={0}
           onClick={this.handleFlipClick}

--- a/src/components/Toolbar/Popup.js
+++ b/src/components/Toolbar/Popup.js
@@ -40,10 +40,11 @@ export default class Popup extends Component {
       <div className={`${this.state.active ? 'active ' : ''}popup-menu`} onBlur={this.handleBlur}>
         <button
           tabIndex={-1}
-          className={`popup-menu--button fa ${this.props.icon ? this.props.icon : ''}`}
+          className="popup-menu--button"
           onMouseDown={handleMouseDown}
           onClick={this.handleClick}
         >
+          {this.props.icon}
           {this.props.label ? this.props.label : ''}
         </button>
         <div className="popup-menu--content">{this.props.children}</div>

--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -98,7 +98,7 @@ code {
   cursor: pointer;
 }
 
-.toolbar--pencil.on .fa-pencil {
+.toolbar--pencil.on .toolbar--icon-pencil {
   color: var(--main-blue) !important;
 }
 
@@ -106,11 +106,11 @@ code {
   color: var(--main-blue) !important;
 }
 
-.toolbar--list-view.on .fa-list {
+.toolbar--list-view.on .toolbar--icon-list {
   color: var(--main-blue) !important;
 }
 
-.toolbar--autocheck.on .fa-check-square {
+.toolbar--autocheck.on .toolbar--icon-autocheck {
   color: var(--main-blue) !important;
 }
 
@@ -118,7 +118,7 @@ code {
   color: var(--main-gray-2);
 }
 
-.toolbar--mobile .toolbar--autocheck.on .fa-check-square {
+.toolbar--mobile .toolbar--autocheck.on .toolbar--icon-autocheck {
   color: white !important;
 }
 

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -3,6 +3,7 @@ import {Component} from 'react';
 import {MdBorderAll, MdChatBubble, MdList, MdSlowMotionVideo, MdErrorOutline} from 'react-icons/md';
 import {AiOutlineMenuFold, AiOutlineMenuUnfold} from 'react-icons/ai';
 import {RiPaintFill, RiPaintLine} from 'react-icons/ri';
+import {FaList, FaPencil, FaSquareCheck, FaCircleInfo} from 'react-icons/fa6';
 import {Link} from 'react-router';
 import Clock from './Clock';
 import ConfirmDialog from '../common/ConfirmDialog';
@@ -295,7 +296,7 @@ export default class Toolbar extends Component {
         onMouseDown={handleMouseDown}
         title="List View"
       >
-        <i className="fa fa-list" />
+        <FaList className="toolbar--icon-list" />
       </div>
     );
   }
@@ -325,7 +326,7 @@ export default class Toolbar extends Component {
         onMouseDown={handleMouseDown}
         title="Shortcut: ."
       >
-        <i className="fa fa-pencil" />
+        <FaPencil className="toolbar--icon-pencil" />
         {pencilMode && (
           <div className="toolbar--pencil-color-picker-container">
             <div
@@ -359,7 +360,7 @@ export default class Toolbar extends Component {
         onMouseDown={handleMouseDown}
         title="Autocheck"
       >
-        <i className="fa fa-check-square" />
+        <FaSquareCheck className="toolbar--icon-autocheck" />
       </div>
     );
   }
@@ -367,7 +368,7 @@ export default class Toolbar extends Component {
   renderInfo() {
     return (
       <div className="toolbar--info">
-        <Popup icon="fa-info-circle" onBlur={this.handleBlur}>
+        <Popup icon={<FaCircleInfo />} onBlur={this.handleBlur}>
           <h3>How to Enter Answers</h3>
           <ul>
             <li>

--- a/src/components/WelcomeVariantsControl.tsx
+++ b/src/components/WelcomeVariantsControl.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useState} from 'react';
 import {Link} from 'react-router';
 import clsx from 'clsx';
 import {MdInfoOutline} from 'react-icons/md';
+import {FaCircleInfo} from 'react-icons/fa6';
 import './css/welcomeVariantsControl.css';
 import InfoDialog from './common/InfoDialog';
 
@@ -46,7 +47,7 @@ export const WelcomeVariantsControl: React.FC<{
           role="button"
           tabIndex={0}
         >
-          <i className="fa fa-info-circle" />
+          <FaCircleInfo />
         </span>
       </span>
       <InfoDialog


### PR DESCRIPTION
## Summary
- Removes the Font Awesome 4.7.0 CDN stylesheet from `index.html` (EOL since 2016, ~85KB external request on every page load)
- Replaces all 6 FA icon usages with `react-icons/fa6` equivalents (already a project dependency — no new packages added)
- Refactors `Popup` component to accept a React element for its `icon` prop instead of constructing FA class names
- Updates CSS selectors that targeted FA class names (`.fa-pencil`, `.fa-list`, `.fa-check-square`) to use new class names

## Icons replaced
| Old (Font Awesome 4) | New (react-icons/fa6) | Component |
|---|---|---|
| `fa-info-circle` | `FaCircleInfo` | WelcomeVariantsControl, Toolbar/Popup |
| `fa-list` | `FaList` | Toolbar |
| `fa-pencil` | `FaPencil` | Toolbar |
| `fa-check-square` | `FaSquareCheck` | Toolbar |
| `fa-clone` | `FaClone` | Chat (×2) |
| `fa-sticky-note` | `FaNoteSticky` | Grid/Cell |

## Test plan
- [x] ESLint passes (zero warnings)
- [x] Stylelint passes
- [x] Frontend tests pass (370)
- [x] Frontend typecheck passes
- [x] Production build succeeds
- [ ] Visual check: Toolbar icons (pencil, list, autocheck, info) render correctly
- [ ] Visual check: Chat copy-to-clipboard icon renders
- [ ] Visual check: Fencing info circle renders on welcome page

🤖 Generated with [Claude Code](https://claude.com/claude-code)