### PR TITLE
Pin ip-address to >=10.1.1 (GHSA-v2v4-37r5-5v8g)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
       "socket.io-parser": ">=4.2.6",
       "axios": ">=1.15.2",
       "follow-redirects": ">=1.16.0",
-      "postcss": ">=8.5.10"
+      "postcss": ">=8.5.10",
+      "ip-address": ">=10.1.1"
     },
     "onlyBuiltDependencies": [
       "bcrypt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   axios: '>=1.15.2'
   follow-redirects: '>=1.16.0'
   postcss: '>=8.5.10'
+  ip-address: '>=10.1.1'
 
 importers:
 
@@ -4125,8 +4126,8 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -10104,7 +10105,7 @@ snapshots:
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -10529,7 +10530,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
Another transitive-dep advisory popped up in the Security Audit step right after #491 (axios) cleared. \`ip-address\` <=10.1.0 has a moderate XSS in its HTML-emitting \`Address6\` methods ([GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g), Dependabot alert #261), pulled in via \`express-rate-limit > ip-address\`.

Same pattern as the postcss / axios bumps — single-line pnpm override. Resolved to 10.2.0.

## Test plan

- [x] \`pnpm audit --ignore-registry-errors\` — no known vulnerabilities
- [x] \`pnpm test\` — 385/385 passing
- [x] \`pnpm test:server --ci\` — 212/212 passing (covers express-rate-limit consumers)
- [x] \`pnpm tsc --noEmit\` and \`pnpm tsc --noEmit -p server/tsconfig.json\` — clean
- [x] \`pnpm build\` — successful

Unblocks CI for #489 and any other open work hitting the audit step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)