### PR TITLE
remove CWF link in mobile toolbar

### DIFF
--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -4,7 +4,6 @@ import {MdBorderAll, MdChatBubble, MdList, MdSlowMotionVideo, MdErrorOutline} fr
 import {AiOutlineMenuFold, AiOutlineMenuUnfold} from 'react-icons/ai';
 import {RiPaintFill, RiPaintLine} from 'react-icons/ri';
 import {FaList, FaPencil, FaSquareCheck, FaCircleInfo} from 'react-icons/fa6';
-import {Link} from 'react-router';
 import Clock from './Clock';
 import ConfirmDialog from '../common/ConfirmDialog';
 import ActionMenu from './ActionMenu';
@@ -594,7 +593,6 @@ export default class Toolbar extends Component {
         <>
           <div className="flex flex--align-center toolbar--mobile">
             <div className="flex flex--grow flex--align-center toolbar--mobile--top">
-              <Link to="/">CWF</Link>{' '}
               {!expandMenu ? (
                 <>
                   <Clock


### PR DESCRIPTION
There's a redundant home link in the mobile toolbar now that there's a new Nav bar. Space is precious on mobile, begone duplicate link!

| Old | New |
|--------|--------|
| <img width="290" height="174" alt="image" src="https://github.com/user-attachments/assets/3400484c-d2f4-4bf9-a593-a3984aa04592" /> | <img width="293" height="174" alt="image" src="https://github.com/user-attachments/assets/b2940604-5783-42f1-92b5-4211dbe15ee7" /> |