### PR TITLE
Outline pencil letters in dark mode

### DIFF
--- a/src/dark.css
+++ b/src/dark.css
@@ -81,12 +81,8 @@
 .dark .cell.pencil .cell--value {
   color: var(--pencil-color);
 
-  /* Outline halo keeps pencil letters legible against colored selection/highlight backgrounds. */
-  text-shadow:
-    -1px -1px 0 rgb(0 0 0 / 70%),
-    1px -1px 0 rgb(0 0 0 / 70%),
-    -1px 1px 0 rgb(0 0 0 / 70%),
-    1px 1px 0 rgb(0 0 0 / 70%);
+  /* Soft halo keeps pencil letters legible against colored selection/highlight backgrounds. */
+  text-shadow: 0 0 2px rgb(0 0 0 / 70%);
 }
 
 .dark .cell--shade {

--- a/src/dark.css
+++ b/src/dark.css
@@ -80,6 +80,13 @@
 
 .dark .cell.pencil .cell--value {
   color: var(--pencil-color);
+
+  /* Outline halo keeps pencil letters legible against colored selection/highlight backgrounds. */
+  text-shadow:
+    -1px -1px 0 rgb(0 0 0 / 70%),
+    1px -1px 0 rgb(0 0 0 / 70%),
+    -1px 1px 0 rgb(0 0 0 / 70%),
+    1px 1px 0 rgb(0 0 0 / 70%);
 }
 
 .dark .cell--shade {


### PR DESCRIPTION
## Summary
Fixes #462.

Gray pencil letters (`#888`) on a colored selected-cell background (`myColor`) produced ~2:1 contrast in dark mode — the "A" in pencilled "BAS" and letters in "SAGE" became unreadable when the cell was selected or highlighted.

Added a 1px 70%-black text-shadow halo to pencil letters in dark mode only. On the normal dark cell background the halo blends into the surrounding darkness; on the colored selection/highlight background it gives each letter a dark outline so it stays legible without overriding the user's configured pencil color.

## Test plan
- [ ] Dark mode, pencil-write letters into a clue, navigate across/down — selected and highlighted cells both stay readable.
- [ ] Dark mode, unselected pencil cells look essentially unchanged (halo blends into dark bg).
- [ ] Light mode unaffected.
- [ ] Try a few different user colors (pink, blue, green) to confirm the halo helps across hues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)