### PR TITLE
Pin postcss to >=8.5.10 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
       "flatted": ">=3.4.2",
       "socket.io-parser": ">=4.2.6",
       "axios": ">=1.15.0",
-      "follow-redirects": ">=1.16.0"
+      "follow-redirects": ">=1.16.0",
+      "postcss": ">=8.5.10"
     },
     "onlyBuiltDependencies": [
       "bcrypt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   socket.io-parser: '>=4.2.6'
   axios: '>=1.15.0'
   follow-redirects: '>=1.16.0'
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -4958,7 +4959,7 @@ packages:
     resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.10'
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -4967,8 +4968,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -11421,9 +11422,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-safe-parser@7.0.1(postcss@8.5.8):
+  postcss-safe-parser@7.0.1(postcss@8.5.12):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.12
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -11432,7 +11433,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.8:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -12128,8 +12129,8 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.8
-      postcss-safe-parser: 7.0.1(postcss@8.5.8)
+      postcss: 8.5.12
+      postcss-safe-parser: 7.0.1(postcss@8.5.12)
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
       string-width: 8.2.0
@@ -12548,7 +12549,7 @@ snapshots:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.12
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary

Closes Dependabot alert #260. PostCSS <8.5.10 has a moderate XSS via unescaped \`</style>\` in CSS stringify output ([GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93)).

## Context

PostCSS is a transitive dep — pulled in by:
- **stylelint** via \`postcss-safe-parser\` (CSS lint pipeline)
- **vite** (frontend dev server / build pipeline)

No direct \`postcss\` dependency, so the fix is a pnpm override mirroring the existing security pins (\`undici\`, \`flatted\`, \`socket.io-parser\`, \`axios\`, \`follow-redirects\`).

\`\`\`json
"postcss": ">=8.5.10"
\`\`\`

Resolved version: **8.5.12** (latest).

## Test plan

- [x] \`pnpm install --ignore-scripts\` clean, lockfile updated
- [x] \`pnpm audit --ignore-registry-errors\` — no known vulnerabilities
- [x] \`pnpm test\` — 382/382 passing
- [x] \`pnpm test:server --ci\` — 208/208 passing
- [x] \`pnpm tsc --noEmit\` and \`pnpm tsc --noEmit -p server/tsconfig.json\` — clean
- [x] \`pnpm build\` — successful (uses postcss via vite)
- [x] \`pnpm stylelint\` — clean (uses postcss via postcss-safe-parser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)