### PR TITLE
Bump uuid to 14, replace server usage with crypto.randomUUID

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "typescript": "~5.9.3",
-    "uuid": "^11.1.0"
+    "uuid": "^14.0.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,8 +131,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
@@ -5883,8 +5883,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -12516,7 +12516,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.0: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -1,7 +1,6 @@
 import crypto from 'crypto';
 import _ from 'lodash';
 import Joi from 'joi';
-import * as uuid from 'uuid';
 import {PuzzleJson, ListPuzzleRequestFilters, AddPuzzleResult} from '@shared/types';
 import {pool} from './pool';
 import {dayOfWeekExtract} from './sql_helpers';
@@ -277,7 +276,7 @@ export async function addPuzzle(
   pid?: string,
   uploadedBy?: string | null
 ): Promise<AddPuzzleResult> {
-  const puzzleId = pid || uuid.v4().substr(0, 8);
+  const puzzleId = pid || crypto.randomUUID().substr(0, 8);
   validatePuzzle(puzzle);
   const contentHash = computePuzzleHash(puzzle);
 

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -276,7 +276,7 @@ export async function addPuzzle(
   pid?: string,
   uploadedBy?: string | null
 ): Promise<AddPuzzleResult> {
-  const puzzleId = pid || crypto.randomUUID().substr(0, 8);
+  const puzzleId = pid || crypto.randomUUID().slice(0, 8);
   validatePuzzle(puzzle);
   const contentHash = computePuzzleHash(puzzle);
 


### PR DESCRIPTION
## Summary

- Bumps `uuid` from `^11.1.0` to `^14.0.0`, resolving the moderate advisory [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) that was failing the CI Security Audit step (#473). Note: the actual vuln only affects `v3/v5/v6` with a caller-supplied `buf`; this codebase uses only `v4()`, so runtime behavior was never at risk.
- `uuid@12+` dropped CommonJS support. `ts-jest` on the server runs in CJS mode, so `import * as uuid from 'uuid'` started failing three server test suites with `SyntaxError: Unexpected token 'export'`. The sole backend callsite (`puzzle id` generation in [server/model/puzzle.ts](server/model/puzzle.ts)) is replaced with Node's built-in `crypto.randomUUID()` — identical output format, no new dependency, tests pass.
- Frontend callsites ([src/localAuth.js](src/localAuth.js), [src/components/Fencing/Fencing.tsx](src/components/Fencing/Fencing.tsx), [src/store/game.js](src/store/game.js)) are unaffected — vitest handles the new ESM export natively.

## Test plan

- [x] `pnpm audit --ignore-registry-errors` — no known vulnerabilities
- [x] `pnpm eslint --max-warnings 0 src/ server/` — clean
- [x] `pnpm stylelint` — clean
- [x] `pnpm prettier --check "src/**/*.{js,jsx,ts,tsx}" "server/**/*.{js,ts}"` — clean
- [x] `pnpm test` — 382/382 passing
- [x] `pnpm test:server --ci` — 208/208 passing (previously 3 suites failed on import)
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm tsc --noEmit -p server/tsconfig.json` — clean
- [x] `pnpm build` — successful

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)