### PR TITLE
Fix Swagger YAML parse error in user_stats

### DIFF
--- a/server/api/user_stats.ts
+++ b/server/api/user_stats.ts
@@ -13,7 +13,7 @@ const router = express.Router();
  *   get:
  *     tags: [Users]
  *     summary: Get user profile and stats
- *     description: Returns solve stats, history, uploads, and in-progress games for a user. Private profiles return {isPrivate: true} unless the requester is the owner.
+ *     description: "Returns solve stats, history, uploads, and in-progress games for a user. Private profiles return {isPrivate: true} unless the requester is the owner."
  *     security: [{bearerAuth: []}, {}]
  *     parameters:
  *       - in: path


### PR DESCRIPTION
## Summary

- Quote the `description` string in the `@openapi` JSDoc for `/user-stats/{userId}` to prevent YAML from interpreting `{isPrivate: true}` as compact mapping syntax
- Fixes the `YAMLSemanticError: Nested mappings are not allowed in compact mappings` error on server startup

## Test plan

- [x] Server starts without Swagger YAML error
- [x] `/api/docs` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)