### PR TITLE
Fix flatted security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
       "diff": "^5.2.0",
       "glob": "^13.0.6",
       "test-exclude>glob": "7",
-      "undici": ">=7.24.0"
+      "undici": ">=7.24.0",
+      "flatted": ">=3.4.0"
     },
     "onlyBuiltDependencies": [
       "bcrypt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   glob: ^13.0.6
   test-exclude>glob: '7'
   undici: '>=7.24.0'
+  flatted: '>=3.4.0'
 
 importers:
 
@@ -3712,8 +3713,8 @@ packages:
   flat-cache@6.1.20:
     resolution: {integrity: sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==}
 
-  flatted@3.3.4:
-    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -9993,16 +9994,16 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.4
+      flatted: 3.4.1
       keyv: 4.5.4
 
   flat-cache@6.1.20:
     dependencies:
       cacheable: 2.3.3
-      flatted: 3.3.4
+      flatted: 3.4.1
       hookified: 1.15.1
 
-  flatted@3.3.4: {}
+  flatted@3.4.1: {}
 
   follow-redirects@1.15.11: {}
 


### PR DESCRIPTION
## Summary
- Override `flatted` to `>=3.4.0` via pnpm overrides to fix high-severity unbounded recursion DoS in `parse()` 
- Transitive dep via `eslint > file-entry-cache > flat-cache > flatted` (dev-only)
- Advisory: GHSA-25h7-pfq9-p65f

## Test plan
- [ ] CI Security Audit passes (`pnpm audit` returns 0 vulnerabilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)