### PR TITLE
fix: Preserve clock state when processing non-game actions

### DIFF
--- a/src/lib/reducers/game.js
+++ b/src/lib/reducers/game.js
@@ -398,8 +398,10 @@ export const reduce = (game, action, options = {}) => {
     result = reducers[type](result, params, timestamp);
 
     result = checkSolved(result);
-    const isPause =
-      (type === 'updateClock' && params && params.action === 'pause') || type === 'create' || result.solved;
+    const clockNeutral = type === 'updateDisplayName';
+    const isPause = clockNeutral
+      ? (result.clock?.paused ?? true)
+      : (type === 'updateClock' && params && params.action === 'pause') || type === 'create' || result.solved;
     if (options.isOptimistic) {
       result = incrementOptimisticCounter(result);
     } else {

--- a/src/lib/reducers/game.js
+++ b/src/lib/reducers/game.js
@@ -398,7 +398,7 @@ export const reduce = (game, action, options = {}) => {
     result = reducers[type](result, params, timestamp);
 
     result = checkSolved(result);
-    const clockNeutral = type === 'updateDisplayName';
+    const clockNeutral = ['updateDisplayName', 'updateColor'].includes(type);
     const isPause = clockNeutral
       ? (result.clock?.paused ?? true)
       : (type === 'updateClock' && params && params.action === 'pause') || type === 'create' || result.solved;


### PR DESCRIPTION
## Description
- Disentangle `updateDisplayName` from implicitly updating the clock from pause

## Notes
Prior to this change, any action not explicitly listed as a pause trigger implicitly resumes the clock. Actions handled via `updateDisplayName` (which handles both changing your name and chat visibility toggling) are non-game events that should not affect the timer's paused status.

## Testing
Locally on Firefox with `pnpm start` in multiplayer and singleplayer.