### PR TITLE
Reduce Sentry log volume: drop console.log, lower trace rate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,9 @@ if (sentryDsn) {
     integrations: [
       Sentry.browserTracingIntegration(),
       Sentry.replayIntegration(),
-      Sentry.consoleLoggingIntegration({levels: ['log', 'warn', 'error']}),
+      Sentry.consoleLoggingIntegration({levels: ['warn', 'error']}),
     ],
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 0.1,
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0,
     ignoreErrors: [


### PR DESCRIPTION
## Summary
- Remove `log` from `consoleLoggingIntegration` levels (keep `warn` and `error` only)
- Lower `tracesSampleRate` from `1.0` (100%) to `0.1` (10%)
- Currently ingesting ~10GB/day in Sentry logs, mostly from `console.log` capture

## Test plan
- [ ] Deploy and monitor Sentry log volume over 24h
- [ ] Verify warn/error logs still appear in Sentry
- [ ] Verify errors/issues are still captured normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)