### PR TITLE
Fix CI workflows for fork compatibility

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -55,7 +55,12 @@ jobs:
       - name: Seed load test data
         env:
           DATABASE_URL: ${{ secrets.TESTING_DB_URL }}
-        run: psql "$DATABASE_URL" -f loadtest/seed.sql
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "Skipping — TESTING_DB_URL secret not configured (fork?)"
+            exit 0
+          fi
+          psql "$DATABASE_URL" -f loadtest/seed.sql
 
   playwright:
     name: Playwright E2E

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/scaleovenstove/crosswithfriends
+          images: ghcr.io/${{ github.repository_owner }}/crosswithfriends
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}


### PR DESCRIPTION
Closes #421

## Summary
- **Docker Publish**: Use `github.repository_owner` instead of hardcoded `scaleovenstove` so forks push to their own GHCR namespace
- **Deploy Tests**: Skip database seed gracefully when `TESTING_DB_URL` secret is missing (forks don't have it)

## Test plan
- [ ] Fork contributor confirms Docker publish succeeds
- [ ] Fork contributor confirms deploy tests don't fail on missing secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)