### PR TITLE
fix: return 404 for missing puzzle in POST /api/game

### DIFF
--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -10,12 +10,20 @@ import {dismissGameForUser, undismissGameForUser} from '../model/game_dismissal'
 
 const router = express.Router();
 
-router.post<{}, CreateGameResponse, CreateGameRequest>('/', async (req, res) => {
-  console.log('got req', req.headers, req.body);
-  const gid = await addInitialGameEvent(req.body.gid, req.body.pid);
-  res.json({
-    gid,
-  });
+router.post<{}, CreateGameResponse, CreateGameRequest>('/', async (req, res, next) => {
+  try {
+    console.log('got req', req.headers, req.body);
+    const gid = await addInitialGameEvent(req.body.gid, req.body.pid);
+    res.json({
+      gid,
+    });
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith('Puzzle not found')) {
+      res.status(404).json({error: e.message} as any);
+    } else {
+      next(e);
+    }
+  }
 });
 
 router.get<{gid: string}, GetGameResponse>('/:gid', async (req, res) => {


### PR DESCRIPTION
## Summary
- `POST /api/game` had no try/catch, so a missing puzzle ID caused an unhandled promise rejection that could crash the server
- Now returns a proper 404 response with `{error: "Puzzle not found: <id>"}`
- Other errors are forwarded to Express error middleware via `next(e)`

## Sentry Issues
Fixes NODE-EXPRESS-4, NODE-EXPRESS-5

## Test plan
- [x] All 160 server tests pass (`pnpm test:server --ci`)
- [x] Server type check passes
- [x] Lint + Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)