### PR TITLE
Add Focus mode and let fontScale grow grid cells

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -405,13 +405,15 @@ export default class Game extends Component {
     if (this.props.mobile) {
       width = Math.min((35 * 15 * cols) / rows, screenWidth - 20);
     } else {
-      // Size grid to fill available viewport height without overflowing the screen.
-      // Reserved space: nav (~41px) + toolbar (~30px) + clue bar (~44px) + padding (~24px) + margin (~46px)
-      const DESKTOP_CHROME_HEIGHT = 185;
+      // Keep the grid inside the viewport so high browser zooms don't overflow.
+      // Reserved chrome: nav (~41px) + toolbar (~30px) + clue bar (~44px) + padding (~24px) + margin (~46px).
+      // Focus mode hides the nav, so subtract its height.
+      const NAV_HEIGHT = 41;
+      const DESKTOP_CHROME_HEIGHT = 185 - (this.props.focusMode ? NAV_HEIGHT : 0);
       const availableHeight = window.innerHeight - DESKTOP_CHROME_HEIGHT;
       const viewportWidth = (availableHeight * cols) / rows;
-      // Cap at the old fixed sizing so zooming out shrinks the grid as expected
-      const fixedWidth = (35 * 15 * cols) / rows;
+      // Cap scales with fontScale so "Text: Larger" grows cells up to the viewport cap.
+      const fixedWidth = (35 * 15 * this.state.fontScale * cols) / rows;
       width = Math.min(viewportWidth, fixedWidth, screenWidth - 20);
     }
     const minSize = this.props.mobile ? 1 : 20;
@@ -545,6 +547,8 @@ export default class Game extends Component {
         percentComplete={this.state.showProgress ? this.getPercentComplete() : 0}
         fontScale={this.state.fontScale}
         onFontScaleChange={this.handleFontScale}
+        focusMode={this.props.focusMode}
+        onToggleFocusMode={this.props.onToggleFocusMode}
       />
     );
   }

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -197,11 +197,15 @@ export default class Toolbar extends Component {
       showProgress,
       onFontScaleChange,
       fontScale = 1,
+      focusMode,
+      onToggleFocusMode,
+      mobile,
     } = this.props;
     const vimModeLabel = vimMode ? 'Vim mode off' : 'Vim mode';
     const skipFilledSquaresLabel = skipFilledSquares ? "Don't skip filled" : 'Skip filled';
     const autoAdvanceLabel = autoAdvanceCursor ? 'No auto-advance' : 'Auto-advance';
     const showProgressLabel = showProgress ? 'Hide progress' : 'Show progress';
+    const focusModeLabel = focusMode ? 'Focus mode off' : 'Focus mode';
     const isScaled = Math.round(fontScale * 100) !== 100;
     const resetLabel = `Text: Reset (${Math.round(fontScale * 100)}%)`;
     return (
@@ -213,6 +217,7 @@ export default class Toolbar extends Component {
           [skipFilledSquaresLabel]: this.handleSkipFilledSquaresClick,
           [autoAdvanceLabel]: this.props.onToggleAutoAdvanceCursor,
           [showProgressLabel]: this.props.onToggleShowProgress,
+          ...(!mobile && onToggleFocusMode && {[focusModeLabel]: onToggleFocusMode}),
           'Color Attribution': onToggleColorAttributionMode,
           'List View': this.props.onToggleListView,
           Pencil: this.props.onTogglePencil,

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -37,6 +37,7 @@ class Game extends Component {
       mobile: isMobile(),
       mode: 'game',
       chatHidden: localStorage.getItem('chat_hidden') === 'true',
+      focusMode: localStorage.getItem('focus_mode') === 'true',
       lastReadChat: 0,
       replayRetained: null, // null = no snapshot yet, false = snapshot exists but not retained, true = retained
       savingReplay: false,
@@ -234,6 +235,14 @@ class Game extends Component {
     return color;
   }
 
+  handleToggleFocusMode = () => {
+    this.setState((prevState) => {
+      const focusMode = !prevState.focusMode;
+      localStorage.setItem('focus_mode', String(focusMode));
+      return {focusMode};
+    });
+  };
+
   handleToggleChat = () => {
     if (this.state.mobile) {
       this.setState((prevState) => ({mode: prevState.mode === 'game' ? 'chat' : 'game'}));
@@ -389,6 +398,8 @@ class Game extends Component {
         savingReplay={this.state.savingReplay}
         isAuthenticated={this.context?.isAuthenticated}
         onPreferenceChange={this.context?.savePreference}
+        focusMode={this.state.focusMode}
+        onToggleFocusMode={this.handleToggleFocusMode}
       />
     );
   }
@@ -445,10 +456,10 @@ class Game extends Component {
       </>
     );
 
-    const {chatHidden} = this.state;
+    const {chatHidden, focusMode} = this.state;
     const desktopContent = (
       <>
-        <Nav />
+        <Nav hidden={focusMode} />
         <div className="game">
           <div className={`flex--column flex--shrink-0${chatHidden ? ' flex--center-h' : ''}`}>
             {this.showingGame && this.renderGame()}


### PR DESCRIPTION
## Summary
Fixes #463.

- **Focus mode** toggle in the Extras menu (desktop only) hides the Nav and hands its ~41px back to the grid. Persists in `localStorage`.
- **"Text: Larger" now grows cells**, not just text. The desktop grid size cap scales with `fontScale`, clamped by the viewport so high browser zooms don't overflow.

On Katlyn's 13" MBA (the case in the issue), a 15×15 grid at default `fontScale` 1.0 stays at 525px. With focus mode + `fontScale` 1.4, it fills the freed vertical space (~735px). Browser zoom still scales everything proportionally.

## Test plan
- [ ] Desktop: open a game, flip Extras → Focus mode; Nav hides, grid grows to fill the reclaimed space.
- [ ] Desktop: Extras → Text: Larger; cells (not just letters) get bigger until they hit the viewport cap.
- [ ] Desktop: browser zoom 100 → 150; grid scales with the rest of the page and stays inside the viewport.
- [ ] Focus mode preference survives reload.
- [ ] Mobile: no Focus mode entry in the Extras menu; mobile sizing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)