### PR TITLE
Show direct puzzle link on all upload success states

### DIFF
--- a/src/components/Upload/Upload.js
+++ b/src/components/Upload/Upload.js
@@ -80,7 +80,7 @@ export default class Upload extends Component {
         uploading: false,
       });
     } else {
-      const url = `/beta/play/${this.state.recentUnlistedPid}${this.props.fencing ? '?fencing=1' : ''}`;
+      const url = `/beta/play/${response.pid}${this.props.fencing ? '?fencing=1' : ''}`;
       this.setState({
         modal: {type: 'success', url, message: 'Successfully created an unlisted puzzle.'},
         uploading: false,


### PR DESCRIPTION
## Summary
- Show a direct link to the puzzle on all upload success modals (new public, new unlisted, duplicate)
- Previously new public puzzles only said "view on the home page" — but the puzzle list is cached (5 min TTL) so it wouldn't show up immediately
- Add note that it may take a few minutes to appear on the home page for everyone
- Simplified success modal rendering to consistently show message + link

## Test plan
- [ ] Upload a new public puzzle → modal shows link + cache delay message
- [ ] Upload a new unlisted puzzle → modal shows link + unlisted message
- [ ] Upload a duplicate puzzle → modal shows link (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)