### PR TITLE
Add missing indexes on puzzle_solves table

### DIFF
--- a/server/sql/alter_puzzle_solves_add_indexes.sql
+++ b/server/sql/alter_puzzle_solves_add_indexes.sql
@@ -1,0 +1,16 @@
+-- alter_puzzle_solves_add_indexes.sql
+-- Adds missing indexes to puzzle_solves for game-scoped lookups and user history ordering.
+--
+-- Usage:  psql -U dfacadmin -d <dbname> -f server/sql/alter_puzzle_solves_add_indexes.sql
+
+-- Fast lookups by gid for solve checks, co-solver queries, replay data, and cleanup jobs.
+-- Benefits: isGidAlreadySolved, isAlreadySolvedByUser, getPuzzleSolves, co-solver/solver-count
+--           queries, game_snapshot fallback, backfillSolvesForDfacId, cleanup_game_events JOIN.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS puzzle_solves_gid_idx
+  ON puzzle_solves (gid);
+
+-- Composite index for user solve history sorted by solved_time DESC.
+-- Benefits: getUserSolveStats history query (ORDER BY ps.solved_time DESC LIMIT 100).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS puzzle_solves_user_solved_time_idx
+  ON puzzle_solves (user_id, solved_time DESC)
+  WHERE user_id IS NOT NULL;

--- a/server/sql/create_puzzle_solves.sql
+++ b/server/sql/create_puzzle_solves.sql
@@ -24,6 +24,15 @@ CREATE UNIQUE INDEX IF NOT EXISTS puzzle_solves_anon_game_idx
 CREATE INDEX IF NOT EXISTS puzzle_solves_user_id_idx
   ON puzzle_solves (user_id) WHERE user_id IS NOT NULL;
 
+-- Fast lookups by gid for solve checks, co-solver queries, and replay data
+CREATE INDEX IF NOT EXISTS puzzle_solves_gid_idx
+  ON puzzle_solves (gid);
+
+-- User solve history sorted by solved_time (for profile page)
+CREATE INDEX IF NOT EXISTS puzzle_solves_user_solved_time_idx
+  ON puzzle_solves (user_id, solved_time DESC)
+  WHERE user_id IS NOT NULL;
+
 -- GRANT ALL ON TABLE public.puzzle_solves TO dfac_staging;
 -- GRANT ALL ON TABLE public.puzzle_solves TO dfac_production;
 ALTER TABLE public.puzzle_solves


### PR DESCRIPTION
## Summary
- Add `puzzle_solves_gid_idx` index on `(gid)` — eliminates sequential scans on 8+ queries (solve dedup checks, co-solver lookups, getPuzzleSolves, game_snapshot fallback, cleanup jobs)
- Add `puzzle_solves_user_solved_time_idx` composite index on `(user_id, solved_time DESC)` — enables index-ordered scan for user solve history (profile page)
- Migration file uses `CREATE INDEX CONCURRENTLY` to avoid locking the table in production
- Base schema (`create_puzzle_solves.sql`) updated so fresh environments get the indexes automatically

## Context
Investigation of the reported N+1 pattern in `puzzle_solve.ts` found that `computeGamesProgress` already uses a batch query — no N+1 issue exists. The real performance gap is the completely unindexed `gid` column on `puzzle_solves`, which forces sequential scans on every game view, solve check, and co-solver lookup.

## Test plan
- [x] `pnpm tsc --noEmit -p server/tsconfig.json` passes
- [x] `pnpm test:server --ci` — 176 tests pass
- [ ] Run migration on staging: `psql -f server/sql/alter_puzzle_solves_add_indexes.sql`
- [ ] Verify indexes: `\di puzzle_solves*` in psql

🤖 Generated with [Claude Code](https://claude.com/claude-code)