### PR TITLE
Unblock Android volume rocker in games (#479)

### DIFF
--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -19,6 +19,16 @@ function getClueAbbreviation({clueNumber = '', direction = ''} = {}) {
   return `${clueNumber}${direction.substring(0, 1).toUpperCase()}`;
 }
 
+// Firefox Android routes hardware volume keys through the focused element
+// instead of the OS media bus, so while our hidden IME-capture textarea is
+// focused the device volume rocker stops working (#479). Blur on detection
+// so the next press reaches the OS.
+function handleVolumeKeyBlur(ev) {
+  if (ev.key === 'AudioVolumeUp' || ev.key === 'AudioVolumeDown' || ev.key === 'AudioVolumeMute') {
+    ev.target.blur();
+  }
+}
+
 export default class MobileGridControls extends GridControls {
   constructor() {
     super();
@@ -571,6 +581,7 @@ export default class MobileGridControls extends GridControls {
             onBlur={this.handleInputBlur}
             onFocus={this.handleInputFocus}
             onChange={this.handleInputChange}
+            onKeyDown={handleVolumeKeyBlur}
           />
           <textarea
             name="2"
@@ -589,6 +600,7 @@ export default class MobileGridControls extends GridControls {
             onBlur={this.handleInputBlur}
             onFocus={this.handleInputFocus}
             onChange={this.handleInputChange}
+            onKeyDown={handleVolumeKeyBlur}
             onKeyUp={this.handleKeyUp}
           />
           <textarea
@@ -607,6 +619,7 @@ export default class MobileGridControls extends GridControls {
             onBlur={this.handleInputBlur}
             onFocus={this.handleInputFocus}
             onChange={this.handleInputChange}
+            onKeyDown={handleVolumeKeyBlur}
           />
         </>
       );

--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -22,9 +22,19 @@ function getClueAbbreviation({clueNumber = '', direction = ''} = {}) {
 // Firefox Android routes hardware volume keys through the focused element
 // instead of the OS media bus, so while our hidden IME-capture textarea is
 // focused the device volume rocker stops working (#479). Blur on detection
-// so the next press reaches the OS.
+// so the next press reaches the OS. Includes both the modern AudioVolume*
+// values and the deprecated Volume* values still used by some older Android
+// browsers / WebViews.
+const VOLUME_KEYS = new Set([
+  'AudioVolumeUp',
+  'AudioVolumeDown',
+  'AudioVolumeMute',
+  'VolumeUp',
+  'VolumeDown',
+  'VolumeMute',
+]);
 function handleVolumeKeyBlur(ev) {
-  if (ev.key === 'AudioVolumeUp' || ev.key === 'AudioVolumeDown' || ev.key === 'AudioVolumeMute') {
+  if (VOLUME_KEYS.has(ev.key)) {
     ev.target.blur();
   }
 }


### PR DESCRIPTION
## Summary

Fix for #479 — on Firefox Android (reporter: Xiaomi Note 10 Pro, Android 12, Firefox 149.0.2), the device volume rocker stops working whenever a game is open with the keyboard up. Volume keys work normally on non-game pages.

## Hypothesis

The mobile input layer (`MobileGridControls`) renders three opacity-0 hidden `<textarea>` elements that are continuously focused to keep the native IME visible and capture letter input via `onChange` value-diffing. Firefox Android is known to route hardware volume keys through the currently-focused element's keydown path rather than the OS media bus; as long as the hidden textarea holds focus, the rocker has no audible effect.

Chrome intercepts these keys at a lower layer, which is why the bug is Firefox-specific.

## Change

A module-level `handleVolumeKeyBlur` is wired as `onKeyDown` on all three hidden textareas ([src/components/Player/MobileGridControls.js](src/components/Player/MobileGridControls.js)). If the event's `key` is `AudioVolumeUp`, `AudioVolumeDown`, or `AudioVolumeMute`, the textarea is blurred, which hands control of subsequent volume presses back to the OS. `keepFocus` refocuses the textarea on the next grid/clue-bar interaction so gameplay is uninterrupted.

Handler is plain (no `this`) so it lives outside the class and satisfies `class-methods-use-this`.

## Known limitations

- **Unverified against the target device.** Cannot reproduce without a Xiaomi Android 12 / Firefox 149 setup. If volume keys don't actually surface as `keydown` events on that device (e.g. the block is happening at the audio-focus layer instead), this change is a no-op rather than a regression.
- **First press is still lost.** This fix only restores control for *subsequent* presses after the handler fires. A true fix would require not holding focus on the hidden textarea at all, which is a much bigger redesign of the mobile IME-capture scheme.
- **Dead fallback branch untouched.** The `USE_TEXT_AREA=false` `<input>` path in the same file is hardcoded off and not patched.

## Test plan

- [x] Lint, prettier, typecheck, tests, build all clean
- [ ] Deploy to testing env and have reporter confirm volume rocker responds while a game is open with the keyboard visible
- [ ] Confirm no regression in normal typing, letter entry, backspace, tab, and on-screen-keyboard behavior on iOS Safari and Chrome Android
- [ ] Confirm no visible loss-of-focus flicker when non-volume keys are pressed

Refs #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)