### PR TITLE
Fix orphan games leaking into every puzzle's Your Games list (#478)

### DIFF
--- a/server/model/user_games.ts
+++ b/server/model/user_games.ts
@@ -210,7 +210,9 @@ export async function getUserGamesForPuzzle(
        FROM user_games ug
        LEFT JOIN game_events ce ON ce.gid = ug.gid AND ce.event_type = 'create'
        LEFT JOIN game_snapshots gs ON gs.gid = ug.gid
-       LEFT JOIN firebase_history fh ON fh.gid = ug.gid AND fh.dfac_id = ANY($1)
+       LEFT JOIN LATERAL (
+         SELECT pid FROM firebase_history WHERE gid = ug.gid AND dfac_id = ANY($1) LIMIT 1
+       ) fh ON true
        WHERE COALESCE(ce.event_payload->'params'->>'pid', gs.pid, fh.pid::text) = $2
        ORDER BY ug.last_activity DESC`,
       options.userId ? [dfacIds, pid, options.userId, pidInt] : [dfacIds, pid, pidInt]

--- a/server/model/user_games.ts
+++ b/server/model/user_games.ts
@@ -203,14 +203,15 @@ export async function getUserGamesForPuzzle(
        )
        SELECT
          ug.gid,
-         COALESCE(ce.event_payload->'params'->>'pid', gs.pid, $2) AS pid,
+         COALESCE(ce.event_payload->'params'->>'pid', gs.pid, fh.pid::text) AS pid,
          CASE WHEN gs.gid IS NOT NULL OR ug.fh_solved THEN true ELSE false END AS solved,
          ug.last_activity,
          ug.v2
        FROM user_games ug
        LEFT JOIN game_events ce ON ce.gid = ug.gid AND ce.event_type = 'create'
        LEFT JOIN game_snapshots gs ON gs.gid = ug.gid
-       WHERE COALESCE(ce.event_payload->'params'->>'pid', gs.pid, $2) = $2
+       LEFT JOIN firebase_history fh ON fh.gid = ug.gid AND fh.dfac_id = ANY($1)
+       WHERE COALESCE(ce.event_payload->'params'->>'pid', gs.pid, fh.pid::text) = $2
        ORDER BY ug.last_activity DESC`,
       options.userId ? [dfacIds, pid, options.userId, pidInt] : [dfacIds, pid, pidInt]
     );


### PR DESCRIPTION
## Summary

Primary cause of #478. `getUserGamesForPuzzle` was returning games that don't belong to the requested puzzle — the reporter saw the same gid(s) appear at the top of the "Your Games" list for every puzzle they opened from the Profile In Progress table.

## Root cause

[server/model/user_games.ts](server/model/user_games.ts) — the CTE fetches every gid the user has any event for, across all puzzles, with no pid filter. The outer WHERE is supposed to constrain by pid:

```sql
WHERE COALESCE(ce.event_payload->'params'->>'pid', gs.pid, $2) = $2
```

But the `$2` fallback inside the `COALESCE` defeats the filter: if a game has no `create` event in `game_events` AND no `game_snapshots` row, `COALESCE` returns `$2` (the requested pid), which trivially equals `$2`. Such "orphan" games leak into every puzzle's "Your Games" list.

## Fix

Join `firebase_history` for pid resolution and drop the `$2` fallback so games with no resolvable pid are correctly excluded:

```sql
LEFT JOIN firebase_history fh ON fh.gid = ug.gid AND fh.dfac_id = ANY($1)
WHERE COALESCE(ce.event_payload->'params'->>'pid', gs.pid, fh.pid::text) = $2
```

`getInProgressGames` already uses exactly this pattern — this change makes `getUserGamesForPuzzle` consistent.

## Verification

Reproduced live against the reporter's data (`userId=03430744-7132-4e74-b72d-965a07f50df1`):

**Before:** visiting three different puzzle pids each returned the same two orphan gids (`100483157-vusk`, `100487196-bruss`).
**After:** each pid returns only its true game; orphans without a resolvable pid return zero rows.

## Known follow-ups (not in this PR)

This PR addresses the pid leak — the user-visible "wrong game at top of list" symptom. Two related issues remain:

1. **Orphan games on the Profile In Progress list** — the reporter's only non-dismissed games are themselves orphans (single `updateDisplayName` event, no `create`, no saved grid state in `firebase_history`). Even after this fix, clicking them will hit `gameNotFound` in the Game page. These are effectively unrecoverable. Needs a separate call on whether to filter them from InProgress, or give them a different UX.
2. **Where are the stray `updateDisplayName` events coming from?** — clustered on 2026-04-22 through 2026-04-24. Something started emitting `updateDisplayName` for legacy gids that never had a create event server-side, producing new orphans. Still investigating.

## Test plan

- [x] Server typecheck, ESLint, Prettier — clean
- [x] `pnpm test:server --ci` — 208/208 passing
- [x] `pnpm test` — 382/382 passing
- [x] SQL repro against live DB — before/after verified
- [ ] Deploy to testing and confirm reporter's "Your Games" list no longer surfaces wrong puzzles' games

Refs #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)