### PR TITLE
Fix dark mode cell colors broken by --cell-bg inline styles

### DIFF
--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -189,16 +189,10 @@ export default class Cell extends React.Component<Props> {
   getStyle(): React.CSSProperties {
     const {attributionColor, cellStyle, selected, highlighted, frozen, image} = this.props;
     let style: React.CSSProperties;
-    const isDark = document.body.classList.contains('dark');
     if (selected) {
-      // In dark mode, let CSS handle selected/highlighted colors
-      style = isDark ? {} : cellStyle.selected;
+      style = cellStyle.selected;
     } else if (highlighted) {
-      if (isDark) {
-        style = {};
-      } else {
-        style = frozen ? cellStyle.frozen : cellStyle.highlighted;
-      }
+      style = frozen ? cellStyle.frozen : cellStyle.highlighted;
     } else {
       style = {'--cell-bg': attributionColor};
     }

--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -189,10 +189,16 @@ export default class Cell extends React.Component<Props> {
   getStyle(): React.CSSProperties {
     const {attributionColor, cellStyle, selected, highlighted, frozen, image} = this.props;
     let style: React.CSSProperties;
+    const isDark = document.body.classList.contains('dark');
     if (selected) {
-      style = cellStyle.selected;
+      // In dark mode, let CSS handle selected/highlighted colors
+      style = isDark ? {} : cellStyle.selected;
     } else if (highlighted) {
-      style = frozen ? cellStyle.frozen : cellStyle.highlighted;
+      if (isDark) {
+        style = {};
+      } else {
+        style = frozen ? cellStyle.frozen : cellStyle.highlighted;
+      }
     } else {
       style = {'--cell-bg': attributionColor};
     }

--- a/src/dark.css
+++ b/src/dark.css
@@ -61,6 +61,10 @@
   background-color: var(--dark-background);
 }
 
+.dark .cell.selected {
+  --cell-bg: var(--dark-blue-1);
+}
+
 .dark .cell.highlighted,
 .dark div:focus .cell.highlighted {
   --cell-bg: var(--dark-blue-2);

--- a/src/dark.css
+++ b/src/dark.css
@@ -52,7 +52,7 @@
 }
 
 .dark .cell {
-  --cell-bg: var(--dark-background-2);
+  --cell-bg: var(--dark-background-2) !important;
 
   color: var(--dark-primary-text);
 }
@@ -62,24 +62,24 @@
 }
 
 .dark .cell.selected {
-  --cell-bg: var(--dark-blue-1);
+  --cell-bg: var(--dark-blue-1) !important;
 }
 
 .dark .cell.highlighted,
 .dark div:focus .cell.highlighted {
-  --cell-bg: var(--dark-blue-2);
+  --cell-bg: var(--dark-blue-2) !important;
 }
 
 .dark .cell.referenced,
 .dark div:focus .cell.referenced {
-  --cell-bg: #80a030;
+  --cell-bg: #80a030 !important;
 
   color: white;
 }
 
 .dark .cell.frozen.highlighted,
 .dark div:focus .frozen .cell.highlighted {
-  --cell-bg: #399629;
+  --cell-bg: #399629 !important;
 
   color: white;
 }


### PR DESCRIPTION
## Summary
- PR #451 changed cell background colors to use a `--cell-bg` CSS variable set via **inline styles**. Since inline styles always win on specificity, dark mode CSS rules could never override them — causing selected/highlighted cells to show light-mode colors in dark mode.
- Fixes by skipping inline `--cell-bg` for selected/highlighted cells when dark mode is active, letting `dark.css` rules control the colors instead.
- Adds explicit `.dark .cell.selected` rule in `dark.css` for the selected cell color.

Supersedes #454 which only addressed the CSS side but missed the inline style specificity issue.

## Test plan
- [ ] Open a puzzle in dark mode — selected cell should be dark blue, highlighted cells should be darker blue
- [ ] Open a puzzle in light mode — selected/highlighted cells should be unchanged from current behavior
- [ ] Cmd+P in both modes — print preview should show white cell backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)