### PR TITLE
Add Sound on Solve toggle to user menu

### DIFF
--- a/src/components/common/Nav.js
+++ b/src/components/common/Nav.js
@@ -144,23 +144,23 @@ function UserMenu() {
             </div>
           )}
           <div
-            className="nav--user-menu--item nav--user-menu--dark-mode"
+            className="nav--user-menu--item"
             role="button"
             tabIndex={0}
             onClick={toggleMolesterMoons}
             onKeyDown={handleToggleDarkMode}
           >
-            <span className="nav--user-menu--dark-mode-icon">{darkModeIcon(darkModePreference)}</span>
+            <span className="nav--user-menu--item-icon">{darkModeIcon(darkModePreference)}</span>
             {darkModeLabel(darkModePreference)}
           </div>
           <div
-            className="nav--user-menu--item nav--user-menu--dark-mode"
+            className="nav--user-menu--item"
             role="button"
             tabIndex={0}
             onClick={handleToggleSound}
             onKeyDown={handleToggleSoundKey}
           >
-            <span className="nav--user-menu--dark-mode-icon">
+            <span className="nav--user-menu--item-icon">
               {soundEnabled ? <FaVolumeUp /> : <FaVolumeMute />}
             </span>
             {soundEnabled ? 'Sound on solve: On' : 'Sound on solve: Off'}

--- a/src/components/common/Nav.js
+++ b/src/components/common/Nav.js
@@ -4,7 +4,7 @@ import {Link} from 'react-router';
 import {useCallback, useContext, useEffect, useRef, useState} from 'react';
 
 import clsx from 'clsx';
-import {FaSun, FaMoon, FaDesktop, FaUserCircle} from 'react-icons/fa';
+import {FaSun, FaMoon, FaDesktop, FaUserCircle, FaVolumeUp, FaVolumeMute} from 'react-icons/fa';
 import {MdInfoOutline} from 'react-icons/md';
 import GlobalContext from '../../lib/GlobalContext';
 import AuthContext from '../../lib/AuthContext';
@@ -25,8 +25,9 @@ function darkModeLabel(darkModePreference) {
 }
 
 function UserMenu() {
-  const {isAuthenticated, user, handleLogout} = useContext(AuthContext);
+  const {isAuthenticated, user, handleLogout, preferences, savePreference} = useContext(AuthContext);
   const {darkModePreference, toggleMolesterMoons} = useContext(GlobalContext);
+  const soundEnabled = preferences?.sound ?? true;
   const [open, setOpen] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
@@ -85,6 +86,19 @@ function UserMenu() {
     [toggleMolesterMoons]
   );
 
+  const handleToggleSound = useCallback(() => {
+    savePreference('sound', !soundEnabled);
+  }, [savePreference, soundEnabled]);
+
+  const handleToggleSoundKey = useCallback(
+    (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        handleToggleSound();
+      }
+    },
+    [handleToggleSound]
+  );
+
   const handleButtonKeyDown = useCallback(
     (handler) => (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
@@ -138,6 +152,18 @@ function UserMenu() {
           >
             <span className="nav--user-menu--dark-mode-icon">{darkModeIcon(darkModePreference)}</span>
             {darkModeLabel(darkModePreference)}
+          </div>
+          <div
+            className="nav--user-menu--item nav--user-menu--dark-mode"
+            role="button"
+            tabIndex={0}
+            onClick={handleToggleSound}
+            onKeyDown={handleToggleSoundKey}
+          >
+            <span className="nav--user-menu--dark-mode-icon">
+              {soundEnabled ? <FaVolumeUp /> : <FaVolumeMute />}
+            </span>
+            {soundEnabled ? 'Sound on solve: On' : 'Sound on solve: Off'}
           </div>
           <div
             className="nav--user-menu--item"

--- a/src/components/common/css/nav.css
+++ b/src/components/common/css/nav.css
@@ -105,7 +105,7 @@
   background: #f5f5f5;
 }
 
-.nav--user-menu--dark-mode-icon {
+.nav--user-menu--item-icon {
   margin-right: 8px;
   display: flex;
   align-items: center;

--- a/src/lib/AuthContext.js
+++ b/src/lib/AuthContext.js
@@ -65,7 +65,7 @@ export function AuthProvider({children}) {
   const [user, setUser] = useState(null);
   const [accessToken, setAccessToken] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [preferences, setPreferences] = useState(null);
+  const [preferences, setPreferences] = useState(readLocalStoragePrefs);
   const refreshTimerRef = useRef(null);
   const debounceTimerRef = useRef(null);
   const pendingPrefsRef = useRef({});
@@ -136,7 +136,7 @@ export function AuthProvider({children}) {
     await apiLogout();
     setAccessToken(null);
     setUser(null);
-    setPreferences(null);
+    setPreferences(readLocalStoragePrefs());
   }, []);
 
   const refreshUser = useCallback(async () => {


### PR DESCRIPTION
## Summary
- Adds a "Sound on solve: On/Off" item to the user dropdown next to dark mode, using `FaVolumeUp`/`FaVolumeMute` icons
- Wires it to the existing `sound` preference via `savePreference` from AuthContext, so the menu toggle and the Account page toggle stay in sync (both write to the same localStorage key + prefs endpoint)
- Account page toggle is intentionally kept

Closes #492

## Test plan
- [ ] Open the user menu — "Sound on solve: On" is shown by default
- [ ] Click it — label flips to "Off", icon changes to muted
- [ ] Solve a puzzle with sound off — no jingle plays
- [ ] Toggle back on, solve again — jingle plays
- [ ] Toggle from Account page, reopen menu — menu reflects new state
- [ ] As a guest (logged out), toggle works and persists across reload (localStorage only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)