### PR TITLE
Add daily cron job to clean up copyrighted puzzles

### DIFF
--- a/server/jobs/cleanup_copyrighted_puzzles.ts
+++ b/server/jobs/cleanup_copyrighted_puzzles.ts
@@ -1,6 +1,9 @@
 /**
  * Delete public puzzles that contain copyrighted content (e.g. New Yorker).
  *
+ * Matches against puzzle info fields (title, author, copyright) rather than
+ * the entire content blob to avoid false positives from clue text.
+ *
  * Usage:
  *   dotenv -e server/.env.local -- npx ts-node -P server/tsconfig.json server/jobs/cleanup_copyrighted_puzzles.ts
  *
@@ -10,18 +13,39 @@
 
 import pg from 'pg';
 
+pg.types.setTypeParser(1114, (str: string) => new Date(str + 'Z'));
+
+const getSslConfig = () => {
+  if (process.env.PGSSL === 'disable') return undefined;
+  if (process.env.NODE_ENV === 'production') return {rejectUnauthorized: false};
+  return undefined;
+};
+
 const pool = new pg.Pool({
   host: process.env.PGHOST || 'localhost',
   user: process.env.PGUSER || process.env.USER,
   password: process.env.PGPASSWORD,
   database: process.env.PGDATABASE,
-  ssl: process.env.NODE_ENV === 'production' ? {rejectUnauthorized: false} : undefined,
+  ssl: getSslConfig(),
   statement_timeout: 120000,
+});
+
+pool.on('connect', (client) => {
+  client.query("SET timezone = 'UTC'").catch((err) => {
+    console.error('Failed to set timezone for new connection.', err);
+  });
 });
 
 const DRY_RUN = process.env.DRY_RUN === '1';
 
 const BLOCKED_PATTERNS = ['%New Yorker%'];
+
+const MATCH_CLAUSE = `
+  is_public = true AND (
+    content->'info'->>'title' ILIKE $1
+    OR content->'info'->>'author' ILIKE $1
+    OR content->'info'->>'copyright' ILIKE $1
+  )`;
 
 async function main() {
   console.log('=== Copyrighted Puzzle Cleanup ===');
@@ -34,16 +58,11 @@ async function main() {
     if (DRY_RUN) {
       const {
         rows: [{count}],
-      } = await pool.query(`SELECT COUNT(*) FROM puzzles WHERE is_public = true AND content::text ILIKE $1`, [
-        pattern,
-      ]);
+      } = await pool.query(`SELECT COUNT(*) FROM puzzles WHERE ${MATCH_CLAUSE}`, [pattern]);
       console.log(`  [DRY RUN] Would delete ${count} puzzles matching "${pattern}"`);
       totalDeleted += Number(count);
     } else {
-      const result = await pool.query(
-        `DELETE FROM puzzles WHERE is_public = true AND content::text ILIKE $1`,
-        [pattern]
-      );
+      const result = await pool.query(`DELETE FROM puzzles WHERE ${MATCH_CLAUSE}`, [pattern]);
       const deleted = result.rowCount || 0;
       console.log(`  Deleted ${deleted} puzzles matching "${pattern}"`);
       totalDeleted += deleted;


### PR DESCRIPTION
## Summary
- Adds `server/jobs/cleanup_copyrighted_puzzles.ts` — standalone job that deletes public puzzles matching blocked content patterns (e.g. New Yorker)
- Supports `DRY_RUN=1` for safe testing
- `BLOCKED_PATTERNS` array makes it easy to add more patterns later

## Deployment
Add a Render Cron Job:
- **Schedule:** `0 6 * * *` (daily at 6am UTC)
- **Command:** `npx ts-node -P server/tsconfig.json server/jobs/cleanup_copyrighted_puzzles.ts`
- **Env vars:** same as archive_game_events job

## Test plan
- [ ] Run with `DRY_RUN=1` to verify count query works
- [ ] Run live against staging/dev to confirm deletes

🤖 Generated with [Claude Code](https://claude.com/claude-code)