### PR TITLE
Fix Play page autocreating empty games during auth hydration

### DIFF
--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -51,7 +51,19 @@ class Play extends Component {
 
   componentDidMount() {
     this._lastAccessToken = this.context?.accessToken ?? null;
-    this.loadGames();
+    this._lastAuthLoading = this.context?.loading ?? true;
+
+    // AuthContext is async on page load (it refreshes the access token before
+    // exposing the session). If we read context here and it's still loading,
+    // accessToken is null and a logged-in user looks like a guest. Fetching
+    // games with no token returns only games matching the local dfac_id —
+    // which can be empty if the user solved on another device — and the
+    // autocreate path below would then spawn a fresh empty game per visit
+    // (see "blank in-progress games" reports). Defer the initial fetch until
+    // auth has resolved.
+    if (!this._lastAuthLoading) {
+      this.loadGames();
+    }
 
     fetchPuzzleInfo(this.pid).then((info) => {
       if (info) this.setState({puzzleInfo: info});
@@ -87,11 +99,30 @@ class Play extends Component {
   }
 
   componentDidUpdate() {
-    // Re-fetch when auth context hydrates after mount
     const currentToken = this.context?.accessToken ?? null;
+    const currentLoading = this.context?.loading ?? true;
+
+    // While auth is still resolving, don't fetch games or decide on
+    // autocreate/autojoin — see the comment in componentDidMount.
+    if (currentLoading) {
+      this._lastAuthLoading = true;
+      return;
+    }
+
+    // First update after auth resolves: kick off the initial fetch with the
+    // correct token, then wait for it to land before any autocreate decision.
+    if (this._lastAuthLoading) {
+      this._lastAuthLoading = false;
+      this._lastAccessToken = currentToken;
+      this.loadGames();
+      return;
+    }
+
+    // Re-fetch when the token changes after the initial load (login/logout).
     if (currentToken !== this._lastAccessToken) {
       this._lastAccessToken = currentToken;
       this.loadGames();
+      return;
     }
 
     const {games} = this.state;


### PR DESCRIPTION
## Summary

Closes the recurring "I solved this puzzle but clicking back in shows it empty / now I have 3 blank in-progress games" reports (most recent: maladroit on pid 100007961).

### Cause

\`Play.componentDidMount\` reads \`AuthContext\` synchronously and immediately calls \`loadGames\`. But the auth context refreshes its access token *asynchronously* after mount — for the first few hundred ms, \`context.accessToken\` is still \`null\` even for a logged-in user. The unauthenticated \`fetchUserGames\` call only matches the raw local \`dfac_id\`, which can legitimately return \`[]\` (different device, recently linked account, stale id).

\`componentDidUpdate\` then sees \`games.length === 0\` and fires the **autocreate** branch — redirecting to a fresh empty gid. Each subsequent attempt repeats the race until auth happens to hydrate fast enough, at which point the user sees their full "Your Games" list with several blank in-progress entries. That's exactly the screenshot pattern.

[d128e457](https://github.com/ScaleOvenStove/crosswithfriends/commit/d128e457) re-fetched after hydration but did *not* gate the autocreate decision on it, so the empty games still got created.

### Fix

Wait for \`AuthContext.loading\` to be \`false\` before doing anything game-related:

- \`componentDidMount\` only fires \`loadGames\` when \`loading\` is already \`false\`
- \`componentDidUpdate\` watches for the \`loading → ready\` transition and kicks off the initial fetch with the resolved token, returning early so a stale \`games=[]\` snapshot can't trigger autocreate first
- The post-load "token changed" re-fetch (login/logout) is preserved

The "Loading..." render path already covers \`games === null\`, so no UI changes are needed during the wait.

### Cleanup

The 3 existing empty in-progress games for maladroit (and any other users hit by this) will not auto-clean. They can hit the "×" abandon button on each, or we can write a one-off SQL clean-up if you want — happy to follow up.

## Test plan

- [x] \`pnpm test\` — 385 passing
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm eslint --max-warnings 0 src/pages/Play.js\` clean
- [ ] Verify on testing env: log in, click a solved puzzle from the homepage list, confirm it loads the existing solved game (no new empty gid created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)