### PR TITLE
fix: remove header logging and fix type safety in game API

### DIFF
--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -10,16 +10,13 @@ import {dismissGameForUser, undismissGameForUser} from '../model/game_dismissal'
 
 const router = express.Router();
 
-router.post<{}, CreateGameResponse, CreateGameRequest>('/', async (req, res, next) => {
+router.post<{}, CreateGameResponse | {error: string}, CreateGameRequest>('/', async (req, res, next) => {
   try {
-    console.log('got req', req.headers, req.body);
     const gid = await addInitialGameEvent(req.body.gid, req.body.pid);
-    res.json({
-      gid,
-    });
+    res.json({gid});
   } catch (e) {
     if (e instanceof Error && e.message.startsWith('Puzzle not found')) {
-      res.status(404).json({error: e.message} as any);
+      res.status(404).json({error: e.message});
     } else {
       next(e);
     }
@@ -27,7 +24,6 @@ router.post<{}, CreateGameResponse, CreateGameRequest>('/', async (req, res, nex
 });
 
 router.get<{gid: string}, GetGameResponse>('/:gid', async (req, res) => {
-  console.log('got req', req.headers, req.body);
   try {
     const {gid} = req.params;
 


### PR DESCRIPTION
## Summary
Follow-up to #364 addressing review feedback:
- Remove `console.log('got req', req.headers, req.body)` from POST and GET handlers — was leaking `Authorization` headers to logs
- Update response type to `CreateGameResponse | {error: string}` to remove `as any` cast

## Test plan
- [x] Server type check passes
- [x] All 160 server tests pass
- [x] Lint + Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)