### PR TITLE
Prevent orphan rows in game_events for unbootstrapped gids

### DIFF
--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -3,7 +3,7 @@
 import {RoomEvent} from '@shared/roomEvents';
 import * as Sentry from '@sentry/node';
 import {Server} from 'socket.io';
-import {addGameEvent, GameEvent, getGameEvents} from './model/game';
+import {addGameEvent, gameExists, GameEvent, getGameEvents} from './model/game';
 import {addRoomEvent, getRoomEvents} from './model/room';
 import {verifyAccessToken} from './auth/jwt';
 
@@ -105,6 +105,23 @@ class SocketManager {
             console.error('Invalid game_event: missing or invalid gid');
             if (typeof ack === 'function') ack({error: 'invalid gid'});
             return;
+          }
+          // Reject persisted, non-create events for gids that don't have a
+          // create event or snapshot — prevents orphan rows from accumulating
+          // for legacy gids whose game was never bootstrapped server-side
+          // (#478). Ephemeral events (cursor, ping) bypass since they aren't
+          // persisted. Cache positive results per socket to avoid repeated
+          // DB lookups.
+          if (event.type !== 'create' && !EPHEMERAL_EVENT_TYPES.has(event.type)) {
+            const verified: Set<string> = (socket.data.verifiedGids ||= new Set());
+            if (!verified.has(message.gid)) {
+              if (await gameExists(message.gid)) {
+                verified.add(message.gid);
+              } else {
+                if (typeof ack === 'function') ack({error: 'unknown game'});
+                return;
+              }
+            }
           }
           // Replace non-numeric timestamps with real server time
           if (typeof event.timestamp !== 'number') {

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -135,6 +135,12 @@ class SocketManager {
             delete event.verifiedUserId;
           }
           await this.addGameEvent(message.gid, event);
+          // A successful create persists the bootstrap row, so future events
+          // from this socket can skip the gameExists lookup.
+          if (event.type === 'create') {
+            const verified: Set<string> = (socket.data.verifiedGids ||= new Set());
+            verified.add(message.gid);
+          }
           if (typeof ack === 'function') ack();
         } catch (err) {
           console.error(`[Socket] game_event error:`, err);

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -183,6 +183,8 @@ describe('SocketManager', () => {
       const sm = new SocketManager(io);
       sm.listen();
 
+      // gameExists check — game has a create event
+      pool.query.mockResolvedValueOnce({rowCount: 1, rows: [{}]});
       const ack = jest.fn();
       const event = {type: 'updateCell', timestamp: 1700000000000, params: {id: 'p1'}} as any;
       await socketHandlers['game_event']({gid: 'g1', event}, ack);
@@ -233,6 +235,8 @@ describe('SocketManager', () => {
       const sm = new SocketManager(io);
       sm.listen();
 
+      // gameExists check — game has a create event
+      pool.query.mockResolvedValueOnce({rowCount: 1, rows: [{}]});
       const ack = jest.fn();
       const event = {
         type: 'updateCell',
@@ -255,6 +259,66 @@ describe('SocketManager', () => {
       await expect(
         socketHandlers['game_event']({gid: 'g1', event: {type: 'updateCursor', timestamp: 1000, params: {}}})
       ).resolves.not.toThrow();
+    });
+
+    it('rejects persisted events for gids without a create event or snapshot', async () => {
+      const {io, socketHandlers} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+
+      // gameExists: no create event, then no snapshot
+      pool.query.mockResolvedValueOnce({rowCount: 0, rows: []}); // create event lookup
+      pool.query.mockResolvedValueOnce({rows: []}); // getGameSnapshot
+
+      const ack = jest.fn();
+      const event = {type: 'updateCell', timestamp: 1700000000000, params: {id: 'p1'}};
+      await socketHandlers['game_event']({gid: 'orphan-gid', event}, ack);
+
+      expect(ack).toHaveBeenCalledWith({error: 'unknown game'});
+      // Only the two gameExists lookups should have run — no INSERT
+      expect(pool.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches gameExists result per socket', async () => {
+      const {io, socketHandlers} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+
+      // First event: gameExists hits DB and finds create event
+      pool.query.mockResolvedValueOnce({rowCount: 1, rows: [{}]});
+      const ack1 = jest.fn();
+      await socketHandlers['game_event'](
+        {gid: 'g1', event: {type: 'updateCell', timestamp: 1700000000000, params: {id: 'p1'}}},
+        ack1
+      );
+      expect(ack1).toHaveBeenCalledWith();
+
+      // Second event for the same gid should NOT call gameExists again — only INSERT
+      pool.query.mockClear();
+      const ack2 = jest.fn();
+      await socketHandlers['game_event'](
+        {gid: 'g1', event: {type: 'updateCell', timestamp: 1700000000001, params: {id: 'p1'}}},
+        ack2
+      );
+      expect(ack2).toHaveBeenCalledWith();
+      // Only one query should have run (the INSERT) — the gameExists check was cached
+      expect(pool.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows ephemeral events to bypass the gate', async () => {
+      const {io, socketHandlers} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+
+      const ack = jest.fn();
+      await socketHandlers['game_event'](
+        {gid: 'orphan-gid', event: {type: 'updateCursor', timestamp: 1000, params: {}}},
+        ack
+      );
+
+      expect(ack).toHaveBeenCalledWith();
+      // No DB query should have run for an ephemeral event
+      expect(pool.query).not.toHaveBeenCalled();
     });
   });
 

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -305,6 +305,31 @@ describe('SocketManager', () => {
       expect(pool.query).toHaveBeenCalledTimes(1);
     });
 
+    it('primes the gameExists cache after a successful create event', async () => {
+      const {io, socketHandlers} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+
+      // Create event passes through without a gameExists lookup
+      const ack1 = jest.fn();
+      await socketHandlers['game_event'](
+        {gid: 'g1', event: {type: 'create', timestamp: 1700000000000, params: {pid: 'p1'}}},
+        ack1
+      );
+      expect(ack1).toHaveBeenCalledWith();
+
+      // Subsequent updateCell on the same socket+gid should NOT call gameExists —
+      // the create should have primed verifiedGids. Only the INSERT runs.
+      pool.query.mockClear();
+      const ack2 = jest.fn();
+      await socketHandlers['game_event'](
+        {gid: 'g1', event: {type: 'updateCell', timestamp: 1700000000001, params: {id: 'p1'}}},
+        ack2
+      );
+      expect(ack2).toHaveBeenCalledWith();
+      expect(pool.query).toHaveBeenCalledTimes(1);
+    });
+
     it('allows ephemeral events to bypass the gate', async () => {
       const {io, socketHandlers} = createMockIo();
       const sm = new SocketManager(io);

--- a/server/model/game.ts
+++ b/server/model/game.ts
@@ -121,6 +121,21 @@ export interface InitialGameEvent extends GameEvent {
   };
 }
 
+/**
+ * Returns true if the gid is a real, bootstrapped game (has a create event
+ * or a snapshot). Used to gate non-create event persistence so legacy/orphan
+ * gids don't accumulate stray events (#478).
+ */
+export async function gameExists(gid: string): Promise<boolean> {
+  const {rowCount} = await pool.query(
+    "SELECT 1 FROM game_events WHERE gid=$1 AND event_type='create' LIMIT 1",
+    [gid]
+  );
+  if (rowCount && rowCount > 0) return true;
+  const snapshot = await getGameSnapshot(gid);
+  return snapshot !== null;
+}
+
 export async function addGameEvent(gid: string, event: GameEvent) {
   // event.user is historically always null; fall back to params.id (the player's dfac_id)
   const uid = event.user || event.params?.id || null;

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -147,6 +147,13 @@ class Game extends Component {
       this.setState({gameNotFound: true});
     });
 
+    // Defer updateDisplayName until after we confirm the game has a create
+    // event server-side. Emitting on mount produced orphan rows in
+    // game_events for legacy gids that never had a create (#478).
+    this.gameModel.on('gameReady', () => {
+      this.handleUpdateDisplayName(this.userId, this.initialUsername);
+    });
+
     this.gameModel.on('archived', () => {
       this.setState({
         archived: true,
@@ -167,7 +174,6 @@ class Game extends Component {
 
   componentDidMount() {
     this.initializeGame();
-    this.handleUpdateDisplayName(this.userId, this.initialUsername);
     this.maybeUndismiss();
   }
 

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -205,7 +205,9 @@ export default class Game extends EventEmitter {
       event = castNullsToUndefined(event);
       this.emitWSEvent(event);
     });
-    if (!response.some((event) => event && event.type === 'create')) {
+    if (response.some((event) => event && event.type === 'create')) {
+      this.emit('gameReady');
+    } else {
       this.emit('gameNotFound');
     }
   }


### PR DESCRIPTION
## Summary

Stops new orphan rows from being inserted into \`game_events\` for legacy gids that were never bootstrapped server-side. This is the upstream cause of #478 — every time a user opened a Firebase-era game from their In Progress list, Game.js's mount-time \`updateDisplayName\` emit would persist a stray row to a gid that had no \`create\` event, leaving the game in a permanently un-resumable "Game not found" state and (pre-#481) leaking the gid into every other puzzle's "Your Games" list.

This PR is independent of #481 — that one stops *existing* orphans from leaking; this one stops *new* orphans from being created.

## Two defenses

### A. Client (defer the emit until the game is confirmed)

[src/pages/Game.js](src/pages/Game.js) — remove the unconditional \`handleUpdateDisplayName\` from \`componentDidMount\`. Subscribe to a new \`gameReady\` event on the gameModel and call it from there.

[src/store/game.js](src/store/game.js) — emit \`gameReady\` (counterpart to existing \`gameNotFound\`) when \`sync_all_game_events\` returns a response containing a \`create\` event.

Net effect: the first \`updateDisplayName\` only fires after the server confirms the game is real. For legacy/orphan gids, \`gameNotFound\` fires instead, just as before — no event is persisted.

### B. Server (gate persisted events on game existence)

[server/SocketManager.ts](server/SocketManager.ts) — in the \`game_event\` socket handler, before \`addGameEvent\`, check that either:
- the event is itself a \`create\` event (bootstrap path), or
- the event is ephemeral (\`updateCursor\` / \`addPing\` — never persisted), or
- the gid already has a \`create\` event or a snapshot in the DB.

Otherwise reject with \`{error: 'unknown game'}\`.

[server/model/game.ts](server/model/game.ts) — new \`gameExists(gid)\` helper. Single index lookup on \`game_events_gid_event_type_idx\`, fast.

Per-socket cache (\`socket.data.verifiedGids: Set<string>\`) so the existence check only hits the DB once per gid per session, not per event — no impact on hot loops like \`updateCell\` during active play.

## Test coverage

Three new tests in [server/__tests__/SocketManager.test.ts](server/__tests__/SocketManager.test.ts):
- Rejects persisted events for gids without a create event or snapshot
- Caches \`gameExists\` result per socket
- Allows ephemeral events to bypass the gate

Plus updated mocks for the two existing \`updateCell\` tests to satisfy the new gameExists check.

## Test plan

- [x] \`pnpm tsc --noEmit\` (frontend) and \`pnpm tsc --noEmit -p server/tsconfig.json\` — clean
- [x] \`pnpm eslint --max-warnings 0 src/ server/\` — clean
- [x] \`pnpm prettier --check\` (CI scope) — clean
- [x] \`pnpm test\` — 382/382 frontend tests passing
- [x] \`pnpm test:server --ci\` — 211/211 server tests passing (3 new + the existing 208)
- [x] \`pnpm build\` — successful
- [ ] Deploy to testing and confirm:
  - normal in-progress games still load and persist edits as expected
  - opening a legacy/orphan gid still shows "Game not found" but does **not** add new rows to game_events
  - chat / cursor / ping continue working in active games

## Caveats

- **First press of "Resume" on a legacy game still fails with \`gameNotFound\`.** This PR doesn't make legacy games playable — it just stops them from polluting the DB. That's option C from the earlier discussion (auto-bootstrap a synthetic create from \`firebase_history.pid\`) and a separate decision on UX.
- **Pre-existing orphans remain in the DB.** Cleaning them up requires either running the existing \`cleanup_orphaned_games.sql\` template or letting them be picked up by the \`archive_game_events\` job's "abandoned" category over time.

Refs #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)