### PR TITLE
Fix undici security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
       "serialize-javascript": "^7.0.3",
       "diff": "^5.2.0",
       "glob": "^13.0.6",
-      "test-exclude>glob": "7"
+      "test-exclude>glob": "7",
+      "undici": ">=7.24.0"
     },
     "onlyBuiltDependencies": [
       "bcrypt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   diff: ^5.2.0
   glob: ^13.0.6
   test-exclude>glob: '7'
+  undici: '>=7.24.0'
 
 importers:
 
@@ -5783,8 +5784,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.3:
+    resolution: {integrity: sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -10848,7 +10849,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.22.0
+      undici: 7.24.3
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -12402,7 +12403,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.22.0: {}
+  undici@7.24.3: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- Override `undici` to `>=7.24.0` via pnpm overrides to fix 7 vulnerabilities (4 high, 3 moderate)
- Vulnerabilities are in the transitive chain `jsdom -> undici` (dev-only dependency used by vitest)
- `jsdom` hasn't released a patched version yet, so the override is the cleanest fix

## Advisories resolved
- GHSA-2mjp-6q6p-2qxm
- GHSA-4992-7rv2-5pvq
- GHSA-phc3-fgpg-7m6h
- Plus 4 additional high-severity undici advisories

## Test plan
- [ ] CI Security Audit passes
- [ ] Frontend tests still pass (jsdom/vitest unaffected by patch bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)