### PR TITLE
Pin fast-uri to >=3.1.1 to clear GHSA-q3j6-qgpj-74h6

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
       "axios": ">=1.15.2",
       "follow-redirects": ">=1.16.0",
       "postcss": ">=8.5.10",
-      "ip-address": ">=10.1.1"
+      "ip-address": ">=10.1.1",
+      "fast-uri": ">=3.1.1"
     },
     "onlyBuiltDependencies": [
       "bcrypt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   follow-redirects: '>=1.16.0'
   postcss: '>=8.5.10'
   ip-address: '>=10.1.1'
+  fast-uri: '>=3.1.1'
 
 importers:
 
@@ -3758,8 +3759,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -9061,7 +9062,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10156,7 +10157,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 


### PR DESCRIPTION
## Summary

Security audit started failing today on a high-severity advisory in `fast-uri` (path traversal via percent-encoded dot segments — [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6)). It reaches us transitively via `stylelint > table > ajv > fast-uri`, no direct dep.

Patched in `>=3.1.1`; pinning via `pnpm.overrides` resolves to `fast-uri@3.1.2` with no other lockfile churn. `pnpm audit --ignore-registry-errors` is clean afterwards.

This is the same shape as the recent `axios`/`ip-address`/`postcss` overrides — it's blocking #494 (and master CI) right now.

## Test plan

- [x] `pnpm audit --ignore-registry-errors` → "No known vulnerabilities found"
- [x] `pnpm why fast-uri` shows a single resolved version (3.1.2)
- [x] `pnpm stylelint` passes
- [x] Frontend tests pass (385/385)

🤖 Generated with [Claude Code](https://claude.com/claude-code)