### PR TITLE
Fix DB read amplification from firebase_history queries

### DIFF
--- a/server/__tests__/model/puzzle_solve.test.ts
+++ b/server/__tests__/model/puzzle_solve.test.ts
@@ -36,9 +36,6 @@ describe('getInProgressGames', () => {
         },
       ],
     });
-    // Third call: computeGamesProgress events query
-    pool.query.mockResolvedValueOnce({rows: []});
-
     const result = await getInProgressGames('user-123');
 
     expect(result).toEqual([
@@ -51,7 +48,7 @@ describe('getInProgressGames', () => {
         percentComplete: 0,
       },
     ]);
-    expect(pool.query).toHaveBeenCalledTimes(3);
+    expect(pool.query).toHaveBeenCalledTimes(2);
   });
 
   it('uses "Untitled" when title is null', async () => {
@@ -59,8 +56,6 @@ describe('getInProgressGames', () => {
     pool.query.mockResolvedValueOnce({
       rows: [{gid: 'game-1', pid: 'puzzle-1', title: null, size: '15x15', last_activity: null}],
     });
-    // computeGamesProgress events query
-    pool.query.mockResolvedValueOnce({rows: []});
 
     const result = await getInProgressGames('user-123');
 

--- a/server/model/game.ts
+++ b/server/model/game.ts
@@ -115,5 +115,6 @@ export async function addInitialGameEvent(gid: string, pid: string) {
       },
     },
   };
-  addGameEvent(gid, initialEvent);
+  await addGameEvent(gid, initialEvent);
+  return gid;
 }

--- a/server/model/puzzle_solve.ts
+++ b/server/model/puzzle_solve.ts
@@ -1,7 +1,6 @@
 import {PuzzleJson} from '@shared/types';
 import {pool} from './pool';
 import {dayOfWeekExtract} from './sql_helpers';
-import {computeGamesProgress} from './game_progress';
 
 export type UserSolveHistoryItem = {
   pid: string;
@@ -230,16 +229,13 @@ export async function getInProgressGames(userId: string): Promise<InProgressGame
     [dfacIds, userId]
   );
 
-  const gids = result.rows.map((r: any) => r.gid);
-  const progressMap = await computeGamesProgress(gids);
-
   return result.rows.map((r: any) => ({
     gid: r.gid,
     pid: r.pid,
     title: r.title || 'Untitled',
     size: r.size,
     lastActivity: r.last_activity ? r.last_activity.toISOString() : '',
-    percentComplete: progressMap.get(r.gid) ?? 0,
+    percentComplete: 0,
   }));
 }
 

--- a/server/model/user_games.ts
+++ b/server/model/user_games.ts
@@ -1,6 +1,5 @@
 import {pool} from './pool';
 import {getDfacIdsForUser} from './user';
-import {computeGamesProgress} from './game_progress';
 
 export type PuzzleStatusMap = {[pid: string]: 'solved' | 'started'};
 
@@ -127,8 +126,6 @@ export async function getUserGamesForPuzzle(
   );
 
   const rows: UserGameRow[] = result.rows;
-  const unsolved = rows.filter((r) => !r.solved).map((r) => r.gid);
-  const progressMap = unsolved.length > 0 ? await computeGamesProgress(unsolved) : new Map();
 
   return rows.map((r) => ({
     gid: r.gid,
@@ -136,6 +133,6 @@ export async function getUserGamesForPuzzle(
     solved: r.solved,
     time: r.last_activity ? new Date(r.last_activity).getTime() : 0,
     v2: r.v2,
-    percentComplete: r.solved ? 100 : (progressMap.get(r.gid) ?? 0),
+    percentComplete: r.solved ? 100 : 0,
   }));
 }

--- a/server/sql/adhoc/add_firebase_history_composite_indexes_3_9_26.sql
+++ b/server/sql/adhoc/add_firebase_history_composite_indexes_3_9_26.sql
@@ -1,0 +1,10 @@
+-- Add composite indexes on firebase_history to reduce read amplification.
+-- The (dfac_id, pid) index supports getUserGamesForPuzzle filtering.
+-- The (dfac_id, solved) index supports getGuestPuzzleStatuses and getInProgressGames filtering.
+-- Use CONCURRENTLY to avoid locking the table during creation.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_firebase_history_dfac_pid
+  ON firebase_history (dfac_id, pid);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_firebase_history_dfac_solved
+  ON firebase_history (dfac_id, solved);

--- a/server/sql/create_firebase_history.sql
+++ b/server/sql/create_firebase_history.sql
@@ -13,5 +13,7 @@ CREATE TABLE IF NOT EXISTS firebase_history (
 
 CREATE INDEX IF NOT EXISTS idx_firebase_history_dfac ON firebase_history (dfac_id);
 CREATE INDEX IF NOT EXISTS idx_firebase_history_pid  ON firebase_history (pid);
+CREATE INDEX IF NOT EXISTS idx_firebase_history_dfac_pid ON firebase_history (dfac_id, pid);
+CREATE INDEX IF NOT EXISTS idx_firebase_history_dfac_solved ON firebase_history (dfac_id, solved);
 
 GRANT ALL ON firebase_history TO dfacadmin;

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -181,7 +181,7 @@ function InProgressTable({inProgress, onRemove}) {
                 </Link>
               </td>
               <td>{item.size}</td>
-              <td>{item.percentComplete}%</td>
+              <td>{item.percentComplete > 0 ? `${item.percentComplete}%` : '–'}</td>
               <td>{formatDate(item.lastActivity)}</td>
               <td>
                 <Link to={`/beta/game/${item.gid}`} className="profile--replay-link" title="Resume game">


### PR DESCRIPTION
## Summary
- **Remove `computeGamesProgress` calls** from `getUserGamesForPuzzle` and `getInProgressGames` — these replayed every game event for every unsolved game on each request, causing the 5-10x read spike visible in DB metrics since March 8
- **Fix missing `await`/`return`** in `addInitialGameEvent` — race condition where game creation API responded before the DB write completed, causing "Creating game" hangs under load
- **Add composite indexes** on `firebase_history` for `(dfac_id, pid)` and `(dfac_id, solved)` to speed up the UNION queries introduced in ddfc280

## Trade-off
Percent-complete progress temporarily shows "–" on the profile page and is omitted from the Play page game list. The toolbar progress (computed client-side from loaded events) is unaffected. Persisted progress tracking will be added in a follow-up.

## Test plan
- [x] Server tests pass (191/191)
- [x] Server type check passes
- [ ] Run composite index migration on production: `server/sql/adhoc/add_firebase_history_composite_indexes_3_9_26.sql`
- [ ] Monitor DB read operations after deploy — expect significant drop
- [ ] Verify puzzle list loads quickly for guest users
- [ ] Verify game creation no longer hangs intermittently
- [ ] Verify profile page shows "–" for in-progress game progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)