### PR TITLE
Add /api/version endpoint and fix deploy-test polling

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -28,18 +28,20 @@ jobs:
     name: Wait for deploy to be live
     runs-on: ubuntu-latest
     steps:
-      - name: Poll health endpoint
+      - name: Wait for new version to be deployed
         run: |
-          echo "Waiting for $BASE_URL to be reachable..."
-          for i in $(seq 1 60); do
-            if curl -sf "$BASE_URL/api/puzzle_list?page=0&pageSize=1" > /dev/null 2>&1; then
-              echo "Site is live"
+          EXPECTED_SHA="${GITHUB_SHA}"
+          echo "Waiting for $BASE_URL to serve commit $EXPECTED_SHA..."
+          for i in $(seq 1 120); do
+            DEPLOYED_SHA=$(curl -sf "$BASE_URL/api/version" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('sha',''))" 2>/dev/null || echo "")
+            if [ "$DEPLOYED_SHA" = "$EXPECTED_SHA" ]; then
+              echo "New version is live!"
               exit 0
             fi
-            echo "Attempt $i — not ready yet"
-            sleep 5
+            echo "Attempt $i — got '$DEPLOYED_SHA', waiting for '$EXPECTED_SHA'"
+            sleep 10
           done
-          echo "Site did not become ready in time"
+          echo "Deploy did not complete within 20 minutes"
           exit 1
 
   seed-testing-db:

--- a/server/server.ts
+++ b/server/server.ts
@@ -66,6 +66,13 @@ if (process.env.NODE_ENV === 'production') {
   app.use(morgan('tiny'));
 }
 
+app.get('/api/version', (_req, res) => {
+  res.json({
+    sha: process.env.RENDER_GIT_COMMIT || process.env.GIT_SHA || 'unknown',
+    env: process.env.NODE_ENV || 'development',
+  });
+});
+
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use('/api', apiRouter);
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/version` endpoint that returns the deployed git SHA (via Render's `RENDER_GIT_COMMIT` env var)
- Fixes the post-deploy test workflow to poll `/api/version` until the deployed SHA matches the triggering commit, instead of just checking if the site is reachable (which passes immediately for the old version)

## Setup needed
After merging, add `TESTING_DB_URL` GitHub secret (Render testing DB external connection string) to activate the post-deploy workflow.

## Test plan
- [ ] Verify `/api/version` returns `{"sha":"unknown","env":"development"}` locally
- [ ] Confirm deploy-tests workflow doesn't trigger until secret is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)