### PR TITLE
Bump axios override to >=1.15.2 (8 advisories)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       "undici": ">=7.24.0",
       "flatted": ">=3.4.2",
       "socket.io-parser": ">=4.2.6",
-      "axios": ">=1.15.0",
+      "axios": ">=1.15.2",
       "follow-redirects": ">=1.16.0",
       "postcss": ">=8.5.10"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   undici: '>=7.24.0'
   flatted: '>=3.4.2'
   socket.io-parser: '>=4.2.6'
-  axios: '>=1.15.0'
+  axios: '>=1.15.2'
   follow-redirects: '>=1.16.0'
   postcss: '>=8.5.10'
 
@@ -2983,8 +2983,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -8360,7 +8360,7 @@ snapshots:
   '@sendgrid/client@8.1.6':
     dependencies:
       '@sendgrid/helpers': 8.0.0
-      axios: 1.15.0
+      axios: 1.16.0
     transitivePeerDependencies:
       - debug
 
@@ -9194,7 +9194,7 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5


### PR DESCRIPTION
CI's Security Audit started failing on transitive \`axios\` pulled in via \`@sendgrid/mail > @sendgrid/client > axios\`. Eight advisories total, all in axios versions <1.15.2:

| Severity | Advisory | Patched in |
|---|---|---|
| high | [GHSA-pmwg-cvhr-8vh7](https://github.com/advisories/GHSA-pmwg-cvhr-8vh7) — NO_PROXY incomplete fix | >=1.15.1 |
| high | [GHSA-q8qp-cvcw-x6jj](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj) — prototype pollution read-side gadgets | >=1.15.2 |
| high | [GHSA-pf86-5x62-jrwf](https://github.com/advisories/GHSA-pf86-5x62-jrwf) — prototype pollution gadgets, response | >=1.15.1 |
| high | [GHSA-6chq-wfr3-2hj9](https://github.com/advisories/GHSA-6chq-wfr3-2hj9) — header injection via prototype pollution | >=1.15.1 |
| moderate | [GHSA-w9j2-pvgh-6h63](https://github.com/advisories/GHSA-w9j2-pvgh-6h63) — auth bypass via prototype pollution | >=1.15.1 |
| moderate | [GHSA-3w6x-2g7m-8v23](https://github.com/advisories/GHSA-3w6x-2g7m-8v23) — JSON response tampering | >=1.15.2 |
| moderate | (CRLF injection, multipart/form-data) | >=1.15.x |
| (others) | | |

The current pnpm override is \`axios: ">=1.15.0"\` — too low. Bumping to \`>=1.15.2\` (highest patch threshold across all advisories) clears every one with a single pin. Resolved version: **1.16.0**.

Same pattern as the postcss bump (#486) and follow-redirects bump (#459) — transitive-dep override in the existing \`pnpm.overrides\` block.

## Test plan

- [x] \`pnpm install --ignore-scripts\` — lockfile updated, axios@1.16.0
- [x] \`pnpm audit --ignore-registry-errors\` — no known vulnerabilities
- [x] \`pnpm test\` — 385/385 passing
- [x] \`pnpm test:server --ci\` — 212/212 passing
- [x] \`pnpm tsc --noEmit\` and \`pnpm tsc --noEmit -p server/tsconfig.json\` — clean
- [x] \`pnpm build\` — successful

Unblocks CI for #489 (and any other open PRs blocked by the audit step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)