### PR TITLE
fix: persist game events offline using localStorage queue

### DIFF
--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -109,13 +109,9 @@ class Game extends Component {
       this.handleUpdate();
     });
     this.gameModel.on('reconnect', () => {
-      // Don't clear optimistic events — the retry loop will re-send them
-      // and they'll be confirmed through the normal server broadcast flow
-      // Only clear the warning banner if the model isn't in 'failed' state —
-      // failed events exhausted retries and were never persisted
-      if (this.gameModel.syncState !== 'failed') {
-        this.setState({syncWarning: null});
-      }
+      // Offline events were flushed by the Game model on reconnect,
+      // so we can safely clear warnings and optimistic state
+      this.setState({syncWarning: null});
       if (this._connectionTimer) clearTimeout(this._connectionTimer);
       this.setState({connectionFailed: false});
       this.handleChange();

--- a/src/store/__tests__/game.test.js
+++ b/src/store/__tests__/game.test.js
@@ -1,0 +1,286 @@
+import {vi} from 'vitest';
+
+// Stub socket before importing Game
+const mockSocket = {
+  connected: true,
+  on: vi.fn(),
+  once: vi.fn(),
+  emit: vi.fn((...args) => {
+    // auto-ack
+    const cb = args[args.length - 1];
+    if (typeof cb === 'function') cb();
+  }),
+};
+
+vi.mock('../../sockets/getSocket', () => ({
+  getSocket: vi.fn(() => Promise.resolve(mockSocket)),
+}));
+
+vi.mock('../../sockets/emitAsync', () => ({
+  emitAsync: vi.fn((_socket, ...args) => {
+    const cb = args[args.length - 1];
+    if (typeof cb === 'function') return Promise.resolve(cb());
+    return Promise.resolve();
+  }),
+  emitAsyncWithTimeout: vi.fn((_socket, _timeout, ..._args) => {
+    return Promise.resolve();
+  }),
+}));
+
+vi.mock('@sentry/react', () => ({
+  captureException: vi.fn(),
+}));
+
+import Game from '../game';
+import {emitAsyncWithTimeout} from '../../sockets/emitAsync';
+
+function makeGame() {
+  const game = new Game('/game/test-123');
+  return game;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+  mockSocket.connected = true;
+});
+
+// ---- Offline queue persistence ----
+
+describe('offline event queue', () => {
+  it('sends event directly when socket is connected', async () => {
+    const game = makeGame();
+    await game.addEvent({type: 'updateCell', timestamp: 1});
+
+    expect(emitAsyncWithTimeout).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('offline_queue_test-123')).toBeNull();
+  });
+
+  it('queues event to localStorage when socket is disconnected', async () => {
+    const game = makeGame();
+    // Connect first so socket is assigned, then disconnect
+    await game.connectToWebsocket();
+    mockSocket.connected = false;
+
+    await game.addEvent({type: 'updateCell', timestamp: 1});
+
+    const queue = JSON.parse(localStorage.getItem('offline_queue_test-123'));
+    expect(queue).toHaveLength(1);
+    expect(queue[0].type).toBe('updateCell');
+  });
+
+  it('queues multiple events while offline', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+    mockSocket.connected = false;
+
+    await game.addEvent({type: 'updateCell', timestamp: 1});
+    await game.addEvent({type: 'updateCell', timestamp: 2});
+    await game.addEvent({type: 'updateCell', timestamp: 3});
+
+    const queue = JSON.parse(localStorage.getItem('offline_queue_test-123'));
+    expect(queue).toHaveLength(3);
+  });
+
+  it('assigns unique IDs to each event', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+    mockSocket.connected = false;
+
+    await game.addEvent({type: 'updateCell', timestamp: 1});
+    await game.addEvent({type: 'updateCell', timestamp: 2});
+
+    const queue = JSON.parse(localStorage.getItem('offline_queue_test-123'));
+    expect(queue[0].id).toBeDefined();
+    expect(queue[1].id).toBeDefined();
+    expect(queue[0].id).not.toBe(queue[1].id);
+  });
+
+  it('sets syncState to retrying when event is queued', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+    mockSocket.connected = false;
+
+    const warnings = [];
+    game.on('syncWarning', (info) => warnings.push(info));
+
+    await game.addEvent({type: 'updateCell', timestamp: 1});
+
+    expect(game.syncState).toBe('retrying');
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings[0].level).toBe('retrying');
+  });
+
+  it('keeps separate queues per game', async () => {
+    const game1 = new Game('/game/aaa');
+    const game2 = new Game('/game/bbb');
+    await game1.connectToWebsocket();
+    await game2.connectToWebsocket();
+    mockSocket.connected = false;
+
+    await game1.addEvent({type: 'updateCell', timestamp: 1});
+    await game2.addEvent({type: 'updateCell', timestamp: 2});
+    await game2.addEvent({type: 'updateCell', timestamp: 3});
+
+    expect(JSON.parse(localStorage.getItem('offline_queue_aaa'))).toHaveLength(1);
+    expect(JSON.parse(localStorage.getItem('offline_queue_bbb'))).toHaveLength(2);
+  });
+
+  it('appends to queue instead of sending directly when queue is non-empty', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+
+    // Seed an existing queued event
+    localStorage.setItem(
+      'offline_queue_test-123',
+      JSON.stringify([{id: 'old', type: 'updateCell', timestamp: 1}])
+    );
+
+    // Make flush fail so events stay in the queue for inspection
+    emitAsyncWithTimeout.mockImplementation(() => Promise.reject(new Error('offline')));
+
+    await game.addEvent({type: 'updateCell', timestamp: 2});
+
+    const queue = JSON.parse(localStorage.getItem('offline_queue_test-123'));
+    expect(queue[0].id).toBe('old');
+    expect(queue[1].type).toBe('updateCell');
+    expect(queue[1].timestamp).toBe(2);
+
+    // Restore default mock
+    emitAsyncWithTimeout.mockImplementation(() => Promise.resolve());
+  });
+});
+
+// ---- Flush ----
+
+describe('flushOfflineQueue', () => {
+  it('sends all queued events and clears localStorage', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+
+    // Seed the queue as if we were offline earlier
+    localStorage.setItem(
+      'offline_queue_test-123',
+      JSON.stringify([
+        {id: 'e1', type: 'updateCell', timestamp: 1},
+        {id: 'e2', type: 'updateCell', timestamp: 2},
+      ])
+    );
+
+    mockSocket.connected = true;
+    await game.flushOfflineQueue();
+
+    expect(emitAsyncWithTimeout).toHaveBeenCalledTimes(2);
+    expect(localStorage.getItem('offline_queue_test-123')).toBeNull();
+    expect(game.syncState).toBeNull();
+  });
+
+  it('stops on first failure and keeps remaining events in queue', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+
+    localStorage.setItem(
+      'offline_queue_test-123',
+      JSON.stringify([
+        {id: 'e1', type: 'updateCell', timestamp: 1},
+        {id: 'e2', type: 'updateCell', timestamp: 2},
+        {id: 'e3', type: 'updateCell', timestamp: 3},
+      ])
+    );
+
+    // Fail on the second event
+    let callCount = 0;
+    emitAsyncWithTimeout.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 2) return Promise.reject(new Error('timeout'));
+      return Promise.resolve();
+    });
+
+    mockSocket.connected = true;
+    await game.flushOfflineQueue();
+
+    // Should have stopped at e2, leaving e2 and e3 in the queue
+    const remaining = JSON.parse(localStorage.getItem('offline_queue_test-123'));
+    expect(remaining).toHaveLength(2);
+    expect(remaining[0].id).toBe('e2');
+    expect(remaining[1].id).toBe('e3');
+    expect(game.syncState).toBe('retrying');
+
+    emitAsyncWithTimeout.mockImplementation(() => Promise.resolve());
+  });
+
+  it('does nothing when queue is empty', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+
+    await game.flushOfflineQueue();
+
+    expect(emitAsyncWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it('prevents concurrent flushes', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+
+    localStorage.setItem(
+      'offline_queue_test-123',
+      JSON.stringify([{id: 'e1', type: 'updateCell', timestamp: 1}])
+    );
+
+    // Start two flushes at the same time
+    mockSocket.connected = true;
+    const p1 = game.flushOfflineQueue();
+    const p2 = game.flushOfflineQueue();
+    await Promise.all([p1, p2]);
+
+    // Should only have sent the event once
+    expect(emitAsyncWithTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not lose events appended during flush', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+
+    localStorage.setItem(
+      'offline_queue_test-123',
+      JSON.stringify([{id: 'e1', type: 'updateCell', timestamp: 1}])
+    );
+
+    // While flushing e1, simulate a concurrent addEvent writing e2 to localStorage
+    emitAsyncWithTimeout.mockImplementation(() => {
+      const queue = JSON.parse(localStorage.getItem('offline_queue_test-123')) || [];
+      if (!queue.some((e) => e.id === 'e2')) {
+        queue.push({id: 'e2', type: 'updateCell', timestamp: 2});
+        localStorage.setItem('offline_queue_test-123', JSON.stringify(queue));
+      }
+      return Promise.resolve();
+    });
+
+    mockSocket.connected = true;
+    await game.flushOfflineQueue();
+
+    // e1 should have been sent and removed, e2 should also have been sent
+    expect(localStorage.getItem('offline_queue_test-123')).toBeNull();
+    expect(emitAsyncWithTimeout).toHaveBeenCalledTimes(2);
+
+    emitAsyncWithTimeout.mockImplementation(() => Promise.resolve());
+  });
+});
+
+// ---- Optimistic events ----
+
+describe('optimistic events', () => {
+  it('emits wsOptimisticEvent even when offline', async () => {
+    const game = makeGame();
+    await game.connectToWebsocket();
+    mockSocket.connected = false;
+
+    const optimistic = [];
+    game.on('wsOptimisticEvent', (e) => optimistic.push(e));
+
+    await game.addEvent({type: 'updateCell', timestamp: 1});
+
+    expect(optimistic).toHaveLength(1);
+    expect(optimistic[0].type).toBe('updateCell');
+  });
+});

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-param-reassign */
-import * as Sentry from '@sentry/react';
 import EventEmitter from 'events';
 import _ from 'lodash';
 import * as uuid from 'uuid';
@@ -22,6 +21,34 @@ const castNullsToUndefined = (obj) => {
   return obj;
 };
 
+// ============ Offline Event Queue ========== //
+// Persists unsent events to localStorage so they survive disconnects and page refreshes.
+
+function offlineQueueKey(gid) {
+  return `offline_queue_${gid}`;
+}
+
+function loadOfflineQueue(gid) {
+  try {
+    const raw = localStorage.getItem(offlineQueueKey(gid));
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveOfflineQueue(gid, queue) {
+  try {
+    if (queue.length === 0) {
+      localStorage.removeItem(offlineQueueKey(gid));
+    } else {
+      localStorage.setItem(offlineQueueKey(gid), JSON.stringify(queue));
+    }
+  } catch {
+    // localStorage full or unavailable — events stay in memory only
+  }
+}
+
 // a wrapper class that models Game
 
 const CURRENT_VERSION = 1.0;
@@ -31,7 +58,8 @@ export default class Game extends EventEmitter {
     window.game = this;
     this.path = path;
     this.createEvent = null;
-    this.syncState = null; // null | 'retrying' | 'failed'
+    this.syncState = null; // null | 'retrying'
+    this._flushing = false;
   }
 
   get gid() {
@@ -55,11 +83,8 @@ export default class Game extends EventEmitter {
       console.log('reconnecting...');
       await emitAsync(socket, 'join_game', this.gid);
       console.log('reconnected...');
-      // Only clear sync state if not 'failed' — failed events exhausted retries
-      // and were never persisted, so reconnecting doesn't fix them
-      if (this.syncState !== 'failed') {
-        this.syncState = null;
-      }
+      this.syncState = null;
+      await this.flushOfflineQueue();
       this.emitReconnect();
     });
   }
@@ -85,9 +110,6 @@ export default class Game extends EventEmitter {
   }
 
   setSyncState(level, detail) {
-    // Once failed, only a reconnect (or refresh) can clear it — individual
-    // event successes and retries must not mask the lost-data state
-    if (this.syncState === 'failed' && level !== 'failed') return;
     this.syncState = level;
     this.emit('syncWarning', {level, ...detail});
   }
@@ -101,34 +123,55 @@ export default class Game extends EventEmitter {
     this.emitOptimisticEvent(event);
     await this.connectToWebsocket();
 
-    const MAX_RETRIES = 3;
-    const RETRY_DELAYS = [5000, 10000, 20000];
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    // If queue is empty, try sending immediately
+    const queue = loadOfflineQueue(this.gid);
+    if (queue.length === 0) {
       try {
         await this.pushEventToWebsocket(event);
         this.setSyncState(null);
         return;
-      } catch (err) {
-        console.warn(`Event emit failed (attempt ${attempt + 1}/${MAX_RETRIES + 1}):`, err.message);
-        if (attempt < MAX_RETRIES) {
-          this.setSyncState('retrying', {retryIn: RETRY_DELAYS[attempt] / 1000});
-          // Wait for the backoff delay OR socket reconnect, whichever comes first
-          await new Promise((resolve) => {
-            const timeout = setTimeout(resolve, RETRY_DELAYS[attempt]);
-            if (this.socket && !this.socket.connected) {
-              this.socket.once('connect', () => {
-                clearTimeout(timeout);
-                resolve();
-              });
-            }
-          });
-        }
+      } catch {
+        // Fall through to queuing logic
       }
     }
-    // all retries exhausted — freeze input, let socket.io keep trying to reconnect
-    Sentry.captureException(new Error('Event delivery failed after all retries'));
-    console.error('Event delivery failed after all retries');
-    this.setSyncState('failed');
+
+    // Persist to localStorage so the event survives page refreshes / long tunnels
+    queue.push(event);
+    saveOfflineQueue(this.gid, queue);
+    console.log(`Queued event offline (${queue.length} pending)`);
+    this.setSyncState('retrying', {retryIn: null});
+    await this.flushOfflineQueue();
+  }
+
+  async flushOfflineQueue() {
+    if (this._flushing) return;
+    this._flushing = true;
+    try {
+      while (true) {
+        const queue = loadOfflineQueue(this.gid);
+        if (queue.length === 0) {
+          this.setSyncState(null);
+          break;
+        }
+
+        const event = queue[0];
+        try {
+          await this.pushEventToWebsocket(event);
+          // Re-load to avoid overwriting events added concurrently by addEvent
+          const currentQueue = loadOfflineQueue(this.gid);
+          if (currentQueue.length > 0 && currentQueue[0].id === event.id) {
+            currentQueue.shift();
+            saveOfflineQueue(this.gid, currentQueue);
+          }
+        } catch (err) {
+          console.warn('Failed to flush offline event:', err.message);
+          this.setSyncState('retrying', {retryIn: null});
+          break; // Stop on first failure to preserve event order
+        }
+      }
+    } finally {
+      this._flushing = false;
+    }
   }
 
   pushEventToWebsocket(event) {
@@ -168,7 +211,10 @@ export default class Game extends EventEmitter {
   }
 
   async attach() {
-    const websocketPromise = this.connectToWebsocket().then(() => this.subscribeToWebsocketEvents());
+    const websocketPromise = this.connectToWebsocket().then(async () => {
+      await this.flushOfflineQueue();
+      await this.subscribeToWebsocketEvents();
+    });
     await websocketPromise;
   }
 


### PR DESCRIPTION
## Problem

I play this on the subway and love it, but my progress gets reset when I lose signal for more than ~35 seconds between stops. The old retry loop (3 attempts over ~35s) would exhaust and silently drop any cell entries made while offline.

## Solution

Replace the retry-then-discard flow with a localStorage-backed offline queue:

- When the WebSocket is down, events are saved to localStorage instead of retried and lost
- On reconnect (or page reload), queued events are flushed to the server automatically
- Existing dedup logic in HistoryWrapper prevents double-entries

## Changes

- Replace retry loop with offline queue (offline_queue_{gid} in localStorage). Add flushOfflineQueue() called on reconnect and initial attach.
- Simplify reconnect handler since events are queued, not lost.
- Added unit tests

## Testing

- All 11 new unit tests pass
- Manual testing: DevTools Network > Offline, type letters, go back online, entries persist

## Demo

LEFT = crosswithfriends.com today aka before

RIGHT = localhost aka after

https://github.com/user-attachments/assets/5367fc1f-bc08-43ab-a2c6-095bbc826513

*AI Disclaimer: AI was used for some parts of implementation (tests) but most was written, reviewed and tested by me*