### PR TITLE
Fix grid not shrinking when zooming out on desktop

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -387,7 +387,10 @@ export default class Game extends Component {
       // Reserved space: nav (~41px) + toolbar (~30px) + clue bar (~44px) + padding (~24px) + margin (~46px)
       const DESKTOP_CHROME_HEIGHT = 185;
       const availableHeight = window.innerHeight - DESKTOP_CHROME_HEIGHT;
-      width = Math.min((availableHeight * cols) / rows, screenWidth - 20);
+      const viewportWidth = (availableHeight * cols) / rows;
+      // Cap at the old fixed sizing so zooming out shrinks the grid as expected
+      const fixedWidth = (35 * 15 * cols) / rows;
+      width = Math.min(viewportWidth, fixedWidth, screenWidth - 20);
     }
     const minSize = this.props.mobile ? 1 : 20;
     const size = Math.max(minSize, width / cols);


### PR DESCRIPTION
Closes #426

## Summary
- The viewport-based grid sizing from #414 made the grid grow to fill `window.innerHeight`, which increases when the user zooms out
- Now caps grid width at the old fixed formula (`35 * 15 * cols / rows`) so zooming out shrinks the grid as before
- The viewport-based sizing still applies as a lower bound, preventing overflow on small screens

## How it works
Takes the minimum of three values:
- Viewport-based width (prevents overflow on small screens)
- Fixed formula width (prevents grid from growing when zooming out)
- Available screen width minus padding

## Test plan
- [ ] At 100% zoom: grid fills available height (same as before)
- [ ] At 75% zoom: grid shrinks, clues visible without scrolling
- [ ] On small screen: grid doesn't overflow
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)