### PR TITLE
Fix Sentry crashes: out-of-bounds scope and empty replay history

### DIFF
--- a/src/lib/reducers/__tests__/game.test.js
+++ b/src/lib/reducers/__tests__/game.test.js
@@ -375,6 +375,103 @@ describe('reduce — solved detection with image cells', () => {
   });
 });
 
+describe('reduce — check/reveal/reset with out-of-bounds scope', () => {
+  it('check ignores scope coordinates beyond grid dimensions', () => {
+    let game = makeGame(); // 2x2 grid
+    game = reduce(game, {
+      type: 'updateCell',
+      timestamp: 2000,
+      params: {cell: {r: 0, c: 0}, value: 'A', id: 'u1'},
+    });
+    // Scope includes an out-of-bounds row (r=5 on a 2-row grid)
+    game = reduce(game, {
+      type: 'check',
+      timestamp: 3000,
+      params: {
+        scope: [
+          {r: 0, c: 0},
+          {r: 5, c: 0},
+        ],
+      },
+    });
+    // The in-bounds cell should still be checked correctly
+    expect(game.grid[0][0].good).toBe(true);
+  });
+
+  it('check ignores scope coordinates with out-of-bounds column', () => {
+    let game = makeGame(); // 2x2 grid
+    game = reduce(game, {
+      type: 'updateCell',
+      timestamp: 2000,
+      params: {cell: {r: 0, c: 0}, value: 'A', id: 'u1'},
+    });
+    game = reduce(game, {
+      type: 'check',
+      timestamp: 3000,
+      params: {
+        scope: [
+          {r: 0, c: 0},
+          {r: 0, c: 10},
+        ],
+      },
+    });
+    expect(game.grid[0][0].good).toBe(true);
+  });
+
+  it('reveal ignores out-of-bounds scope coordinates', () => {
+    let game = makeGame(); // 2x2 grid
+    game = reduce(game, {
+      type: 'reveal',
+      timestamp: 2000,
+      params: {
+        scope: [
+          {r: 0, c: 0},
+          {r: 99, c: 99},
+        ],
+      },
+    });
+    expect(game.grid[0][0].value).toBe('A');
+    expect(game.grid[0][0].good).toBe(true);
+  });
+
+  it('reset ignores out-of-bounds scope coordinates', () => {
+    let game = makeGame();
+    game = reduce(game, {
+      type: 'updateCell',
+      timestamp: 2000,
+      params: {cell: {r: 0, c: 0}, value: 'A', id: 'u1'},
+    });
+    game = reduce(game, {
+      type: 'reset',
+      timestamp: 3000,
+      params: {
+        scope: [
+          {r: 0, c: 0},
+          {r: 5, c: 0},
+        ],
+      },
+    });
+    expect(game.grid[0][0].value).toBe('');
+  });
+
+  it('check with entirely out-of-bounds scope does not crash', () => {
+    let game = makeGame();
+    // All scope coordinates are out of bounds
+    game = reduce(game, {
+      type: 'check',
+      timestamp: 2000,
+      params: {
+        scope: [
+          {r: 10, c: 10},
+          {r: -1, c: 0},
+        ],
+      },
+    });
+    // Game should be returned unchanged (no crash)
+    expect(game.grid[0][0].good).toBeFalsy();
+  });
+});
+
 describe('reduce — contest puzzles', () => {
   function makeContestGame() {
     return makeGame({

--- a/src/lib/reducers/game.js
+++ b/src/lib/reducers/game.js
@@ -6,7 +6,9 @@ import {MAIN_BLUE_3} from '../colors';
 function getScopeGrid(grid, scope) {
   const scopeGrid = grid.map((row) => row.map(() => false));
   scope.forEach(({r, c}) => {
-    scopeGrid[r][c] = true;
+    if (r >= 0 && r < grid.length && c >= 0 && c < grid[r].length) {
+      scopeGrid[r][c] = true;
+    }
   });
   return scopeGrid;
 }

--- a/src/pages/Replay.js
+++ b/src/pages/Replay.js
@@ -85,6 +85,7 @@ class Replay extends Component {
   }
 
   handleSetPosition = (position, isAutoplay = false) => {
+    if (this.state.history.length === 0) return;
     const clampedPosition = Math.min(
       position,
       this.state.history[this.state.history.length - 1].gameTimestamp


### PR DESCRIPTION
## Summary
- **JAVASCRIPT-REACT-1S** (136 events, 5 users): `getScopeGrid` in game reducer now bounds-checks `r`/`c` before grid access, fixing `TypeError: Cannot set properties of undefined` when check/reveal/reset actions replay with stale scope coordinates from a different grid size
- **JAVASCRIPT-REACT-W** (2 events, 2 users): `Replay.handleSetPosition` guards against empty `history` array before accessing the last element, fixing `TypeError: Cannot read properties of undefined (reading 'gameTimestamp')`

## Test plan
- [x] 5 new unit tests for out-of-bounds scope (row, column, combined, all-OOB, reveal, reset)
- [x] All 359 frontend tests pass
- [x] ESLint, Prettier clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)