### PR TITLE
Add /api/health/email endpoint for SendGrid monitoring

### DIFF
--- a/server/__tests__/api/health.test.ts
+++ b/server/__tests__/api/health.test.ts
@@ -79,6 +79,38 @@ describe('/api/health/email', () => {
     expect(bodyStr).not.toContain('sendgrid');
   });
 
+  it('coalesces concurrent cache misses into a single SendGrid call', async () => {
+    let resolveCheck: (value: {ok: boolean}) => void = () => {};
+    const pending = new Promise<{ok: boolean}>((resolve) => {
+      resolveCheck = resolve;
+    });
+    const fetchMock = jest.fn().mockReturnValue(pending);
+    global.fetch = fetchMock as any;
+    const app = buildApp();
+
+    // Fire 5 concurrent requests while SendGrid call is pending
+    const requests = Promise.all([
+      request(app).get('/health/email'),
+      request(app).get('/health/email'),
+      request(app).get('/health/email'),
+      request(app).get('/health/email'),
+      request(app).get('/health/email'),
+    ]);
+
+    // Let the event loop run so all requests hit the handler
+    await new Promise((r) => setImmediate(r));
+
+    resolveCheck({ok: true});
+    const responses = await requests;
+
+    responses.forEach((res) => {
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('ok');
+    });
+    // Despite 5 concurrent requests, SendGrid was only called once
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('calls SendGrid /v3/scopes with Bearer auth', async () => {
     const fetchMock = jest.fn().mockResolvedValue({ok: true});
     global.fetch = fetchMock as any;

--- a/server/__tests__/api/health.test.ts
+++ b/server/__tests__/api/health.test.ts
@@ -1,0 +1,96 @@
+import express from 'express';
+import request from 'supertest';
+
+describe('/api/health/email', () => {
+  const originalFetch = global.fetch;
+  const originalApiKey = process.env.SENDGRID_API_KEY;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.SENDGRID_API_KEY = originalApiKey;
+  });
+
+  function buildApp() {
+    // Re-require the router so the in-memory cache resets between tests.
+    const healthRouter = require('../../api/health').default;
+    const app = express();
+    app.use('/health', healthRouter);
+    return app;
+  }
+
+  it('returns 200 when SendGrid returns success', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ok: true}) as any;
+    const app = buildApp();
+    const res = await request(app).get('/health/email');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+
+  it('returns 503 when SendGrid returns an error status', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ok: false, status: 401}) as any;
+    const app = buildApp();
+    const res = await request(app).get('/health/email');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('degraded');
+  });
+
+  it('returns 503 when SendGrid fetch throws', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network error')) as any;
+    const app = buildApp();
+    const res = await request(app).get('/health/email');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('degraded');
+  });
+
+  it('returns 503 when SENDGRID_API_KEY is unset', async () => {
+    delete process.env.SENDGRID_API_KEY;
+    global.fetch = jest.fn();
+    const app = buildApp();
+    const res = await request(app).get('/health/email');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('degraded');
+    // Should not have called SendGrid at all
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('caches the result: second request does not hit SendGrid', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ok: true});
+    global.fetch = fetchMock as any;
+    const app = buildApp();
+    const res1 = await request(app).get('/health/email');
+    const res2 = await request(app).get('/health/email');
+    expect(res1.body.cached).toBe(false);
+    expect(res2.body.cached).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('response body contains no sensitive data', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ok: true}) as any;
+    const app = buildApp();
+    const res = await request(app).get('/health/email');
+    const bodyStr = JSON.stringify(res.body);
+    expect(bodyStr).not.toContain('SG.');
+    expect(bodyStr).not.toContain('apiKey');
+    expect(bodyStr).not.toContain('sendgrid');
+  });
+
+  it('calls SendGrid /v3/scopes with Bearer auth', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ok: true});
+    global.fetch = fetchMock as any;
+    const app = buildApp();
+    await request(app).get('/health/email');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.sendgrid.com/v3/scopes',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: expect.stringMatching(/^Bearer /),
+        }),
+      })
+    );
+  });
+});

--- a/server/api/health.ts
+++ b/server/api/health.ts
@@ -16,6 +16,7 @@ const healthLimiter = rateLimit({
 type CachedResult = {status: 'ok' | 'degraded'; timestamp: number};
 const CACHE_TTL_MS = 60 * 1000;
 let emailCache: CachedResult | null = null;
+let inflightCheck: Promise<'ok' | 'degraded'> | null = null;
 
 async function checkSendGrid(): Promise<'ok' | 'degraded'> {
   const apiKey = process.env.SENDGRID_API_KEY;
@@ -56,7 +57,13 @@ router.get('/email', healthLimiter, async (_req, res) => {
     return;
   }
 
-  const status = await checkSendGrid();
+  // Coalesce concurrent cache misses: all callers share one in-flight SendGrid call
+  if (!inflightCheck) {
+    inflightCheck = checkSendGrid().finally(() => {
+      inflightCheck = null;
+    });
+  }
+  const status = await inflightCheck;
   emailCache = {status, timestamp: now};
   res.status(status === 'ok' ? 200 : 503).json({status, cached: false});
 });

--- a/server/api/health.ts
+++ b/server/api/health.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import rateLimit, {ipKeyGenerator} from 'express-rate-limit';
+
+const router = express.Router();
+
+// Rate limit: 60 requests/hour per IP. UptimeRobot at 5-min intervals = 12/hr.
+const healthLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 60,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+  keyGenerator: (req) => ipKeyGenerator(req.ip || 'unknown'),
+  message: {status: 'rate_limited'},
+});
+
+type CachedResult = {status: 'ok' | 'degraded'; timestamp: number};
+const CACHE_TTL_MS = 60 * 1000;
+let emailCache: CachedResult | null = null;
+
+async function checkSendGrid(): Promise<'ok' | 'degraded'> {
+  const apiKey = process.env.SENDGRID_API_KEY;
+  if (!apiKey) return 'degraded';
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const resp = await fetch('https://api.sendgrid.com/v3/scopes', {
+      headers: {Authorization: `Bearer ${apiKey}`},
+      signal: controller.signal,
+    });
+    return resp.ok ? 'ok' : 'degraded';
+  } catch {
+    return 'degraded';
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * @openapi
+ * /health/email:
+ *   get:
+ *     tags: [Health]
+ *     summary: Email (SendGrid) health check
+ *     description: Returns 200 if the SendGrid API key is accepted by SendGrid, 503 otherwise. Cached for 60s to cap upstream cost.
+ *     responses:
+ *       200: {description: SendGrid reachable and authenticated}
+ *       503: {description: SendGrid unreachable or API key rejected}
+ *       429: {description: Rate limited}
+ */
+router.get('/email', healthLimiter, async (_req, res) => {
+  const now = Date.now();
+  if (emailCache && now - emailCache.timestamp < CACHE_TTL_MS) {
+    res.status(emailCache.status === 'ok' ? 200 : 503).json({status: emailCache.status, cached: true});
+    return;
+  }
+
+  const status = await checkSendGrid();
+  emailCache = {status, timestamp: now};
+  res.status(status === 'ok' ? 200 : 503).json({status, cached: false});
+});
+
+export default router;

--- a/server/api/router.ts
+++ b/server/api/router.ts
@@ -11,6 +11,7 @@ import userStatsRouter from './user_stats';
 import gameSnapshotRouter from './game_snapshot';
 import gameProgressRouter from './game_progress';
 import userGamesRouter from './user_games';
+import healthRouter from './health';
 
 const router = express.Router();
 
@@ -26,5 +27,6 @@ router.use('/game-progress', gameProgressRouter);
 router.use('/oembed', oEmbedRouter);
 router.use('/link_preview', linkPreviewRouter);
 router.use('/counters', countersRouter);
+router.use('/health', healthRouter);
 
 export default router;


### PR DESCRIPTION
## Summary
- Adds `GET /api/health/email` that checks if the SendGrid API key is accepted. Returns **200** if valid, **503** if not.
- Designed for UptimeRobot to catch SendGrid outages proactively — the one this week blocked 7 users from verifying emails and went undetected for ~30 hours.

## Abuse protections
- **Rate limited**: 60 req/hr per IP (UptimeRobot at 5min = 12/hr — plenty of headroom)
- **Cached**: in-memory TTL of 60s. Even if someone spams the endpoint, SendGrid is only called once per minute
- **No secrets in response**: body is just `{status: 'ok'|'degraded', cached: bool}` — no stack traces, no env vars, no API key fragments
- **5s timeout** on the upstream SendGrid call prevents hangs
- **Cheapest upstream check**: `GET /v3/scopes` (auth check only, no data returned)

## Next step after merge
Add UptimeRobot monitor:
- URL: `https://downforacross-com.onrender.com/api/health/email`
- Expect: HTTP 200
- Interval: 5 min

## Test plan
- [x] 7 unit tests pass (all 207 server tests pass)
- [x] TypeScript + ESLint clean
- [ ] After deploy: curl the endpoint and verify it returns 200 with valid SendGrid key

🤖 Generated with [Claude Code](https://claude.com/claude-code)