### PR TITLE
Add Sound on solve preference toggle

### DIFF
--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -585,6 +585,7 @@ const preferencesSchema = Joi.object({
   showProgress: Joi.boolean(),
   darkMode: Joi.string().valid('0', '1', '2'),
   colorAttribution: Joi.boolean(),
+  sound: Joi.boolean(),
 }).unknown(false);
 
 /**
@@ -607,6 +608,7 @@ const preferencesSchema = Joi.object({
  *               showProgress: {type: boolean}
  *               darkMode: {type: string, enum: ['0', '1', '2']}
  *               colorAttribution: {type: boolean}
+ *               sound: {type: boolean}
  *     responses:
  *       200:
  *         description: Preferences updated

--- a/src/components/Game/Confetti.js
+++ b/src/components/Game/Confetti.js
@@ -4,6 +4,16 @@ import jingleSound from '..//..//assets/cwfJingle.mp3';
 
 const jingleAudio = new Audio(jingleSound);
 
+function soundEnabled() {
+  try {
+    const stored = localStorage.getItem('sound');
+    if (stored == null) return true;
+    return JSON.parse(stored) !== false;
+  } catch {
+    return true;
+  }
+}
+
 export default class ConfettiWrapper extends Component {
   constructor() {
     super();
@@ -20,6 +30,7 @@ export default class ConfettiWrapper extends Component {
         numberOfPieces: 0,
       });
     }, 7000);
+    if (!soundEnabled()) return;
     if (jingleAudio.readyState > 0) {
       jingleAudio.currentTime = 0;
     }

--- a/src/lib/AuthContext.js
+++ b/src/lib/AuthContext.js
@@ -13,6 +13,7 @@ const PREF_STORAGE_MAP = {
   showProgress: {key: 'show-progress', type: 'json', default: true},
   darkMode: {key: 'dark_mode_preference', type: 'string', default: '0'},
   colorAttribution: {key: null, type: 'json', default: false},
+  sound: {key: 'sound', type: 'json', default: true},
 };
 
 function readLocalStoragePrefs() {

--- a/src/pages/Account.js
+++ b/src/pages/Account.js
@@ -99,6 +99,7 @@ function GamePreferencesSection({preferences, savePreference, darkModePreference
     {key: 'autoAdvanceCursor', label: 'Auto-advance cursor', value: preferences?.autoAdvanceCursor ?? true},
     {key: 'showProgress', label: 'Show progress', value: preferences?.showProgress ?? true},
     {key: 'colorAttribution', label: 'Color Attribution', value: preferences?.colorAttribution ?? false},
+    {key: 'sound', label: 'Sound on solve', value: preferences?.sound ?? true},
   ];
 
   return (


### PR DESCRIPTION
Gates the jingle played in Confetti on game solve behind a user
preference, following the same pattern as dark mode and other game
preferences: persisted to localStorage, synced to the server's
preferences JSONB for authenticated users, and exposed as a toggle in
the Account page's Game Preferences section. Defaults to on so existing
behavior is unchanged.

https://claude.ai/code/session_015TKrfqg9pjspDaSXw7NfKq