### PR TITLE
Set seed puzzles to is_public=true

### DIFF
--- a/loadtest/seed.sql
+++ b/loadtest/seed.sql
@@ -51,7 +51,7 @@ FROM generate_series(1, 200) AS i;
 INSERT INTO puzzles (pid, is_public, uploaded_at, content, uploaded_by, content_hash)
 SELECT
   'lt-mini-' || i,
-  false,
+  true,
   NOW() - (random() * interval '365 days'),
   jsonb_build_object(
     'grid', (SELECT jsonb_agg(
@@ -99,7 +99,7 @@ FROM generate_series(1, 200) AS i;
 INSERT INTO puzzles (pid, is_public, uploaded_at, content, uploaded_by, content_hash)
 SELECT
   'lt-std-' || i,
-  false,
+  true,
   NOW() - (random() * interval '365 days'),
   jsonb_build_object(
     'grid', (SELECT jsonb_agg(
@@ -142,7 +142,7 @@ FROM generate_series(1, 250) AS i;
 INSERT INTO puzzles (pid, is_public, uploaded_at, content, uploaded_by, content_hash)
 SELECT
   'lt-lg-' || i,
-  false,
+  true,
   NOW() - (random() * interval '365 days'),
   jsonb_build_object(
     'grid', (SELECT jsonb_agg(


### PR DESCRIPTION
## Summary
- Set load test seed puzzles back to `is_public=true` so they appear in the puzzle list
- The pid-as-string fix in PR #403 means non-numeric PIDs work correctly now — no need to hide them
- Fixes the E2E smoke test failure in the deploy-tests workflow where searching for "Mini" found no results

## Test plan
- [x] Verified locally that seed puzzles appear in puzzle list
- [ ] Deploy-tests workflow Playwright smoke tests pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)