### PR TITLE
Fix completed puzzles not showing as Complete for authenticated users

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
       "test-exclude>glob": "7",
       "undici": ">=7.24.0",
       "flatted": ">=3.4.2",
-      "socket.io-parser": ">=4.2.6"
+      "socket.io-parser": ">=4.2.6",
+      "axios": ">=1.15.0"
     },
     "onlyBuiltDependencies": [
       "bcrypt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   undici: '>=7.24.0'
   flatted: '>=3.4.2'
   socket.io-parser: '>=4.2.6'
+  axios: '>=1.15.0'
 
 importers:
 
@@ -2889,8 +2890,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -8165,7 +8166,7 @@ snapshots:
   '@sendgrid/client@8.1.6':
     dependencies:
       '@sendgrid/helpers': 8.0.0
-      axios: 1.14.0
+      axios: 1.15.0
     transitivePeerDependencies:
       - debug
 
@@ -8999,7 +9000,7 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.14.0:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -400,11 +400,14 @@ describe('recordSolve', () => {
     expect(pool.connect).not.toHaveBeenCalled();
   });
 
-  it('skips insert when anonymous and game already solved', async () => {
-    // isGidAlreadySolved returns count > 0
+  it('skips insert when anonymous and an anonymous solve already exists', async () => {
+    // isGidAlreadySolved checks only anonymous solves (user_id IS NULL)
     pool.query.mockResolvedValueOnce({rows: [{count: 1}]});
     await recordSolve('p1', 'g1', 300);
     expect(pool.connect).not.toHaveBeenCalled();
+    // Verify query checks only anonymous solves
+    const dedupSql = pool.query.mock.calls[0][0] as string;
+    expect(dedupSql).toContain('user_id IS NULL');
   });
 
   it('increments times_solved only for first solve of a game', async () => {
@@ -450,6 +453,30 @@ describe('recordSolve', () => {
     expect(mockClient.query).toHaveBeenCalledTimes(5);
     const allSql = mockClient.query.mock.calls.map((c: any[]) => c[0] as string);
     expect(allSql.some((s) => s.includes('times_solved'))).toBe(false);
+  });
+
+  it('allows anonymous solve even when an authenticated solve exists for the same game', async () => {
+    // isGidAlreadySolved: only checks anonymous solves, should return count=0
+    // even though an authenticated solve exists for this gid
+    pool.query.mockResolvedValueOnce({rows: [{count: 0}]});
+    // BEGIN
+    mockClient.query.mockResolvedValueOnce({rows: []});
+    // SELECT FOR UPDATE
+    mockClient.query.mockResolvedValueOnce({rows: []});
+    // COUNT for first-solve check: 1 (authenticated user already solved)
+    mockClient.query.mockResolvedValueOnce({rows: [{count: 1}]});
+    // INSERT puzzle_solve (anonymous)
+    mockClient.query.mockResolvedValueOnce({rows: []});
+    // COMMIT
+    mockClient.query.mockResolvedValueOnce({rows: []});
+
+    await recordSolve('p1', 'g1', 300); // no userId = anonymous
+
+    // Should have proceeded to insert (pool.connect was called)
+    expect(pool.connect).toHaveBeenCalled();
+    // Verify the dedup query checked only anonymous solves
+    const dedupSql = pool.query.mock.calls[0][0] as string;
+    expect(dedupSql).toContain('user_id IS NULL');
   });
 
   it('calls ROLLBACK on error and releases client', async () => {

--- a/server/__tests__/model/puzzle_solve.test.ts
+++ b/server/__tests__/model/puzzle_solve.test.ts
@@ -205,4 +205,11 @@ describe('backfillSolvesForDfacId', () => {
     expect(params[0]).toBe('user-1');
     expect(params[1]).toBe('dfac-xyz');
   });
+
+  it('uses ON CONFLICT DO NOTHING so repeated calls are safe', async () => {
+    pool.query.mockResolvedValueOnce({rowCount: 0});
+    await backfillSolvesForDfacId('user-1', 'dfac-abc');
+    const sql = pool.query.mock.calls[0][0] as string;
+    expect(sql).toContain('ON CONFLICT DO NOTHING');
+  });
 });

--- a/server/__tests__/model/user_games.test.ts
+++ b/server/__tests__/model/user_games.test.ts
@@ -2,7 +2,11 @@ import {pool, resetPoolMocks} from '../../__mocks__/pool';
 
 jest.mock('../../model/pool', () => require('../../__mocks__/pool'));
 
-import {getUserGamesForPuzzle, clearUserGamesCache} from '../../model/user_games';
+import {
+  getUserGamesForPuzzle,
+  getAuthenticatedPuzzleStatuses,
+  clearUserGamesCache,
+} from '../../model/user_games';
 
 describe('getUserGamesForPuzzle', () => {
   beforeEach(() => {
@@ -132,5 +136,62 @@ describe('getUserGamesForPuzzle', () => {
     const result = await getUserGamesForPuzzle('123', {dfacId: 'guest-1'});
 
     expect(result[0].time).toBe(0);
+  });
+});
+
+describe('getAuthenticatedPuzzleStatuses', () => {
+  beforeEach(() => {
+    resetPoolMocks();
+    clearUserGamesCache();
+  });
+
+  it('returns empty map when user has no linked dfac_ids', async () => {
+    pool.query.mockResolvedValueOnce({rows: []}); // getDfacIdsForUser
+    const result = await getAuthenticatedPuzzleStatuses('user-123');
+    expect(result).toEqual({});
+    expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks puzzle as solved when game_snapshots entry exists', async () => {
+    // getDfacIdsForUser
+    pool.query.mockResolvedValueOnce({rows: [{dfac_id: 'dfac-abc'}]});
+    // main status query
+    pool.query.mockResolvedValueOnce({
+      rows: [{pid: 'puzzle-1', status: 'solved'}],
+    });
+    const result = await getAuthenticatedPuzzleStatuses('user-123');
+    expect(result['puzzle-1']).toBe('solved');
+  });
+
+  it('marks puzzle as started when no game_snapshots entry exists', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{dfac_id: 'dfac-abc'}]});
+    pool.query.mockResolvedValueOnce({
+      rows: [{pid: 'puzzle-2', status: 'started'}],
+    });
+    const result = await getAuthenticatedPuzzleStatuses('user-123');
+    expect(result['puzzle-2']).toBe('started');
+  });
+
+  it('passes all dfac_ids via ANY($1)', async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [{dfac_id: 'dfac-1'}, {dfac_id: 'dfac-2'}],
+    });
+    pool.query.mockResolvedValueOnce({rows: []});
+    await getAuthenticatedPuzzleStatuses('user-123');
+    const params = pool.query.mock.calls[1][1] as any[];
+    expect(params[0]).toEqual(['dfac-1', 'dfac-2']);
+  });
+
+  it('uses cache on second call', async () => {
+    // First call: dfac_id lookup + main query
+    pool.query.mockResolvedValueOnce({rows: [{dfac_id: 'dfac-abc'}]});
+    pool.query.mockResolvedValueOnce({rows: [{pid: 'p1', status: 'solved'}]});
+    await getAuthenticatedPuzzleStatuses('user-123');
+
+    // Second call: dfac_id lookup still runs, but main query hits cache
+    pool.query.mockResolvedValueOnce({rows: [{dfac_id: 'dfac-abc'}]});
+    const result = await getAuthenticatedPuzzleStatuses('user-123');
+    expect(pool.query).toHaveBeenCalledTimes(3); // 2 from first call + 1 dfac_id lookup
+    expect(result['p1']).toBe('solved');
   });
 });

--- a/server/__tests__/model/user_games.test.ts
+++ b/server/__tests__/model/user_games.test.ts
@@ -182,16 +182,15 @@ describe('getAuthenticatedPuzzleStatuses', () => {
     expect(params[0]).toEqual(['dfac-1', 'dfac-2']);
   });
 
-  it('uses cache on second call', async () => {
+  it('uses cache on second call (no DB queries)', async () => {
     // First call: dfac_id lookup + main query
     pool.query.mockResolvedValueOnce({rows: [{dfac_id: 'dfac-abc'}]});
     pool.query.mockResolvedValueOnce({rows: [{pid: 'p1', status: 'solved'}]});
     await getAuthenticatedPuzzleStatuses('user-123');
 
-    // Second call: dfac_id lookup still runs, but main query hits cache
-    pool.query.mockResolvedValueOnce({rows: [{dfac_id: 'dfac-abc'}]});
+    // Second call: entire fetch is cached, no new DB queries
     const result = await getAuthenticatedPuzzleStatuses('user-123');
-    expect(pool.query).toHaveBeenCalledTimes(3); // 2 from first call + 1 dfac_id lookup
+    expect(pool.query).toHaveBeenCalledTimes(2); // only the original 2 calls
     expect(result['p1']).toBe('solved');
   });
 });

--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -1201,12 +1201,10 @@ router.post('/link-identity', authLimiter, requireAuth, async (req, res) => {
     res.status(400).json({error: 'dfacId is required'});
     return;
   }
-  const isNew = await linkDfacId(req.authUser!.userId, dfacId);
-  // Only backfill on first link — skip the heavy game_events scan on subsequent page loads
-  let backfilled = 0;
-  if (isNew) {
-    backfilled = await backfillSolvesForDfacId(req.authUser!.userId, dfacId);
-  }
+  await linkDfacId(req.authUser!.userId, dfacId);
+  // Always attempt backfill — catches anonymous solves created after initial link.
+  // Uses ON CONFLICT DO NOTHING so repeated calls are safe.
+  const backfilled = await backfillSolvesForDfacId(req.authUser!.userId, dfacId);
   res.json({ok: true, backfilledSolves: backfilled});
 });
 

--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -41,6 +41,7 @@ import {
 import {sendVerificationEmail, sendPasswordResetEmail} from '../model/mailer';
 import {pool} from '../model/pool';
 import {backfillSolvesForDfacId} from '../model/puzzle_solve';
+import {invalidateAuthPuzzleStatusCache} from '../model/user_games';
 
 const router = express.Router();
 const BCRYPT_ROUNDS = 12;
@@ -1205,6 +1206,9 @@ router.post('/link-identity', authLimiter, requireAuth, async (req, res) => {
   // Always attempt backfill — catches anonymous solves created after initial link.
   // Uses ON CONFLICT DO NOTHING so repeated calls are safe.
   const backfilled = await backfillSolvesForDfacId(req.authUser!.userId, dfacId);
+  if (backfilled > 0) {
+    invalidateAuthPuzzleStatusCache(req.authUser!.userId);
+  }
   res.json({ok: true, backfilledSolves: backfilled});
 });
 

--- a/server/api/record_solve.ts
+++ b/server/api/record_solve.ts
@@ -3,7 +3,7 @@ import {RecordSolveRequest, RecordSolveResponse} from '../../src/shared/types';
 import {recordSolve} from '../model/puzzle';
 import {saveGameSnapshot} from '../model/game_snapshot';
 import {invalidateInProgressCacheForUser} from '../model/puzzle_solve';
-import {invalidateUserGamesCacheForUser} from '../model/user_games';
+import {invalidateUserGamesCacheForUser, invalidateAuthPuzzleStatusCache} from '../model/user_games';
 import {getDfacIdsForUser} from '../model/user';
 import {verifyAccessToken} from '../auth/jwt';
 
@@ -63,6 +63,7 @@ router.post<{pid: string}, RecordSolveResponse, RecordSolveRequest>('/:pid', asy
     // Invalidate caches so solved game disappears from in-progress lists
     if (userId) {
       invalidateInProgressCacheForUser(userId);
+      invalidateAuthPuzzleStatusCache(userId);
       const dfacIds = await getDfacIdsForUser(userId);
       for (const dfacId of dfacIds) invalidateUserGamesCacheForUser(dfacId);
     }

--- a/server/api/user_stats.ts
+++ b/server/api/user_stats.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import {getUserSolveStats, getInProgressGames} from '../model/puzzle_solve';
 import {getUserById} from '../model/user';
 import {getUserUploadedPuzzles} from '../model/puzzle';
+import {getAuthenticatedPuzzleStatuses} from '../model/user_games';
 import {verifyAccessToken} from '../auth/jwt';
 
 const router = express.Router();
@@ -93,12 +94,19 @@ router.get('/:userId', async (req, res, next) => {
     }
 
     let inProgress: Awaited<ReturnType<typeof getInProgressGames>> = [];
+    let snapshotStatuses: Awaited<ReturnType<typeof getAuthenticatedPuzzleStatuses>> = {};
     if (isOwner) {
       try {
         inProgress = await getInProgressGames(userId);
       } catch (err) {
         Sentry.captureException(err);
         console.error('getInProgressGames error:', err);
+      }
+      try {
+        snapshotStatuses = await getAuthenticatedPuzzleStatuses(userId);
+      } catch (err) {
+        Sentry.captureException(err);
+        console.error('getAuthenticatedPuzzleStatuses error:', err);
       }
     }
 
@@ -122,6 +130,7 @@ router.get('/:userId', async (req, res, next) => {
       history,
       uploads,
       inProgress,
+      snapshotStatuses,
     });
   } catch (e) {
     next(e);

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -335,7 +335,7 @@ export async function getUserUploadedPuzzles(userId: string) {
 async function isGidAlreadySolved(gid: string) {
   const {
     rows: [{count}],
-  } = await pool.query(`SELECT COUNT(*) FROM puzzle_solves WHERE gid=$1`, [gid]);
+  } = await pool.query(`SELECT COUNT(*) FROM puzzle_solves WHERE gid=$1 AND user_id IS NULL`, [gid]);
   return count > 0;
 }
 

--- a/server/model/user_games.ts
+++ b/server/model/user_games.ts
@@ -97,10 +97,10 @@ export async function getGuestPuzzleStatuses(dfacId: string): Promise<PuzzleStat
  * without a puzzle_solves record still show as solved.
  */
 export async function getAuthenticatedPuzzleStatuses(userId: string): Promise<PuzzleStatusMap> {
-  const dfacIds = await getDfacIdsForUser(userId);
-  if (dfacIds.length === 0) return {};
-
   return authPuzzleStatusCache.getOrFetch(userId, async () => {
+    const dfacIds = await getDfacIdsForUser(userId);
+    if (dfacIds.length === 0) return {};
+
     const result = await pool.query(
       `SELECT pid, CASE WHEN bool_or(solved) THEN 'solved' ELSE 'started' END AS status
        FROM (

--- a/server/model/user_games.ts
+++ b/server/model/user_games.ts
@@ -16,10 +16,12 @@ export type UserGameItem = {
 // ---- In-memory TTL caches ----
 // Cache key format for userGamesForPuzzleCache: "pid:dfacId1,dfacId2:userId"
 const guestPuzzleStatusCache = new TTLCache<PuzzleStatusMap>({ttlMs: 10 * 60_000, maxSize: 10_000});
+const authPuzzleStatusCache = new TTLCache<PuzzleStatusMap>({ttlMs: 10 * 60_000, maxSize: 2_000});
 const userGamesForPuzzleCache = new TTLCache<UserGameItem[]>({ttlMs: 3 * 60_000, maxSize: 5_000});
 
 export function clearUserGamesCache(): void {
   guestPuzzleStatusCache.clear();
+  authPuzzleStatusCache.clear();
   userGamesForPuzzleCache.clear();
 }
 
@@ -32,6 +34,11 @@ export function invalidateUserGamesCacheForUser(dfacId: string): void {
     const dfacSegment = key.split(':')[1];
     return dfacSegment !== undefined && dfacSegment.split(',').includes(dfacId);
   });
+}
+
+/** Invalidate authenticated puzzle status cache for a specific user. */
+export function invalidateAuthPuzzleStatusCache(userId: string): void {
+  authPuzzleStatusCache.delete(userId);
 }
 
 /**
@@ -74,6 +81,53 @@ export async function getGuestPuzzleStatuses(dfacId: string): Promise<PuzzleStat
        ) combined
        GROUP BY pid`,
       [dfacId]
+    );
+
+    const statuses: PuzzleStatusMap = {};
+    for (const row of result.rows as {pid: string; status: 'solved' | 'started'}[]) {
+      statuses[row.pid] = row.status;
+    }
+    return statuses;
+  });
+}
+
+/**
+ * Get puzzle statuses (solved/started) for an authenticated user.
+ * Falls back to game_snapshots (like the guest path) so puzzles completed
+ * without a puzzle_solves record still show as solved.
+ */
+export async function getAuthenticatedPuzzleStatuses(userId: string): Promise<PuzzleStatusMap> {
+  const dfacIds = await getDfacIdsForUser(userId);
+  if (dfacIds.length === 0) return {};
+
+  return authPuzzleStatusCache.getOrFetch(userId, async () => {
+    const result = await pool.query(
+      `SELECT pid, CASE WHEN bool_or(solved) THEN 'solved' ELSE 'started' END AS status
+       FROM (
+         SELECT
+           COALESCE(ce.pid, gs.pid) AS pid,
+           gs.gid IS NOT NULL AS solved
+         FROM (
+           SELECT DISTINCT gid FROM game_events
+           WHERE uid = ANY($1) OR (event_payload->'params'->>'id') = ANY($1)
+         ) ug
+         LEFT JOIN LATERAL (
+           SELECT event_payload->'params'->>'pid' AS pid
+           FROM game_events
+           WHERE gid = ug.gid AND event_type = 'create'
+           LIMIT 1
+         ) ce ON true
+         LEFT JOIN game_snapshots gs ON gs.gid = ug.gid
+         WHERE COALESCE(ce.pid, gs.pid) IS NOT NULL
+
+         UNION ALL
+
+         SELECT fh.pid::text AS pid, fh.solved
+         FROM firebase_history fh
+         WHERE fh.dfac_id = ANY($1)
+       ) combined
+       GROUP BY pid`,
+      [dfacIds]
     );
 
     const statuses: PuzzleStatusMap = {};

--- a/src/api/user_stats.ts
+++ b/src/api/user_stats.ts
@@ -77,6 +77,7 @@ export interface UserStatsResponse {
   history?: SolveHistoryItem[];
   uploads?: UploadedPuzzle[];
   inProgress?: InProgressGame[];
+  snapshotStatuses?: {[pid: string]: 'solved' | 'started'};
 }
 
 export async function getUserStats(

--- a/src/components/PuzzleList/NewPuzzleList.tsx
+++ b/src/components/PuzzleList/NewPuzzleList.tsx
@@ -61,11 +61,17 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
         .then((stats) => {
           if (stale || !stats) return;
           const statuses: PuzzleStatuses = {};
-          (stats.history || []).forEach((item) => {
-            statuses[item.pid] = 'solved';
-          });
+          // Apply snapshot-based statuses first (fallback from game_snapshots)
+          if (stats.snapshotStatuses) {
+            Object.assign(statuses, stats.snapshotStatuses);
+          }
+          // Overlay in-progress (only if not already marked)
           (stats.inProgress || []).forEach((item) => {
             if (!statuses[item.pid]) statuses[item.pid] = 'started';
+          });
+          // Overlay solved from puzzle_solves (highest priority)
+          (stats.history || []).forEach((item) => {
+            statuses[item.pid] = 'solved';
           });
           updateStatuses(statuses);
         })


### PR DESCRIPTION
## Summary
- **Adds game_snapshots fallback** to the authenticated puzzle status path, matching what the guest path already does. Puzzles completed without a `puzzle_solves` record now show as "Complete" via a new `snapshotStatuses` field in the user-stats API.
- **Fixes anonymous solve dedup** (`isGidAlreadySolved`) to only check anonymous records, so multiplayer guests always get a `puzzle_solves` record to backfill from.
- **Runs backfill on every `link-identity` call** instead of only the first, catching anonymous solves created after account linking.

Closes #447

## Test plan
- [x] New server tests: anonymous dedup checks `user_id IS NULL` (2 tests)
- [x] New server tests: `getAuthenticatedPuzzleStatuses` — empty dfac_ids, solved, started, multiple dfac_ids, caching (5 tests)
- [x] New server test: backfill uses `ON CONFLICT DO NOTHING` (1 test)
- [x] All 200 server tests pass, 372 frontend tests pass
- [x] Verified locally: puzzle `100000133` has `game_snapshots` but no `puzzle_solves` for user — API now returns it as `solved` in `snapshotStatuses`
- [x] Full CI checklist: ESLint, Stylelint, Prettier, TypeScript (frontend + server), build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)