### PR TITLE
Fix duplicate-key race in recordSolve

### DIFF
--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -419,8 +419,8 @@ describe('recordSolve', () => {
     mockClient.query.mockResolvedValueOnce({rows: []});
     // COUNT for first-solve check: 0 existing
     mockClient.query.mockResolvedValueOnce({rows: [{count: 0}]});
-    // INSERT puzzle_solve
-    mockClient.query.mockResolvedValueOnce({rows: []});
+    // INSERT puzzle_solve (rowCount=1: row was inserted)
+    mockClient.query.mockResolvedValueOnce({rows: [], rowCount: 1});
     // UPDATE times_solved
     mockClient.query.mockResolvedValueOnce({rows: []});
     // COMMIT
@@ -442,8 +442,8 @@ describe('recordSolve', () => {
     mockClient.query.mockResolvedValueOnce({rows: []});
     // COUNT: already 1 solve exists
     mockClient.query.mockResolvedValueOnce({rows: [{count: 1}]});
-    // INSERT puzzle_solve
-    mockClient.query.mockResolvedValueOnce({rows: []});
+    // INSERT puzzle_solve (different user_id, no conflict)
+    mockClient.query.mockResolvedValueOnce({rows: [], rowCount: 1});
     // COMMIT (no UPDATE times_solved)
     mockClient.query.mockResolvedValueOnce({rows: []});
 
@@ -453,6 +453,29 @@ describe('recordSolve', () => {
     expect(mockClient.query).toHaveBeenCalledTimes(5);
     const allSql = mockClient.query.mock.calls.map((c: any[]) => c[0] as string);
     expect(allSql.some((s) => s.includes('times_solved'))).toBe(false);
+  });
+
+  it('does not increment times_solved when concurrent insert hit the unique index (ON CONFLICT)', async () => {
+    // Pre-flight check: not yet solved (race: the racing request committed after this check)
+    pool.query.mockResolvedValueOnce({rows: [{count: 0}]});
+    // BEGIN
+    mockClient.query.mockResolvedValueOnce({rows: []});
+    // SELECT FOR UPDATE — racing request has committed by the time we acquire the lock
+    mockClient.query.mockResolvedValueOnce({rows: []});
+    // COUNT inside the locked txn: 1 (the racing request's row)
+    mockClient.query.mockResolvedValueOnce({rows: [{count: 1}]});
+    // INSERT with ON CONFLICT DO NOTHING — no row inserted (rowCount=0)
+    mockClient.query.mockResolvedValueOnce({rows: [], rowCount: 0});
+    // COMMIT — no UPDATE times_solved
+    mockClient.query.mockResolvedValueOnce({rows: []});
+
+    await expect(recordSolve('p1', 'g1', 300)).resolves.not.toThrow();
+
+    expect(mockClient.query).toHaveBeenCalledTimes(5);
+    const allSql = mockClient.query.mock.calls.map((c: any[]) => c[0] as string);
+    expect(allSql.some((s) => s.includes('times_solved'))).toBe(false);
+    // Verify the INSERT uses ON CONFLICT DO NOTHING
+    expect(allSql[3]).toContain('ON CONFLICT DO NOTHING');
   });
 
   it('allows anonymous solve even when an authenticated solve exists for the same game', async () => {
@@ -466,7 +489,7 @@ describe('recordSolve', () => {
     // COUNT for first-solve check: 1 (authenticated user already solved)
     mockClient.query.mockResolvedValueOnce({rows: [{count: 1}]});
     // INSERT puzzle_solve (anonymous)
-    mockClient.query.mockResolvedValueOnce({rows: []});
+    mockClient.query.mockResolvedValueOnce({rows: [], rowCount: 1});
     // COMMIT
     mockClient.query.mockResolvedValueOnce({rows: []});
 

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -372,12 +372,13 @@ export async function recordSolve(
     } = await client.query(`SELECT COUNT(*) FROM puzzle_solves WHERE gid = $1`, [gid]);
     const isFirstSolveForGame = Number(count) === 0;
 
-    await client.query(
+    const insertResult = await client.query(
       `INSERT INTO puzzle_solves (pid, gid, solved_time, time_taken_to_solve, user_id, player_count)
-       VALUES ($1, $2, to_timestamp($3), $4, $5, $6)`,
+       VALUES ($1, $2, to_timestamp($3), $4, $5, $6)
+       ON CONFLICT DO NOTHING`,
       [pid, gid, solved_time / 1000.0, timeToSolve, userId || null, playerCount || 1]
     );
-    if (isFirstSolveForGame) {
+    if (insertResult.rowCount === 1 && isFirstSolveForGame) {
       await client.query(`UPDATE puzzles SET times_solved = times_solved + 1 WHERE pid = $1`, [pid]);
     }
     await client.query('COMMIT');


### PR DESCRIPTION
## Summary
- Adds `ON CONFLICT DO NOTHING` to the INSERT in `recordSolve` so concurrent solve requests for the same `(pid, gid)` no longer trip the unique index
- Gates `times_solved` bump on `rowCount === 1` so a racing duplicate can never double-bump
- Adds a test covering the ON CONFLICT path

## Why
Sentry [NODE-EXPRESS-R](https://cross-with-friends.sentry.io/issues/7469953460/) — 10 occurrences in ~4 hours, escalating. The pre-flight `isGidAlreadySolved` check runs on the connection pool before the transaction, so two concurrent requests can both see count=0, both pass the gate, then serialize on `SELECT 1 FROM puzzles ... FOR UPDATE` and trip `puzzle_solves_anon_game_idx` on the INSERT. record_solve.ts already catches the throw and logs it as a warning ("snapshot orphaned by solve failure"), so the user-facing flow is intact — this just stops the noise and makes the duplicate a clean no-op.

Covers both unique indexes (authenticated `(pid, gid, user_id)` and anonymous `(pid, gid)`).

## Test plan
- [x] `pnpm test:server -- --testPathPatterns=puzzle.test` — 34 passing including new race test
- [x] `pnpm tsc --noEmit -p server/tsconfig.json`
- [x] `pnpm eslint --max-warnings 0 server/model/puzzle.ts`
- [ ] After deploy, confirm NODE-EXPRESS-R stops firing in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)