### PR TITLE
Fix e2e selectors broken by dark-mode CSS rename

### DIFF
--- a/e2e/tests/dark-mode.spec.ts
+++ b/e2e/tests/dark-mode.spec.ts
@@ -8,6 +8,7 @@ test.describe('Dark mode', () => {
     await assertPageRendered(page);
 
     const routerWrapper = page.locator('.router-wrapper');
+    const darkModeButton = page.getByRole('button', {name: /^Dark Mode:/});
 
     // Initially dark mode should be off
     await expect(routerWrapper).not.toHaveClass(/\bdark\b/);
@@ -17,11 +18,11 @@ test.describe('Dark mode', () => {
     await expect(page.locator('.nav--user-menu--dropdown')).toBeVisible();
 
     // Should show "Dark Mode: Off"
-    await expect(page.getByRole('button', {name: /^Dark Mode:/})).toContainText('Dark Mode: Off');
+    await expect(darkModeButton).toContainText('Dark Mode: Off');
 
     // Toggle to On
-    await page.getByRole('button', {name: /^Dark Mode:/}).click();
-    await expect(page.getByRole('button', {name: /^Dark Mode:/})).toContainText('Dark Mode: On');
+    await darkModeButton.click();
+    await expect(darkModeButton).toContainText('Dark Mode: On');
     await expect(routerWrapper).toHaveClass(/\bdark\b/);
 
     // Body should also have dark class
@@ -29,12 +30,12 @@ test.describe('Dark mode', () => {
     expect(bodyHasDark).toBe(true);
 
     // Toggle to System
-    await page.getByRole('button', {name: /^Dark Mode:/}).click();
-    await expect(page.getByRole('button', {name: /^Dark Mode:/})).toContainText('Dark Mode: System');
+    await darkModeButton.click();
+    await expect(darkModeButton).toContainText('Dark Mode: System');
 
     // Toggle back to Off
-    await page.getByRole('button', {name: /^Dark Mode:/}).click();
-    await expect(page.getByRole('button', {name: /^Dark Mode:/})).toContainText('Dark Mode: Off');
+    await darkModeButton.click();
+    await expect(darkModeButton).toContainText('Dark Mode: Off');
     await expect(routerWrapper).not.toHaveClass(/\bdark\b/);
 
     assertNoFatalErrors(consoleErrors);

--- a/e2e/tests/dark-mode.spec.ts
+++ b/e2e/tests/dark-mode.spec.ts
@@ -17,11 +17,11 @@ test.describe('Dark mode', () => {
     await expect(page.locator('.nav--user-menu--dropdown')).toBeVisible();
 
     // Should show "Dark Mode: Off"
-    await expect(page.locator('.nav--user-menu--dark-mode')).toContainText('Dark Mode: Off');
+    await expect(page.getByRole('button', {name: /^Dark Mode:/})).toContainText('Dark Mode: Off');
 
     // Toggle to On
-    await page.locator('.nav--user-menu--dark-mode').click();
-    await expect(page.locator('.nav--user-menu--dark-mode')).toContainText('Dark Mode: On');
+    await page.getByRole('button', {name: /^Dark Mode:/}).click();
+    await expect(page.getByRole('button', {name: /^Dark Mode:/})).toContainText('Dark Mode: On');
     await expect(routerWrapper).toHaveClass(/\bdark\b/);
 
     // Body should also have dark class
@@ -29,12 +29,12 @@ test.describe('Dark mode', () => {
     expect(bodyHasDark).toBe(true);
 
     // Toggle to System
-    await page.locator('.nav--user-menu--dark-mode').click();
-    await expect(page.locator('.nav--user-menu--dark-mode')).toContainText('Dark Mode: System');
+    await page.getByRole('button', {name: /^Dark Mode:/}).click();
+    await expect(page.getByRole('button', {name: /^Dark Mode:/})).toContainText('Dark Mode: System');
 
     // Toggle back to Off
-    await page.locator('.nav--user-menu--dark-mode').click();
-    await expect(page.locator('.nav--user-menu--dark-mode')).toContainText('Dark Mode: Off');
+    await page.getByRole('button', {name: /^Dark Mode:/}).click();
+    await expect(page.getByRole('button', {name: /^Dark Mode:/})).toContainText('Dark Mode: Off');
     await expect(routerWrapper).not.toHaveClass(/\bdark\b/);
 
     assertNoFatalErrors(consoleErrors);
@@ -51,7 +51,7 @@ test.describe('Dark mode', () => {
 
     // Toggle to dark mode
     await page.locator('.nav--user-menu--trigger').click();
-    await page.locator('.nav--user-menu--dark-mode').click();
+    await page.getByRole('button', {name: /^Dark Mode:/}).click();
     await expect(page.locator('.router-wrapper')).toHaveClass(/\bdark\b/);
 
     // Get nav background color in dark mode

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -53,7 +53,7 @@ test.describe('Navigation', () => {
 
     // Unauthenticated items
     await expect(page.locator('.nav--user-menu--item', {hasText: 'Sign Up / Log In'})).toBeVisible();
-    await expect(page.locator('.nav--user-menu--dark-mode')).toBeVisible();
+    await expect(page.getByRole('button', {name: /^Dark Mode:/})).toBeVisible();
     await expect(page.locator('.nav--user-menu--item', {hasText: 'About'})).toBeVisible();
     await expect(page.locator('.nav--user-menu--item', {hasText: 'Help'})).toBeVisible();
 


### PR DESCRIPTION
## Summary

The Post-Deploy Tests workflow has been failing on every merge to master since PR #500 (Sound on Solve). When that PR addressed Gemini's CSS feedback by dropping the dead \`.nav--user-menu--dark-mode\` wrapper class, the e2e suite still selected on it. Nothing in the app is broken — only the tests' selector is stale.

Switches the two affected tests to Playwright's role+name locator on \`/^Dark Mode:/\`, which resolves on visible text and survives future class churn.

Phase 1 / Phase 2 ratings work was unrelated to the failing tests; both PRs deployed successfully, the playwright job just runs after deploy and inherits this pre-existing breakage.

## Test plan

Verified locally against the live testing environment:

\`\`\`
BASE_URL=https://testing.crosswithfriends.com pnpm playwright test \\
  --config=e2e/playwright.config.ts --project=chromium \\
  e2e/tests/dark-mode.spec.ts e2e/tests/navigation.spec.ts
→ 6/6 pass.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)