### PR TITLE
Add game_events archival support

### DIFF
--- a/server/jobs/archive_game_events.ts
+++ b/server/jobs/archive_game_events.ts
@@ -1,0 +1,243 @@
+/**
+ * Automated archival/cleanup of game_events.
+ *
+ * Three categories of cleanup:
+ *   1. Solved games with snapshots (replay_retained=false) — delete all events
+ *   2. Abandoned games (no snapshot, no solve, inactive for N days) — delete all events
+ *   3. (Optional) Expire replay_retained flag after N days
+ *
+ * Usage:
+ *   # Via dotenv-cli (recommended):
+ *   dotenv -e server/.env.local -- npx ts-node -P server/tsconfig.json server/jobs/archive_game_events.ts
+ *
+ *   # Dry run:
+ *   DRY_RUN=1 dotenv -e server/.env.local -- npx ts-node -P server/tsconfig.json server/jobs/archive_game_events.ts
+ *
+ * Environment variables:
+ *   DRY_RUN            - Set to "1" for read-only mode (default: 0)
+ *   GRACE_DAYS         - Grace period for solved games in days (default: 7)
+ *   ABANDON_DAYS       - Inactivity threshold for abandoned games in days (default: 90)
+ *   BATCH_SIZE         - Max games to process per category per run (default: 1000)
+ *   DELETE_CREATE_EVENTS - Set to "1" to delete create events for solved games (default: 0)
+ *   EXPIRE_REPLAY_DAYS - Auto-expire replay_retained after N days, 0 = disabled (default: 0)
+ */
+
+import pg from 'pg';
+
+const pool = new pg.Pool({
+  host: process.env.PGHOST || 'localhost',
+  user: process.env.PGUSER || process.env.USER,
+  password: process.env.PGPASSWORD,
+  database: process.env.PGDATABASE,
+  ssl: process.env.NODE_ENV === 'production' ? {rejectUnauthorized: false} : undefined,
+});
+
+const DRY_RUN = process.env.DRY_RUN === '1';
+const BATCH_SIZE = parseInt(process.env.BATCH_SIZE || '1000', 10);
+const GRACE_DAYS = parseInt(process.env.GRACE_DAYS || '7', 10);
+const ABANDON_DAYS = parseInt(process.env.ABANDON_DAYS || '90', 10);
+const DELETE_CREATE_EVENTS = process.env.DELETE_CREATE_EVENTS === '1';
+const EXPIRE_REPLAY_DAYS = parseInt(process.env.EXPIRE_REPLAY_DAYS || '0', 10);
+
+interface CleanupStats {
+  category: string;
+  gamesProcessed: number;
+  eventsDeleted: number;
+}
+
+/**
+ * Category 1: Delete events for solved games with snapshots (replay_retained=false).
+ * When DELETE_CREATE_EVENTS is false, keeps the create event as a safety net.
+ * When DELETE_CREATE_EVENTS is true, deletes ALL events (including create) but only
+ * if the puzzle still exists in the puzzles table.
+ */
+async function cleanupSolvedGames(): Promise<CleanupStats> {
+  const stats: CleanupStats = {category: 'solved', gamesProcessed: 0, eventsDeleted: 0};
+
+  const eventTypeFilter = DELETE_CREATE_EVENTS
+    ? '' // delete all events
+    : "AND ge.event_type != 'create'"; // keep create events
+
+  // Safety: when deleting create events, only do so if the puzzle still exists
+  const puzzleExistsCheck = DELETE_CREATE_EVENTS
+    ? 'AND EXISTS (SELECT 1 FROM puzzles p WHERE p.pid = gs.pid)'
+    : '';
+
+  // Find eligible games
+  const {rows: eligible} = await pool.query(
+    `SELECT gs.gid
+     FROM game_snapshots gs
+     WHERE gs.replay_retained = false
+       AND gs.created_at < NOW() - ($1 || ' days')::interval
+       ${puzzleExistsCheck}
+       AND EXISTS (
+         SELECT 1 FROM game_events ge
+         WHERE ge.gid = gs.gid ${eventTypeFilter}
+       )
+     LIMIT $2`,
+    [String(GRACE_DAYS), BATCH_SIZE]
+  );
+
+  stats.gamesProcessed = eligible.length;
+  if (eligible.length === 0) return stats;
+
+  const gids = eligible.map((r: {gid: string}) => r.gid);
+
+  if (DRY_RUN) {
+    const {
+      rows: [{count}],
+    } = await pool.query(
+      `SELECT COUNT(*) FROM game_events ge
+       WHERE ge.gid = ANY($1) ${eventTypeFilter}`,
+      [gids]
+    );
+    stats.eventsDeleted = Number(count);
+    console.log(`  [DRY RUN] Would delete ${count} events from ${gids.length} solved games`);
+  } else {
+    const result = await pool.query(
+      `DELETE FROM game_events ge
+       WHERE ge.gid = ANY($1) ${eventTypeFilter}`,
+      [gids]
+    );
+    stats.eventsDeleted = result.rowCount || 0;
+    console.log(`  Deleted ${stats.eventsDeleted} events from ${gids.length} solved games`);
+  }
+
+  if (eligible.length === BATCH_SIZE) {
+    console.log('  Batch limit reached for solved games. Run again to process more.');
+  }
+
+  return stats;
+}
+
+/**
+ * Category 2: Delete all events for abandoned games.
+ * Abandoned = no snapshot, no puzzle_solves record, no activity for ABANDON_DAYS.
+ */
+async function cleanupAbandonedGames(): Promise<CleanupStats> {
+  const stats: CleanupStats = {category: 'abandoned', gamesProcessed: 0, eventsDeleted: 0};
+
+  const {rows: eligible} = await pool.query(
+    `SELECT ge.gid
+     FROM game_events ge
+     WHERE NOT EXISTS (SELECT 1 FROM game_snapshots gs WHERE gs.gid = ge.gid)
+       AND NOT EXISTS (SELECT 1 FROM puzzle_solves ps WHERE ps.gid = ge.gid)
+     GROUP BY ge.gid
+     HAVING MAX(ge.ts) < NOW() - ($1 || ' days')::interval
+     LIMIT $2`,
+    [String(ABANDON_DAYS), BATCH_SIZE]
+  );
+
+  stats.gamesProcessed = eligible.length;
+  if (eligible.length === 0) return stats;
+
+  const gids = eligible.map((r: {gid: string}) => r.gid);
+
+  if (DRY_RUN) {
+    const {
+      rows: [{count}],
+    } = await pool.query(`SELECT COUNT(*) FROM game_events WHERE gid = ANY($1)`, [gids]);
+    stats.eventsDeleted = Number(count);
+    console.log(`  [DRY RUN] Would delete ${count} events from ${gids.length} abandoned games`);
+  } else {
+    const result = await pool.query(`DELETE FROM game_events WHERE gid = ANY($1)`, [gids]);
+    stats.eventsDeleted = result.rowCount || 0;
+    console.log(`  Deleted ${stats.eventsDeleted} events from ${gids.length} abandoned games`);
+  }
+
+  if (eligible.length === BATCH_SIZE) {
+    console.log('  Batch limit reached for abandoned games. Run again to process more.');
+  }
+
+  return stats;
+}
+
+/**
+ * Category 3: Auto-expire replay_retained flag after EXPIRE_REPLAY_DAYS.
+ * Disabled by default (EXPIRE_REPLAY_DAYS=0).
+ */
+async function expireReplayRetention(): Promise<number> {
+  if (EXPIRE_REPLAY_DAYS <= 0) return 0;
+
+  if (DRY_RUN) {
+    const {
+      rows: [{count}],
+    } = await pool.query(
+      `SELECT COUNT(*) FROM game_snapshots
+       WHERE replay_retained = true
+         AND created_at < NOW() - ($1 || ' days')::interval`,
+      [String(EXPIRE_REPLAY_DAYS)]
+    );
+    console.log(`  [DRY RUN] Would expire replay_retained for ${count} games`);
+    return Number(count);
+  }
+
+  const result = await pool.query(
+    `UPDATE game_snapshots
+     SET replay_retained = false
+     WHERE replay_retained = true
+       AND created_at < NOW() - ($1 || ' days')::interval`,
+    [String(EXPIRE_REPLAY_DAYS)]
+  );
+  const expired = result.rowCount || 0;
+  if (expired > 0) {
+    console.log(`  Expired replay_retained for ${expired} games`);
+  }
+  return expired;
+}
+
+async function main() {
+  console.log('=== Game Events Archive Job ===');
+  console.log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
+  console.log(`Settings: GRACE_DAYS=${GRACE_DAYS}, ABANDON_DAYS=${ABANDON_DAYS}, BATCH_SIZE=${BATCH_SIZE}`);
+  console.log(`  DELETE_CREATE_EVENTS=${DELETE_CREATE_EVENTS}, EXPIRE_REPLAY_DAYS=${EXPIRE_REPLAY_DAYS}`);
+  console.log('');
+
+  // Category 3 first — expire replays so they become eligible for Category 1
+  console.log('--- Category 3: Replay retention expiry ---');
+  const expired = await expireReplayRetention();
+  if (expired === 0 && EXPIRE_REPLAY_DAYS <= 0) {
+    console.log('  Disabled (EXPIRE_REPLAY_DAYS=0)');
+  } else if (expired === 0) {
+    console.log('  No replays to expire.');
+  }
+  console.log('');
+
+  // Category 1 — solved games with snapshots
+  console.log('--- Category 1: Solved games with snapshots ---');
+  const solvedStats = await cleanupSolvedGames();
+  if (solvedStats.gamesProcessed === 0) {
+    console.log('  Nothing to clean up.');
+  }
+  console.log('');
+
+  // Category 2 — abandoned games
+  console.log('--- Category 2: Abandoned games ---');
+  const abandonedStats = await cleanupAbandonedGames();
+  if (abandonedStats.gamesProcessed === 0) {
+    console.log('  Nothing to clean up.');
+  }
+  console.log('');
+
+  // Summary
+  console.log('=== Summary ===');
+  console.log(
+    `Solved: ${solvedStats.gamesProcessed} games, ${solvedStats.eventsDeleted} events ${DRY_RUN ? '(would be)' : ''} deleted`
+  );
+  console.log(
+    `Abandoned: ${abandonedStats.gamesProcessed} games, ${abandonedStats.eventsDeleted} events ${DRY_RUN ? '(would be)' : ''} deleted`
+  );
+  if (EXPIRE_REPLAY_DAYS > 0) {
+    console.log(`Replay expirations: ${expired}`);
+  }
+  console.log(
+    `Total: ${solvedStats.eventsDeleted + abandonedStats.eventsDeleted} events ${DRY_RUN ? '(would be)' : ''} deleted`
+  );
+
+  await pool.end();
+}
+
+main().catch((e) => {
+  console.error('Fatal error:', e);
+  process.exit(1);
+});

--- a/server/model/game.ts
+++ b/server/model/game.ts
@@ -4,6 +4,55 @@ import {pool} from './pool';
 import {getPuzzle} from './puzzle';
 import {getGameSnapshot} from './game_snapshot';
 
+/**
+ * Build a synthetic create event from the puzzles table + snapshot.
+ * Used when the create event has been archived/deleted but the snapshot and puzzle still exist.
+ */
+async function buildCreateEventFromPuzzle(pid: string, snapshot: any): Promise<any | null> {
+  const puzzle = await getPuzzle(pid);
+  if (!puzzle) return null;
+
+  const {
+    info = {},
+    grid: solution = [['']],
+    circles = [],
+    shades = [],
+    images = {},
+    contest = false,
+  } = puzzle;
+
+  const gridObject = makeGrid(solution, images);
+  const clues = gridObject.alignClues(puzzle.clues);
+  const grid = gridObject.toArray();
+  const snap = snapshot as any;
+
+  return {
+    user: '',
+    timestamp: 0,
+    type: 'create',
+    params: {
+      pid,
+      version: 1.0,
+      game: {
+        info,
+        grid: snap.grid || grid,
+        solution,
+        circles,
+        shades,
+        ...(Object.keys(images).length > 0 ? {images} : {}),
+        ...(contest ? {contest} : {}),
+        chat: snap.chat || {messages: []},
+        cursor: {},
+        clock: snap.clock || {lastUpdated: 0, totalTime: 0, trueTotalTime: 0, paused: true},
+        users: snap.users || {},
+        solved: true,
+        ...(contest ? {contestSolved: true} : {}),
+        clues,
+      },
+    },
+  };
+}
+
 export async function getGameEvents(gid: string) {
   // Check for a snapshot FIRST — if a non-replay snapshot exists, we only need
   // the create event (1 row) instead of loading the entire event history.
@@ -27,6 +76,10 @@ export async function getGameEvents(gid: string) {
       if (game.contest) game.contestSolved = true;
       return [createEvent];
     }
+
+    // Create event was archived — reconstruct from puzzles table
+    const syntheticEvent = await buildCreateEventFromPuzzle(snapshot.pid, snapshot.snapshot);
+    if (syntheticEvent) return [syntheticEvent];
   }
 
   // No snapshot or replay retained — load all events
@@ -38,11 +91,18 @@ export async function getGameInfo(gid: string) {
   const res = await pool.query("SELECT event_payload FROM game_events WHERE gid=$1 AND event_type='create'", [
     gid,
   ]);
-  if (res.rowCount !== 1) {
-    return {};
+  if (res.rowCount === 1) {
+    return res.rows[0].event_payload.params.game.info;
   }
 
-  return res.rows[0].event_payload.params.game.info;
+  // Create event was archived — fall back to puzzles table via snapshot pid
+  const snapshot = await getGameSnapshot(gid);
+  if (snapshot) {
+    const puzzle = await getPuzzle(snapshot.pid);
+    if (puzzle) return puzzle.info || {};
+  }
+
+  return {};
 }
 
 export interface GameEvent {

--- a/server/model/user_games.ts
+++ b/server/model/user_games.ts
@@ -17,16 +17,16 @@ export async function getGuestPuzzleStatuses(dfacId: string): Promise<PuzzleStat
      FROM (
        -- v2 games from game_events
        SELECT
-         ce.event_payload->'params'->>'pid' AS pid,
+         COALESCE(ce.event_payload->'params'->>'pid', gs.pid) AS pid,
          gs.gid IS NOT NULL AS solved
        FROM (
          SELECT gid FROM game_events WHERE uid = $1
          UNION
          SELECT gid FROM game_events WHERE (event_payload->'params'->>'id') = $1
        ) user_gids
-       JOIN game_events ce ON ce.gid = user_gids.gid AND ce.event_type = 'create'
+       LEFT JOIN game_events ce ON ce.gid = user_gids.gid AND ce.event_type = 'create'
        LEFT JOIN game_snapshots gs ON gs.gid = user_gids.gid
-       WHERE ce.event_payload->'params'->>'pid' IS NOT NULL
+       WHERE COALESCE(ce.event_payload->'params'->>'pid', gs.pid) IS NOT NULL
 
        UNION ALL
 
@@ -117,14 +117,14 @@ export async function getUserGamesForPuzzle(
      )
      SELECT
        ug.gid,
-       COALESCE(ce.event_payload->'params'->>'pid', $2) AS pid,
+       COALESCE(ce.event_payload->'params'->>'pid', gs.pid, $2) AS pid,
        CASE WHEN gs.gid IS NOT NULL OR ug.fh_solved THEN true ELSE false END AS solved,
        ug.last_activity,
        ug.v2
      FROM user_games ug
      LEFT JOIN game_events ce ON ce.gid = ug.gid AND ce.event_type = 'create'
      LEFT JOIN game_snapshots gs ON gs.gid = ug.gid
-     WHERE COALESCE(ce.event_payload->'params'->>'pid', $2) = $2
+     WHERE COALESCE(ce.event_payload->'params'->>'pid', gs.pid, $2) = $2
      ORDER BY ug.last_activity DESC`,
     options.userId ? [dfacIds, pid, options.userId, pidInt] : [dfacIds, pid, pidInt]
   );

--- a/server/sql/adhoc/game_events_assessment.sql
+++ b/server/sql/adhoc/game_events_assessment.sql
@@ -1,0 +1,55 @@
+-- Game Events Assessment Queries
+-- Run these on production (read-only) before implementing archival.
+-- They help understand data distribution and potential savings.
+
+-- 1a. Event distribution by type and size
+SELECT event_type, COUNT(*) AS event_count,
+       pg_size_pretty(SUM(pg_column_size(event_payload)::bigint)) AS payload_size
+FROM game_events GROUP BY event_type ORDER BY event_count DESC;
+
+-- 1b. Game states overview
+SELECT
+  COUNT(DISTINCT ge.gid) AS total_games,
+  COUNT(DISTINCT gs.gid) AS with_snapshots,
+  COUNT(DISTINCT CASE WHEN gs.replay_retained = false THEN gs.gid END) AS snapshot_no_replay,
+  COUNT(DISTINCT CASE WHEN gs.replay_retained = true THEN gs.gid END) AS snapshot_with_replay
+FROM (SELECT DISTINCT gid FROM game_events) ge
+LEFT JOIN game_snapshots gs ON gs.gid = ge.gid;
+
+-- 1c. Create event sizes for snapshotted games (savings from eliminating them)
+SELECT COUNT(*) AS count,
+       pg_size_pretty(SUM(pg_column_size(event_payload)::bigint)) AS total_size,
+       pg_size_pretty(AVG(pg_column_size(event_payload)::bigint)::bigint) AS avg_size
+FROM game_events
+WHERE event_type = 'create'
+  AND gid IN (SELECT gid FROM game_snapshots WHERE replay_retained = false);
+
+-- 1d. Abandoned games by staleness (no snapshot, no solve)
+SELECT
+  CASE
+    WHEN max_ts < NOW() - INTERVAL '90 days' THEN '90+ days'
+    WHEN max_ts < NOW() - INTERVAL '60 days' THEN '60-90 days'
+    WHEN max_ts < NOW() - INTERVAL '30 days' THEN '30-60 days'
+    ELSE 'active (<30 days)'
+  END AS staleness,
+  COUNT(*) AS game_count, SUM(event_count) AS total_events
+FROM (
+  SELECT ge.gid, MAX(ge.ts) AS max_ts, COUNT(*) AS event_count
+  FROM game_events ge
+  WHERE NOT EXISTS (SELECT 1 FROM game_snapshots gs WHERE gs.gid = ge.gid)
+    AND NOT EXISTS (SELECT 1 FROM puzzle_solves ps WHERE ps.gid = ge.gid)
+  GROUP BY ge.gid
+) stale GROUP BY 1 ORDER BY 1;
+
+-- 1e. Solved games without snapshots (need backfill first)
+SELECT COUNT(DISTINCT ps.gid) AS solves_without_snapshots
+FROM puzzle_solves ps
+WHERE NOT EXISTS (SELECT 1 FROM game_snapshots gs WHERE gs.gid = ps.gid);
+
+-- 1f. Table sizes
+SELECT relname, pg_size_pretty(pg_total_relation_size(oid)) AS total_size,
+       pg_size_pretty(pg_relation_size(oid)) AS table_size,
+       pg_size_pretty(pg_indexes_size(oid)) AS index_size
+FROM pg_class
+WHERE relname IN ('game_events', 'game_snapshots', 'puzzle_solves', 'puzzles', 'firebase_history')
+ORDER BY pg_total_relation_size(oid) DESC;


### PR DESCRIPTION
## Summary
- Make code resilient to missing create events so game_events can be fully archived for solved games with snapshots
- `getGameEvents()` reconstructs from puzzles table when create event is missing
- `getGameInfo()` falls back to puzzle info via snapshot pid
- `getGuestPuzzleStatuses()` and `getUserGamesForPuzzle()` use COALESCE with game_snapshots.pid
- New `archive_game_events.ts` job with three cleanup categories (solved, abandoned, replay expiry)
- Assessment queries for production data analysis

## Context
game_events is 19 GB (15 GB data + 2.4 GB indexes). 405K of 591K games have snapshots and are eligible for cleanup. Create events alone account for 1.4 GB for snapshotted games. This PR makes the code resilient to their removal, enabling future cleanup runs.

## Test plan
- [x] Server type check passes
- [x] All 191 server tests pass
- [x] All 354 frontend tests pass
- [ ] Deploy and verify solved games still load correctly
- [ ] Run archive job with `DRY_RUN=1` to preview cleanup
- [ ] Run backfill_snapshots.js for 1,762 solved games without snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)