### PR TITLE
Reduce iOS keyboard footprint by suppressing the AutoFill accessory bar

### DIFF
--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -523,7 +523,6 @@ export default class MobileGridControls extends GridControls {
   renderMobileInputs() {
     // This resets the input to contain just "$" on every render.
     const inputValue = '$';
-    const inputType = 'email';
     const inputStyle = {
       opacity: 0,
       width: 0,
@@ -532,8 +531,18 @@ export default class MobileGridControls extends GridControls {
       touchEvents: 'none',
       position: 'absolute',
     };
-    const inputAutoComplete = 'none';
-    const inputAutoCapitalize = 'none';
+    // The attributes below suppress iOS / mobile keyboard chrome that eats
+    // vertical space:
+    // - autoComplete="off" disables browser autofill suggestions (the
+    //   prior value "none" is invalid and was treated like the default).
+    // - autoCorrect/spellCheck off prevent the predictive-text accessory bar.
+    // - inputMode="text" gives an explicit hint so iOS doesn't fall back to
+    //   email-style behavior (which surfaced the credit-card / contacts /
+    //   location AutoFill bar above the keyboard).
+    // - data-*-ignore + data-form-type opt out of 1Password / LastPass /
+    //   Bitwarden popups (mirrors the desktop GridControls fix).
+    // Previously these textareas had type="email", which is invalid on a
+    // <textarea> but iOS WebKit picked it up and rendered the autofill bar.
 
     const USE_TEXT_AREA = true;
     if (USE_TEXT_AREA) {
@@ -542,10 +551,16 @@ export default class MobileGridControls extends GridControls {
           <textarea
             name="1"
             value={inputValue}
-            type={inputType}
             style={inputStyle}
-            autoComplete={inputAutoComplete}
-            autoCapitalize={inputAutoCapitalize}
+            autoComplete="off"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            inputMode="text"
+            data-1p-ignore
+            data-lpignore="true"
+            data-bw-ignore="true"
+            data-form-type="other"
             onBlur={this.handleInputBlur}
             onFocus={this.handleInputFocus}
             onChange={this.handleInputChange}
@@ -554,10 +569,16 @@ export default class MobileGridControls extends GridControls {
             name="2"
             ref={this.inputRef}
             value={inputValue}
-            type={inputType}
             style={inputStyle}
-            autoComplete={inputAutoComplete}
-            autoCapitalize={inputAutoCapitalize}
+            autoComplete="off"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            inputMode="text"
+            data-1p-ignore
+            data-lpignore="true"
+            data-bw-ignore="true"
+            data-form-type="other"
             onBlur={this.handleInputBlur}
             onFocus={this.handleInputFocus}
             onChange={this.handleInputChange}
@@ -566,10 +587,16 @@ export default class MobileGridControls extends GridControls {
           <textarea
             name="3"
             value={inputValue}
-            type={inputType}
             style={inputStyle}
-            autoComplete={inputAutoComplete}
-            autoCapitalize={inputAutoCapitalize}
+            autoComplete="off"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            inputMode="text"
+            data-1p-ignore
+            data-lpignore="true"
+            data-bw-ignore="true"
+            data-form-type="other"
             onBlur={this.handleInputBlur}
             onFocus={this.handleInputFocus}
             onChange={this.handleInputChange}
@@ -582,10 +609,17 @@ export default class MobileGridControls extends GridControls {
         <input
           name="1"
           value={inputValue}
-          type={inputType}
+          type="text"
           style={inputStyle}
-          autoComplete={inputAutoComplete}
-          autoCapitalize={inputAutoCapitalize}
+          autoComplete="off"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+          inputMode="text"
+          data-1p-ignore
+          data-lpignore="true"
+          data-bw-ignore="true"
+          data-form-type="other"
           onBlur={this.handleInputBlur}
           onFocus={this.handleInputFocus}
           onChange={this.handleInputChange}
@@ -594,10 +628,17 @@ export default class MobileGridControls extends GridControls {
           name="2"
           ref={this.inputRef}
           value={inputValue}
-          type={inputType}
+          type="text"
           style={inputStyle}
-          autoComplete={inputAutoComplete}
-          autoCapitalize={inputAutoCapitalize}
+          autoComplete="off"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+          inputMode="text"
+          data-1p-ignore
+          data-lpignore="true"
+          data-bw-ignore="true"
+          data-form-type="other"
           onBlur={this.handleInputBlur}
           onFocus={this.handleInputFocus}
           onChange={this.handleInputChange}
@@ -606,10 +647,17 @@ export default class MobileGridControls extends GridControls {
         <input
           name="3"
           value={inputValue}
-          type={inputType}
+          type="text"
           style={inputStyle}
-          autoComplete={inputAutoComplete}
-          autoCapitalize={inputAutoCapitalize}
+          autoComplete="off"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+          inputMode="text"
+          data-1p-ignore
+          data-lpignore="true"
+          data-bw-ignore="true"
+          data-form-type="other"
           onBlur={this.handleInputBlur}
           onFocus={this.handleInputFocus}
           onChange={this.handleInputChange}


### PR DESCRIPTION
## Summary

On iOS Chrome the on-screen keyboard was consuming ~60% of the viewport because iOS was rendering its **AutoFill assistant bar** (key / credit-card / location / contacts icons) above the QWERTY keyboard. That bar is shown whenever a focused field looks like a form field worth autofilling.

The hidden keyboard-capture textareas in `src/components/Player/MobileGridControls.js` were actively opting *into* that treatment:

- `type="email"` — invalid on `<textarea>`, but iOS WebKit picks it up and treats the field as an email input.
- `autoComplete="none"` — `"none"` is not a valid value, so browsers fall back to the default (`"on"`).
- No `autoCorrect`, `spellCheck`, `inputMode`, or password-manager opt-out attributes.

A prior commit (0f4a1416, "Prevent password managers from showing autofill on grid input") already fixed this class of bug for the desktop `GridControls.js`, but never touched the mobile path — so Bitwarden/1Password/LastPass popups and the iOS AutoFill bar still appeared over the grid on mobile.

## Changes

For all three hidden capture textareas (and the unused `<input>` fallback branch) in `MobileGridControls.js`:

- Removed `type="email"`.
- `autoComplete="off"` (was the invalid `"none"`).
- Added `autoCorrect="off"`, `spellCheck={false}`, `inputMode="text"` to suppress the predictive-text accessory bar and keep iOS from falling back to email-style behavior.
- Added password-manager opt-outs: `data-1p-ignore`, `data-lpignore="true"`, `data-bw-ignore="true"`, `data-form-type="other"` (matches the desktop `GridControls` fix).

## What this does not fix

The QWERTY keyboard itself is iOS-controlled and can't be made smaller from the web. If the AutoFill bar still appears under some iOS configuration, the only remaining lever is swapping the hidden `<textarea>` for a `<div contenteditable>` (which iOS doesn't attach the AutoFill bar to at all) — a larger refactor that I'd do as a follow-up if needed.

## Test plan

- [x] `pnpm eslint --max-warnings 0 src/components/Player/MobileGridControls.js`
- [x] `pnpm prettier --check`
- [x] `pnpm tsc --noEmit`
- [x] `pnpm vitest run src/components/Player` (56 tests, all pass)
- [ ] Manual: load a game on iOS Chrome, tap a cell, confirm the AutoFill assistant bar no longer appears above the keyboard and the keyboard occupies less vertical space
- [ ] Manual: verify letter entry, backspace, space (via `@`-fallback), Tab (via `,`), and pencil mode (via `.`) still all work on iOS
- [ ] Manual: verify gesture/swipe typing still inputs multiple letters
- [ ] Manual: confirm no password-manager popups appear over the grid on iOS/Android

https://claude.ai/code/session_01Nrn47H9cxW7oM9HL6sMxeK