### PR TITLE
Disable session replays, reduce error replay rate to 50%

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,8 @@ if (sentryDsn) {
       Sentry.consoleLoggingIntegration({levels: ['warn', 'error']}),
     ],
     tracesSampleRate: 0.1,
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 0.5,
     ignoreErrors: [
       // Network failures (Safari / Chrome / Firefox) — client-side connectivity issues
       /^TypeError: Load failed$/,


### PR DESCRIPTION
## Summary
- Disable random session replay recording (0.1 → 0)
- Reduce error replay capture from 100% to 50%
- Follows up on #422 to further reduce Sentry ingestion volume

## Test plan
- [ ] Monitor Sentry replay volume over 24h
- [ ] Verify error replays still capture on errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)