### PR TITLE
Revert --cell-bg CSS variable, restore background-color for cell colors

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -388,13 +388,13 @@ export default class Game extends Component {
       gridStyle: {
         cellStyle: {
           selected: {
-            '--cell-bg': myColor,
+            backgroundColor: myColor,
           },
           highlighted: {
-            '--cell-bg': toHex(darken(themeColor)),
+            backgroundColor: toHex(darken(themeColor)),
           },
           frozen: {
-            '--cell-bg': toHex(GREENISH),
+            backgroundColor: toHex(GREENISH),
           },
         },
       },

--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -7,12 +7,6 @@ import {Ping, CellStyles} from './types';
 import './css/cell.css';
 import {CellData, Cursor} from '../../shared/types';
 
-declare module 'react' {
-  interface CSSProperties {
-    '--cell-bg'?: string;
-  }
-}
-
 export interface EnhancedCellData extends CellData {
   r: number;
   c: number;
@@ -194,7 +188,7 @@ export default class Cell extends React.Component<Props> {
     } else if (highlighted) {
       style = frozen ? cellStyle.frozen : cellStyle.highlighted;
     } else {
-      style = {'--cell-bg': attributionColor};
+      style = {backgroundColor: attributionColor};
     }
     if (image) {
       style = {

--- a/src/components/Grid/css/cell.css
+++ b/src/components/Grid/css/cell.css
@@ -10,16 +10,13 @@
   display: flex;
   flex-direction: column;
   user-select: none;
-
-  --cell-bg: white;
-
-  background-color: var(--cell-bg);
+  background-color: white;
   box-sizing: border-box;
 }
 
 @media print {
   .cell {
-    background-color: white;
+    background-color: white !important;
   }
 }
 
@@ -39,9 +36,7 @@
 
 .cell.hidden {
   pointer-events: none;
-
-  --cell-bg: var(--main-gray-2);
-
+  background-color: var(--main-gray-2);
   color: var(--main-gray-2);
 }
 
@@ -52,27 +47,27 @@
 }
 
 .frozen .cell.highlighted {
-  --cell-bg: var(--main-green-1);
+  background-color: var(--main-green-1);
 }
 
 div:focus .frozen .cell.highlighted {
-  --cell-bg: var(--main-green-2);
+  background-color: var(--main-green-2);
 }
 
 .cell.highlighted {
-  --cell-bg: var(--main-blue-3);
+  background-color: var(--main-blue-3);
 }
 
 div:focus .cell.highlighted {
-  --cell-bg: var(--main-blue-2);
+  background-color: var(--main-blue-2);
 }
 
 .cell.referenced {
-  --cell-bg: #b3ff00;
+  background-color: #b3ff00;
 }
 
 div:focus .cell.referenced {
-  --cell-bg: #b3ff00; /* TODO */
+  background-color: #b3ff00; /* TODO */
 }
 
 .cell.referenced.highlighted {
@@ -80,9 +75,9 @@ div:focus .cell.referenced {
 }
 
 .cell.selected {
-  --cell-bg: #4aeba1;
+  background-color: #4aeba1;
 
-  /* --cell-bg: #98ee99; */
+  /* background-color: #98ee99; */
 }
 
 .cell.pencil .cell--value {

--- a/src/dark.css
+++ b/src/dark.css
@@ -52,8 +52,7 @@
 }
 
 .dark .cell {
-  --cell-bg: var(--dark-background-2) !important;
-
+  background-color: var(--dark-background-2);
   color: var(--dark-primary-text);
 }
 
@@ -61,26 +60,17 @@
   background-color: var(--dark-background);
 }
 
-.dark .cell.selected {
-  --cell-bg: var(--dark-blue-1) !important;
+.dark .cell.highlighted {
+  background-color: var(--dark-blue-2) !important;
 }
 
-.dark .cell.highlighted,
-.dark div:focus .cell.highlighted {
-  --cell-bg: var(--dark-blue-2) !important;
-}
-
-.dark .cell.referenced,
-.dark div:focus .cell.referenced {
-  --cell-bg: #80a030 !important;
-
+.dark .cell.referenced {
+  background-color: #80a030 !important;
   color: white;
 }
 
-.dark .cell.frozen.highlighted,
-.dark div:focus .frozen .cell.highlighted {
-  --cell-bg: #399629 !important;
-
+.dark .cell.frozen.highlighted {
+  background-color: #399629 !important;
   color: white;
 }
 


### PR DESCRIPTION
## Summary
- Reverts the `--cell-bg` CSS variable approach introduced in PR #451 for cell colors. Inline styles setting CSS custom properties cannot be overridden by any CSS rule (not even `!important`), which broke dark mode cell colors entirely.
- Restores `background-color` for all cell states across `Game.js`, `Cell.tsx`, `cell.css`, and `dark.css`.
- Print support preserved via `@media print { background-color: white !important }` which correctly overrides both inline styles and dark mode.
- All non-cell-color print changes from #451 are unaffected (nav/toolbar/chat hiding, clue sizing, game layout, `-webkit-print-color-adjust`).

## Test plan
- [ ] Dark mode: selected, highlighted, referenced, frozen cells show correct dark colors
- [ ] Light mode: unchanged from pre-#451 behavior  
- [ ] Print (Cmd+P): cells show white backgrounds in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)