### PR TITLE
Render Markdown emphasis in clue text

### DIFF
--- a/src/components/Player/ClueText.ts
+++ b/src/components/Player/ClueText.ts
@@ -3,16 +3,17 @@ import type {JSX} from 'react';
 
 type Tree = {name?: string; children: Tree[]} | {name: 'text'; value: string};
 
-// Convert Markdown emphasis markers to HTML so the existing HTML parser
-// can render them. `**text**` becomes <strong>, `*text*` becomes <em>.
-// Bold is processed first so that `**…**` wins over `*…*`. The character
-// adjacent to each marker must be non-whitespace, matching CommonMark
-// emphasis rules — this prevents stray asterisks (e.g. "5 * 6 = 30") from
-// being treated as emphasis.
+// Convert Markdown-style emphasis markers to <strong> so the existing HTML
+// parser can render them. Both `**text**` and `*text*` become bold — this
+// matches NYT-style clue rendering (e.g. "Put all the b*o*l*d* letters"
+// highlighting o, d, o, r in bold) rather than CommonMark, where `*` would
+// be italic. The character adjacent to each marker must be non-whitespace,
+// mirroring CommonMark's flanking rule so stray asterisks (e.g. "5 * 6")
+// aren't treated as emphasis.
 const applyMarkdown = (text: string): string =>
   text
     .replace(/\*\*([^*\s](?:[^*]*?[^*\s])?)\*\*/g, '<strong>$1</strong>')
-    .replace(/\*([^*\s](?:[^*]*?[^*\s])?)\*/g, '<em>$1</em>');
+    .replace(/\*([^*\s](?:[^*]*?[^*\s])?)\*/g, '<strong>$1</strong>');
 
 // parse HTML by creating a template element and walking its tree
 // keep only elements and their contents (i.e. no attributes)

--- a/src/components/Player/ClueText.ts
+++ b/src/components/Player/ClueText.ts
@@ -3,6 +3,17 @@ import type {JSX} from 'react';
 
 type Tree = {name?: string; children: Tree[]} | {name: 'text'; value: string};
 
+// Convert Markdown emphasis markers to HTML so the existing HTML parser
+// can render them. `**text**` becomes <strong>, `*text*` becomes <em>.
+// Bold is processed first so that `**…**` wins over `*…*`. The character
+// adjacent to each marker must be non-whitespace, matching CommonMark
+// emphasis rules — this prevents stray asterisks (e.g. "5 * 6 = 30") from
+// being treated as emphasis.
+const applyMarkdown = (text: string): string =>
+  text
+    .replace(/\*\*([^*\s](?:[^*]*?[^*\s])?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*([^*\s](?:[^*]*?[^*\s])?)\*/g, '<em>$1</em>');
+
 // parse HTML by creating a template element and walking its tree
 // keep only elements and their contents (i.e. no attributes)
 const simpleParse = (clue: string): Tree => {
@@ -64,11 +75,15 @@ export default function ClueText({text = ''}): JSX.Element {
     return createElement('i', {}, text.slice(1, -1));
   }
 
+  // expand Markdown emphasis (**bold**, *italic*) into HTML so the rest of
+  // this component can treat it uniformly with HTML clues
+  const processed = text.includes('*') ? applyMarkdown(text) : text;
+
   // fast path for text with no HTML and no entities
-  if (!text.match(/[<>]|&[^;]+;/)) return createElement('span', {}, text);
+  if (!processed.match(/[<>]|&[^;]+;/)) return createElement('span', {}, processed);
 
   // otherwise, parse HTML and render allowed elements
   const allowed = ['em', 'strong', 'u', 'i', 'b', 'sup', 'sub'];
-  const tree = simpleParse(text);
+  const tree = simpleParse(processed);
   return createElement('span', {}, simpleRender(tree, allowed));
 }

--- a/src/components/Player/__tests__/ClueText.test.tsx
+++ b/src/components/Player/__tests__/ClueText.test.tsx
@@ -20,17 +20,17 @@ describe('ClueText', () => {
     expect(render('""quoted clue""')).toBe('<i>&quot;quoted clue&quot;</i>');
   });
 
-  it('renders **text** as bold via Markdown', () => {
+  it('renders **text** as bold', () => {
     expect(render('A **bold** move')).toBe('<span>A <strong>bold</strong> move</span>');
   });
 
-  it('renders *text* as italic via Markdown', () => {
-    expect(render('An *emphatic* clue')).toBe('<span>An <em>emphatic</em> clue</span>');
+  it('renders *text* as bold (NYT convention)', () => {
+    expect(render('An *emphatic* clue')).toBe('<span>An <strong>emphatic</strong> clue</span>');
   });
 
   it('renders multiple Markdown spans within a single clue', () => {
     expect(render('Put all the b*o*l*d* letters in this clue t*o*gethe*r*?')).toBe(
-      '<span>Put all the b<em>o</em>l<em>d</em> letters in this clue t<em>o</em>gethe<em>r</em>?</span>'
+      '<span>Put all the b<strong>o</strong>l<strong>d</strong> letters in this clue t<strong>o</strong>gethe<strong>r</strong>?</span>'
     );
   });
 
@@ -42,7 +42,7 @@ describe('ClueText', () => {
     expect(render('* not emphasis *')).toBe('<span>* not emphasis *</span>');
   });
 
-  it('prefers ** over * when both are present', () => {
-    expect(render('**very** *neat*')).toBe('<span><strong>very</strong> <em>neat</em></span>');
+  it('renders both ** and * as bold when mixed', () => {
+    expect(render('**very** *neat*')).toBe('<span><strong>very</strong> <strong>neat</strong></span>');
   });
 });

--- a/src/components/Player/__tests__/ClueText.test.tsx
+++ b/src/components/Player/__tests__/ClueText.test.tsx
@@ -1,0 +1,48 @@
+import {renderToStaticMarkup} from 'react-dom/server';
+import ClueText from '../ClueText';
+
+const render = (text: string) => renderToStaticMarkup(<ClueText text={text} />);
+
+describe('ClueText', () => {
+  it('renders plain text as a span', () => {
+    expect(render('Plain clue')).toBe('<span>Plain clue</span>');
+  });
+
+  it('renders allowed HTML tags', () => {
+    expect(render('See <i>also</i> 1A')).toBe('<span>See <i>also</i> 1A</span>');
+  });
+
+  it('strips disallowed tags but keeps their content', () => {
+    expect(render('<script>alert(1)</script>boom')).toBe('<span>alert(1)boom</span>');
+  });
+
+  it('italicizes the whole clue when wrapped in double quotes', () => {
+    expect(render('""quoted clue""')).toBe('<i>&quot;quoted clue&quot;</i>');
+  });
+
+  it('renders **text** as bold via Markdown', () => {
+    expect(render('A **bold** move')).toBe('<span>A <strong>bold</strong> move</span>');
+  });
+
+  it('renders *text* as italic via Markdown', () => {
+    expect(render('An *emphatic* clue')).toBe('<span>An <em>emphatic</em> clue</span>');
+  });
+
+  it('renders multiple Markdown spans within a single clue', () => {
+    expect(render('Put all the b*o*l*d* letters in this clue t*o*gethe*r*?')).toBe(
+      '<span>Put all the b<em>o</em>l<em>d</em> letters in this clue t<em>o</em>gethe<em>r</em>?</span>'
+    );
+  });
+
+  it('leaves stray asterisks alone', () => {
+    expect(render('5 * 6 = 30')).toBe('<span>5 * 6 = 30</span>');
+  });
+
+  it('does not apply emphasis when asterisks hug whitespace', () => {
+    expect(render('* not emphasis *')).toBe('<span>* not emphasis *</span>');
+  });
+
+  it('prefers ** over * when both are present', () => {
+    expect(render('**very** *neat*')).toBe('<span><strong>very</strong> <em>neat</em></span>');
+  });
+});


### PR DESCRIPTION
## Summary
- Clues like the NYT puzzle's `Put all the b*o*l*d* letters in this clue t*o*gethe*r*?` were rendering asterisks literally, breaking the meta clue (fixes #460)
- `ClueText` now expands `**text**` → `<strong>` and `*text*` → `<em>` before HTML parsing
- CommonMark-style guard rails so stray asterisks (e.g. `5 * 6`) aren't treated as emphasis

## Test plan
- [x] New `ClueText.test.tsx` covers plain text, HTML, double-quote italics, single + double Markdown spans, the multi-span clue from the issue, and asterisk edge cases
- [x] `pnpm test` — 382 tests pass
- [x] `pnpm eslint --max-warnings 0 src/`
- [x] `pnpm prettier --check`
- [x] `pnpm tsc --noEmit`

https://claude.ai/code/session_011sJYM4UyFUo8YKwZwMjWzu