### PR TITLE
Simplify archive job: drop GRACE_DAYS and puzzle_solves join

### DIFF
--- a/server/jobs/archive_game_events.ts
+++ b/server/jobs/archive_game_events.ts
@@ -15,7 +15,6 @@
  *
  * Environment variables:
  *   DRY_RUN            - Set to "1" for read-only mode (default: 0)
- *   GRACE_DAYS         - Grace period after solve before deleting events, in days (default: 1)
  *   ABANDON_DAYS       - Inactivity threshold for abandoned games in days (default: 90)
  *   EXPIRE_REPLAY_DAYS - Auto-expire replay_retained after N days, 0 = disabled (default: 0)
  */
@@ -32,7 +31,6 @@ const pool = new pg.Pool({
 });
 
 const DRY_RUN = process.env.DRY_RUN === '1';
-const GRACE_DAYS = parseInt(process.env.GRACE_DAYS || '1', 10);
 const ABANDON_DAYS = parseInt(process.env.ABANDON_DAYS || '90', 10);
 const EXPIRE_REPLAY_DAYS = parseInt(process.env.EXPIRE_REPLAY_DAYS || '0', 10);
 
@@ -58,11 +56,8 @@ async function cleanupSolvedGames(): Promise<CleanupStats> {
          COUNT(*) AS events
        FROM game_events ge
        INNER JOIN game_snapshots gs ON gs.gid = ge.gid
-       INNER JOIN puzzle_solves ps ON ps.gid = ge.gid
        WHERE gs.replay_retained = false
-         AND ps.solved_time < NOW() - ($1 || ' days')::interval
-         AND ge.event_type != 'create'`,
-      [String(GRACE_DAYS)]
+         AND ge.event_type != 'create'`
     );
     stats.gamesProcessed = Number(games);
     stats.eventsDeleted = Number(events);
@@ -72,13 +67,10 @@ async function cleanupSolvedGames(): Promise<CleanupStats> {
 
   const result = await pool.query(
     `DELETE FROM game_events ge
-     USING game_snapshots gs, puzzle_solves ps
+     USING game_snapshots gs
      WHERE gs.gid = ge.gid
-       AND ps.gid = ge.gid
        AND gs.replay_retained = false
-       AND ps.solved_time < NOW() - ($1 || ' days')::interval
-       AND ge.event_type != 'create'`,
-    [String(GRACE_DAYS)]
+       AND ge.event_type != 'create'`
   );
   stats.eventsDeleted = result.rowCount || 0;
   console.log(`  Deleted ${stats.eventsDeleted} events from solved games`);
@@ -177,7 +169,7 @@ async function expireReplayRetention(): Promise<number> {
 async function main() {
   console.log('=== Game Events Archive Job ===');
   console.log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
-  console.log(`Settings: GRACE_DAYS=${GRACE_DAYS}, ABANDON_DAYS=${ABANDON_DAYS}`);
+  console.log(`Settings: ABANDON_DAYS=${ABANDON_DAYS}`);
   console.log(`  EXPIRE_REPLAY_DAYS=${EXPIRE_REPLAY_DAYS}`);
   console.log('');
 


### PR DESCRIPTION
## Summary
- Removes `GRACE_DAYS` config and `puzzle_solves` join from the solved games cleanup query
- The query now matches what we've been running successfully in pgadmin:
  ```sql
  DELETE FROM game_events ge
  USING game_snapshots gs
  WHERE gs.gid = ge.gid
    AND gs.replay_retained = false
    AND ge.event_type != 'create'
  ```
- The previous query joined `puzzle_solves` which excluded snapshotted games without solve records, leaving ~700k+ rows uncleaned
- If a game has a snapshot with `replay_retained=false`, the events are safe to delete

## Test plan
- [ ] Run archive job with `DRY_RUN=1` and verify count matches pgadmin
- [ ] Run archive job live and confirm it cleans up the bulk of eligible events
- [ ] Remove `GRACE_DAYS` env var from Render cron job config

🤖 Generated with [Claude Code](https://claude.com/claude-code)