### PR TITLE
Override follow-redirects to fix moderate vuln blocking CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
       "undici": ">=7.24.0",
       "flatted": ">=3.4.2",
       "socket.io-parser": ">=4.2.6",
-      "axios": ">=1.15.0"
+      "axios": ">=1.15.0",
+      "follow-redirects": ">=1.16.0"
     },
     "onlyBuiltDependencies": [
       "bcrypt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   flatted: '>=3.4.2'
   socket.io-parser: '>=4.2.6'
   axios: '>=1.15.0'
+  follow-redirects: '>=1.16.0'
 
 importers:
 
@@ -3726,8 +3727,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -9002,7 +9003,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -10031,7 +10032,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
## Summary
- Unblocks CI Security Audit job. Adds `follow-redirects: >=1.16.0` to `pnpm.overrides`, same pattern as the earlier axios override.
- Transitive dep: `@sendgrid/mail > @sendgrid/client > axios > follow-redirects`
- CVE: [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) — "follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets" (moderate severity)

## Test plan
- [x] `pnpm audit` returns "No known vulnerabilities found"
- [x] Install succeeds
- [ ] CI Security Audit passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)