### PR TITLE
Profile pagination follow-ups (#468 review)

### DIFF
--- a/server/scripts/seed-test-profile.ts
+++ b/server/scripts/seed-test-profile.ts
@@ -131,8 +131,10 @@ async function main() {
   for (let i = 0; i < NUM_HISTORY; i++) {
     const pid = pids[i];
     const gid = `seed-solved-${String(i + 1).padStart(3, '0')}`;
-    // time_taken_to_solve is in seconds; vary by size (bigger = slower)
-    const timeSec = randBetween(90, 1800);
+    // time_taken_to_solve is in milliseconds despite the SQL column comment
+    // saying seconds — verified against prod (real values are in the
+    // 100k–2M range and the frontend's formatTime treats this field as ms).
+    const timeMs = randBetween(90_000, 1_800_000); // 90s to 30min
     const solvedAt = daysAgo(i * 2 + 1); // spread over past ~50 days
     const playerCount = i % 5 === 0 ? 2 : 1; // every 5th is a co-op solve
 
@@ -140,7 +142,7 @@ async function main() {
       `INSERT INTO puzzle_solves (pid, gid, solved_time, time_taken_to_solve, user_id, player_count)
        VALUES ($1, $2, $3, $4, $5, $6)
        ON CONFLICT DO NOTHING`,
-      [pid, gid, solvedAt, timeSec, userId, playerCount]
+      [pid, gid, solvedAt, timeMs, userId, playerCount]
     );
     if ((r.rowCount ?? 0) > 0) solvesCreated += 1;
   }

--- a/server/sql/create_puzzle_solves.sql
+++ b/server/sql/create_puzzle_solves.sql
@@ -7,7 +7,7 @@ CREATE TABLE
     pid text NOT NULL REFERENCES puzzles ON DELETE CASCADE,
     gid text NOT NULL,
     solved_time timestamp without time zone, -- the time the solve was recorded
-    time_taken_to_solve integer CHECK (time_taken_to_solve > 0), -- the duration (seconds) of how long it took to solve
+    time_taken_to_solve integer CHECK (time_taken_to_solve > 0), -- the duration (milliseconds) of how long it took to solve
     user_id UUID REFERENCES users(id), -- authenticated user who solved (NULL for anonymous)
     player_count integer DEFAULT 1 -- number of players in the game at solve time
 );

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -88,9 +88,6 @@ function usePagination(items, storageKey, defaultPageSize = 10) {
     [storageKey]
   );
 
-  const handlePrev = useCallback(() => setPage((p) => p - 1), []);
-  const handleNext = useCallback(() => setPage((p) => p + 1), []);
-
   // Clamp during render rather than resetting via effect on every items
   // change. The previous implementation forced page=1 whenever items
   // changed reference (e.g. after dismissing an in-progress game), which
@@ -99,6 +96,14 @@ function usePagination(items, storageKey, defaultPageSize = 10) {
   const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
   const safePage = Math.min(Math.max(page, 1), totalPages);
   const pageItems = items.slice((safePage - 1) * pageSize, safePage * pageSize);
+
+  // Derive handlers from safePage rather than the raw page state — when
+  // items shrink and page drifts above totalPages, a functional updater
+  // would decrement the stale value and produce a dead click before the
+  // UI moves.
+  const handlePrev = useCallback(() => setPage(safePage - 1), [safePage]);
+  const handleNext = useCallback(() => setPage(safePage + 1), [safePage]);
+
   return {page: safePage, pageItems, totalPages, pageSize, setPageSize, handlePrev, handleNext};
 }
 

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -73,14 +73,11 @@ const DAY_ORDER = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
 
 function usePagination(items, storageKey, defaultPageSize = 10) {
-  const [pageSize, setPageSizeState] = useState(
-    () => Number(localStorage.getItem(storageKey)) || defaultPageSize
-  );
+  const [pageSize, setPageSizeState] = useState(() => {
+    const stored = Number(localStorage.getItem(storageKey));
+    return PAGE_SIZE_OPTIONS.includes(stored) ? stored : defaultPageSize;
+  });
   const [page, setPage] = useState(1);
-
-  useEffect(() => {
-    setPage(1);
-  }, [items]);
 
   const setPageSize = useCallback(
     (n) => {
@@ -94,9 +91,15 @@ function usePagination(items, storageKey, defaultPageSize = 10) {
   const handlePrev = useCallback(() => setPage((p) => p - 1), []);
   const handleNext = useCallback(() => setPage((p) => p + 1), []);
 
+  // Clamp during render rather than resetting via effect on every items
+  // change. The previous implementation forced page=1 whenever items
+  // changed reference (e.g. after dismissing an in-progress game), which
+  // bounced users back to page 1 mid-task. Clamping keeps them where they
+  // were and only nudges them when their current page no longer exists.
   const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
-  const pageItems = items.slice((page - 1) * pageSize, page * pageSize);
-  return {page, pageItems, totalPages, pageSize, setPageSize, handlePrev, handleNext};
+  const safePage = Math.min(Math.max(page, 1), totalPages);
+  const pageItems = items.slice((safePage - 1) * pageSize, safePage * pageSize);
+  return {page: safePage, pageItems, totalPages, pageSize, setPageSize, handlePrev, handleNext};
 }
 
 function PageSizeSelector({value, onChange}) {


### PR DESCRIPTION
Follow-up to #468 (just merged). The contributor's pagination shipped without addressing the inline review feedback, and three of those items had user/correctness impact worth fixing now. The remaining LOW/NIT items (a11y \`type=\"button\"\`/\`aria-pressed\`, hardcoded primary blue, seed event payload shape) are deferred — none of them affect users.

## What this fixes

### 1. Seed script time-unit bug (HIGH from review)

\`time_taken_to_solve\` is stored as **milliseconds** in production despite the SQL column comment saying seconds. Verified live — real values are in the 100k–2M range. The seed inserted seconds-like values (90–1800) which the frontend's \`formatMilliseconds\` would render as \`0:00:01.800\` instead of the intended ~30min spread.

- [server/scripts/seed-test-profile.ts:135](server/scripts/seed-test-profile.ts#L135) — multiply by 1000
- [server/sql/create_puzzle_solves.sql:10](server/sql/create_puzzle_solves.sql#L10) — correct the misleading column comment so the next contributor doesn't hit the same trap

### 2. Pagination resets to page 1 on every items change (MEDIUM from review)

The \`useEffect(() => setPage(1), [items])\` fired on every list-reference change, including after \`handleDismissConfirm\` filtered an item out — so dismissing one in-progress game while on page 3 would bounce you back to page 1.

Replaced with a clamped page computed during render: stay on the user's current page if it still exists, only nudge them to the last valid page if it doesn't. Also closes a latent edge case where deleting the only item on the last page would leave \`pageItems\` empty for one render before the effect resolved it.

[src/pages/Profile.js:75-100](src/pages/Profile.js#L75-L100)

### 3. Validate stored pageSize against PAGE_SIZE_OPTIONS (LOW from review)

If localStorage somehow held a value not in \`[10, 20, 50, 100]\` (manual edit, future code path), the selector would render with no active button. Falls back to default when invalid. One-line addition while in the same hook.

## Test plan

- [x] \`pnpm test\` — 385/385 frontend tests passing
- [x] \`pnpm test:server --ci\` — 212/212 server tests passing
- [x] \`pnpm tsc --noEmit\` and \`pnpm tsc --noEmit -p server/tsconfig.json\` — clean
- [x] ESLint, Prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)