### PR TITLE
Add typical solve time to puzzle pages

### DIFF
--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -14,6 +14,7 @@ import {
   PUZZLE_STATS_MIN_SAMPLES,
   PUZZLE_STATS_TIME_CAP_MS,
   clearPuzzleListCache,
+  clearPuzzleStatsCache,
 } from '../../model/puzzle';
 
 describe('listPuzzles', () => {
@@ -591,6 +592,7 @@ describe('getPuzzleInfo', () => {
 describe('getPuzzleStats', () => {
   beforeEach(() => {
     resetPoolMocks();
+    clearPuzzleStatsCache();
   });
 
   it('returns the median and sample count when the threshold is met', async () => {
@@ -601,19 +603,19 @@ describe('getPuzzleStats', () => {
 
   it('returns null median when below the sample threshold', async () => {
     pool.query.mockResolvedValueOnce({rows: [{sample_count: 7, median_ms: null}]});
-    const result = await getPuzzleStats('p1');
+    const result = await getPuzzleStats('p2');
     expect(result).toEqual({sampleCount: 7, medianMs: null});
   });
 
   it('handles an empty result row (no solves at all)', async () => {
     pool.query.mockResolvedValueOnce({rows: []});
-    const result = await getPuzzleStats('p1');
+    const result = await getPuzzleStats('p3');
     expect(result).toEqual({sampleCount: 0, medianMs: null});
   });
 
   it('filters by pid, excludes zero-time and over-cap solves, and excludes reveal games', async () => {
     pool.query.mockResolvedValueOnce({rows: [{sample_count: 0, median_ms: null}]});
-    await getPuzzleStats('p1');
+    await getPuzzleStats('p4');
     const [sql, params] = pool.query.mock.calls[0];
     expect(sql).toContain('FROM puzzle_solves');
     expect(sql).toContain('ps.time_taken_to_solve > 0');
@@ -621,6 +623,36 @@ describe('getPuzzleStats', () => {
     expect(sql).toContain("event_type = 'reveal'");
     expect(sql).toContain('NOT EXISTS');
     expect(sql).toContain('PERCENTILE_CONT(0.5)');
-    expect(params).toEqual(['p1', PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]);
+    expect(params).toEqual(['p4', PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]);
+  });
+
+  it('caches repeat lookups for the same pid', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{sample_count: 30, median_ms: 100000}]});
+    await getPuzzleStats('p5');
+    await getPuzzleStats('p5');
+    expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates the cache for a pid when a new solve is recorded', async () => {
+    // Prime: cache pid="p6" stats
+    pool.query.mockResolvedValueOnce({rows: [{sample_count: 30, median_ms: 100000}]});
+    await getPuzzleStats('p6');
+    expect(pool.query).toHaveBeenCalledTimes(1);
+
+    // recordSolve flow: isAlreadySolvedByUser=0, then txn writes
+    pool.query.mockResolvedValueOnce({rows: [{count: 0}]});
+    mockClient.query
+      .mockResolvedValueOnce({rows: []}) // BEGIN
+      .mockResolvedValueOnce({rows: []}) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({rows: [{count: 0}]}) // first-solve COUNT
+      .mockResolvedValueOnce({rows: [], rowCount: 1}) // INSERT
+      .mockResolvedValueOnce({rows: []}) // UPDATE times_solved
+      .mockResolvedValueOnce({rows: []}); // COMMIT
+    await recordSolve('p6', 'g6', 300, 'user-6');
+
+    // Cache should have been invalidated; the next stats call hits the DB again.
+    pool.query.mockResolvedValueOnce({rows: [{sample_count: 31, median_ms: 99000}]});
+    const fresh = await getPuzzleStats('p6');
+    expect(fresh).toEqual({sampleCount: 31, medianMs: 99000});
   });
 });

--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -10,6 +10,9 @@ import {
   addPuzzle,
   recordSolve,
   getPuzzleInfo,
+  getPuzzleStats,
+  PUZZLE_STATS_MIN_SAMPLES,
+  PUZZLE_STATS_TIME_CAP_MS,
   clearPuzzleListCache,
 } from '../../model/puzzle';
 
@@ -582,5 +585,42 @@ describe('getPuzzleInfo', () => {
     pool.query.mockResolvedValueOnce({rows: [{content: {info, grid: [], clues: {across: [], down: []}}}]});
     const result = await getPuzzleInfo('p1');
     expect(result).toEqual(info);
+  });
+});
+
+describe('getPuzzleStats', () => {
+  beforeEach(() => {
+    resetPoolMocks();
+  });
+
+  it('returns the median and sample count when the threshold is met', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{sample_count: 42, median_ms: 1122334}]});
+    const result = await getPuzzleStats('p1');
+    expect(result).toEqual({sampleCount: 42, medianMs: 1122334});
+  });
+
+  it('returns null median when below the sample threshold', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{sample_count: 7, median_ms: null}]});
+    const result = await getPuzzleStats('p1');
+    expect(result).toEqual({sampleCount: 7, medianMs: null});
+  });
+
+  it('handles an empty result row (no solves at all)', async () => {
+    pool.query.mockResolvedValueOnce({rows: []});
+    const result = await getPuzzleStats('p1');
+    expect(result).toEqual({sampleCount: 0, medianMs: null});
+  });
+
+  it('filters by pid, excludes zero-time and over-cap solves, and excludes reveal games', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{sample_count: 0, median_ms: null}]});
+    await getPuzzleStats('p1');
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toContain('FROM puzzle_solves');
+    expect(sql).toContain('ps.time_taken_to_solve > 0');
+    expect(sql).toContain('ps.time_taken_to_solve < $2');
+    expect(sql).toContain("event_type = 'reveal'");
+    expect(sql).toContain('NOT EXISTS');
+    expect(sql).toContain('PERCENTILE_CONT(0.5)');
+    expect(params).toEqual(['p1', PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]);
   });
 });

--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -630,7 +630,9 @@ describe('getPuzzleStats', () => {
     pool.query.mockResolvedValueOnce({rows: [{sample_count: 0, median_ms: null}]});
     await getPuzzleStats('p4b');
     const [sql] = pool.query.mock.calls[0];
-    expect(sql).toContain('MIN(ps.time_taken_to_solve)');
+    // MAX over the per-user clocks approximates total game duration. MIN would
+    // bias downward toward whichever co-op user joined last.
+    expect(sql).toContain('MAX(ps.time_taken_to_solve)');
     expect(sql).toContain('GROUP BY ps.gid');
   });
 

--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -626,6 +626,14 @@ describe('getPuzzleStats', () => {
     expect(params).toEqual(['p4', PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]);
   });
 
+  it('aggregates per gid so co-op games are counted once, not once per user', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{sample_count: 0, median_ms: null}]});
+    await getPuzzleStats('p4b');
+    const [sql] = pool.query.mock.calls[0];
+    expect(sql).toContain('MIN(ps.time_taken_to_solve)');
+    expect(sql).toContain('GROUP BY ps.gid');
+  });
+
   it('caches repeat lookups for the same pid', async () => {
     pool.query.mockResolvedValueOnce({rows: [{sample_count: 30, median_ms: 100000}]});
     await getPuzzleStats('p5');

--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -613,16 +613,17 @@ describe('getPuzzleStats', () => {
     expect(result).toEqual({sampleCount: 0, medianMs: null});
   });
 
-  it('filters by pid, excludes zero-time and over-cap solves, and excludes reveal games', async () => {
+  it('filters by pid and excludes zero-time and over-cap solves', async () => {
     pool.query.mockResolvedValueOnce({rows: [{sample_count: 0, median_ms: null}]});
     await getPuzzleStats('p4');
     const [sql, params] = pool.query.mock.calls[0];
     expect(sql).toContain('FROM puzzle_solves');
     expect(sql).toContain('ps.time_taken_to_solve > 0');
     expect(sql).toContain('ps.time_taken_to_solve < $2');
-    expect(sql).toContain("event_type = 'reveal'");
-    expect(sql).toContain('NOT EXISTS');
     expect(sql).toContain('PERCENTILE_CONT(0.5)');
+    // No reveal-filter: that would require joining game_events, which is archived
+    // away on solved games. See comment in getPuzzleStats.
+    expect(sql).not.toContain('game_events');
     expect(params).toEqual(['p4', PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]);
   });
 

--- a/server/api/puzzle.ts
+++ b/server/api/puzzle.ts
@@ -1,7 +1,7 @@
 import {AddPuzzleResponse, AddPuzzleRequest} from '@shared/types';
 import express from 'express';
 
-import {addPuzzle, getPuzzleInfo} from '../model/puzzle';
+import {addPuzzle, getPuzzleInfo, getPuzzleStats} from '../model/puzzle';
 import {verifyAccessToken} from '../auth/jwt';
 
 const router = express.Router();
@@ -86,6 +86,42 @@ router.get<{pid: string}>('/:pid/info', async (req, res, next) => {
       return;
     }
     res.json(info);
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * @openapi
+ * /puzzle/{pid}/stats:
+ *   get:
+ *     tags: [Puzzles]
+ *     summary: Get aggregate solve stats for a puzzle
+ *     description: |
+ *       Returns the median completion time across "clean" solves (no reveals used, non-zero
+ *       time, under a 2-hour cap). The median is only populated once a minimum sample size
+ *       has been reached; below that the response contains only `sampleCount`.
+ *     parameters:
+ *       - in: path
+ *         name: pid
+ *         required: true
+ *         schema: {type: string}
+ *         description: Puzzle ID
+ *     responses:
+ *       200:
+ *         description: Puzzle stats
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 sampleCount: {type: integer, description: Number of clean solves included}
+ *                 medianMs: {type: integer, nullable: true, description: Median solve time in ms, or null if below threshold}
+ */
+router.get<{pid: string}>('/:pid/stats', async (req, res, next) => {
+  try {
+    const stats = await getPuzzleStats(req.params.pid);
+    res.json(stats);
   } catch (e) {
     next(e);
   }

--- a/server/api/puzzle.ts
+++ b/server/api/puzzle.ts
@@ -98,9 +98,10 @@ router.get<{pid: string}>('/:pid/info', async (req, res, next) => {
  *     tags: [Puzzles]
  *     summary: Get aggregate solve stats for a puzzle
  *     description: |
- *       Returns the median completion time across "clean" solves (no reveals used, non-zero
- *       time, under a 2-hour cap). The median is only populated once a minimum sample size
- *       has been reached; below that the response contains only `sampleCount`.
+ *       Returns the median completion time across solves (non-zero time, under a 2-hour
+ *       cap). Co-op games are reduced to one sample per game. The median is only
+ *       populated once a minimum sample size has been reached; below that the response
+ *       contains only `sampleCount`.
  *     parameters:
  *       - in: path
  *         name: pid

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -439,3 +439,44 @@ export async function getPuzzleInfo(pid: string) {
   const {info = {}} = puzzle;
   return info;
 }
+
+// Solves longer than this are treated as "started a game, came back days later" rather than
+// real attempts. Two hours covers slow Sunday solvers without letting overnight idles skew the
+// median.
+export const PUZZLE_STATS_TIME_CAP_MS = 2 * 60 * 60 * 1000;
+
+// Hide the median until we have a stable sample. Below this it's too noisy to be useful as a
+// difficulty signal.
+export const PUZZLE_STATS_MIN_SAMPLES = 25;
+
+export type PuzzleStats = {
+  sampleCount: number;
+  medianMs: number | null;
+};
+
+export async function getPuzzleStats(pid: string): Promise<PuzzleStats> {
+  // "Clean" solve: no reveal events ever fired for the game, non-zero time, under the cap.
+  // game_events_gid_event_type_idx makes the NOT EXISTS cheap.
+  const {rows} = await pool.query(
+    `SELECT
+       COUNT(*)::int AS sample_count,
+       CASE WHEN COUNT(*) >= $3
+         THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.time_taken_to_solve)::int
+         ELSE NULL
+       END AS median_ms
+     FROM puzzle_solves ps
+     WHERE ps.pid = $1
+       AND ps.time_taken_to_solve > 0
+       AND ps.time_taken_to_solve < $2
+       AND NOT EXISTS (
+         SELECT 1 FROM game_events ge
+         WHERE ge.gid = ps.gid AND ge.event_type = 'reveal'
+       )`,
+    [pid, PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]
+  );
+  const row = rows[0] || {sample_count: 0, median_ms: null};
+  return {
+    sampleCount: Number(row.sample_count) || 0,
+    medianMs: row.median_ms != null ? Number(row.median_ms) : null,
+  };
+}

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -42,6 +42,19 @@ export function clearPuzzleListCache(): void {
   puzzleListCache.clear();
 }
 
+// ---- Puzzle stats cache ----
+// Median solve time moves glacially; aggressive caching is safe and cuts repeat queries on
+// popular puzzles to a single DB hit per TTL window. Keyed by pid.
+const puzzleStatsCache = new TTLCache<PuzzleStats>({
+  ttlMs: 5 * 60 * 1000,
+  maxSize: 5_000,
+  sweepIntervalMs: 10 * 60 * 1000,
+});
+
+export function clearPuzzleStatsCache(): void {
+  puzzleStatsCache.clear();
+}
+
 export async function getPuzzle(pid: string): Promise<PuzzleJson | null> {
   const {rows} = await pool.query(
     `
@@ -424,6 +437,9 @@ export async function recordSolve(
       await client.query(`UPDATE puzzles SET times_solved = times_solved + 1 WHERE pid = $1`, [pid]);
     }
     await client.query('COMMIT');
+    if (insertResult.rowCount === 1) {
+      puzzleStatsCache.delete(pid);
+    }
   } catch (e) {
     await client.query('ROLLBACK');
     console.error(`[recordSolve] failed for pid=${pid} gid=${gid}:`, e);
@@ -455,28 +471,30 @@ export type PuzzleStats = {
 };
 
 export async function getPuzzleStats(pid: string): Promise<PuzzleStats> {
-  // "Clean" solve: no reveal events ever fired for the game, non-zero time, under the cap.
-  // game_events_gid_event_type_idx makes the NOT EXISTS cheap.
-  const {rows} = await pool.query(
-    `SELECT
-       COUNT(*)::int AS sample_count,
-       CASE WHEN COUNT(*) >= $3
-         THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.time_taken_to_solve)::int
-         ELSE NULL
-       END AS median_ms
-     FROM puzzle_solves ps
-     WHERE ps.pid = $1
-       AND ps.time_taken_to_solve > 0
-       AND ps.time_taken_to_solve < $2
-       AND NOT EXISTS (
-         SELECT 1 FROM game_events ge
-         WHERE ge.gid = ps.gid AND ge.event_type = 'reveal'
-       )`,
-    [pid, PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]
-  );
-  const row = rows[0] || {sample_count: 0, median_ms: null};
-  return {
-    sampleCount: Number(row.sample_count) || 0,
-    medianMs: row.median_ms != null ? Number(row.median_ms) : null,
-  };
+  return puzzleStatsCache.getOrFetch(pid, async () => {
+    // "Clean" solve: no reveal events ever fired for the game, non-zero time, under the cap.
+    // game_events_gid_event_type_idx makes the NOT EXISTS cheap.
+    const {rows} = await pool.query(
+      `SELECT
+         COUNT(*)::int AS sample_count,
+         CASE WHEN COUNT(*) >= $3
+           THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.time_taken_to_solve)::int
+           ELSE NULL
+         END AS median_ms
+       FROM puzzle_solves ps
+       WHERE ps.pid = $1
+         AND ps.time_taken_to_solve > 0
+         AND ps.time_taken_to_solve < $2
+         AND NOT EXISTS (
+           SELECT 1 FROM game_events ge
+           WHERE ge.gid = ps.gid AND ge.event_type = 'reveal'
+         )`,
+      [pid, PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]
+    );
+    const row = rows[0] || {sample_count: 0, median_ms: null};
+    return {
+      sampleCount: Number(row.sample_count) || 0,
+      medianMs: row.median_ms != null ? Number(row.median_ms) : null,
+    };
+  });
 }

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -472,23 +472,32 @@ export type PuzzleStats = {
 
 export async function getPuzzleStats(pid: string): Promise<PuzzleStats> {
   return puzzleStatsCache.getOrFetch(pid, async () => {
-    // "Clean" solve: no reveal events ever fired for the game, non-zero time, under the cap.
-    // game_events_gid_event_type_idx makes the NOT EXISTS cheap.
+    // Aggregate to one row per gid first: a co-op game has one puzzle_solves row per
+    // authenticated user, and counting each as a separate sample would weight the
+    // median toward larger teams. MIN(time) per gid approximates game duration
+    // (the user who was present longest has the lowest elapsed clock).
+    // "Clean" solve: no reveal events ever fired for the game, non-zero time, under
+    // the cap. game_events_gid_event_type_idx makes the NOT EXISTS cheap.
     const {rows} = await pool.query(
-      `SELECT
+      `WITH game_times AS (
+         SELECT ps.gid, MIN(ps.time_taken_to_solve) AS time_ms
+         FROM puzzle_solves ps
+         WHERE ps.pid = $1
+           AND ps.time_taken_to_solve > 0
+           AND ps.time_taken_to_solve < $2
+           AND NOT EXISTS (
+             SELECT 1 FROM game_events ge
+             WHERE ge.gid = ps.gid AND ge.event_type = 'reveal'
+           )
+         GROUP BY ps.gid
+       )
+       SELECT
          COUNT(*)::int AS sample_count,
          CASE WHEN COUNT(*) >= $3
-           THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.time_taken_to_solve)::int
+           THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY time_ms)::int
            ELSE NULL
          END AS median_ms
-       FROM puzzle_solves ps
-       WHERE ps.pid = $1
-         AND ps.time_taken_to_solve > 0
-         AND ps.time_taken_to_solve < $2
-         AND NOT EXISTS (
-           SELECT 1 FROM game_events ge
-           WHERE ge.gid = ps.gid AND ge.event_type = 'reveal'
-         )`,
+       FROM game_times`,
       [pid, PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]
     );
     const row = rows[0] || {sample_count: 0, median_ms: null};

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -474,13 +474,14 @@ export async function getPuzzleStats(pid: string): Promise<PuzzleStats> {
   return puzzleStatsCache.getOrFetch(pid, async () => {
     // Aggregate to one row per gid first: a co-op game has one puzzle_solves row per
     // authenticated user, and counting each as a separate sample would weight the
-    // median toward larger teams. MIN(time) per gid approximates game duration
-    // (the user who was present longest has the lowest elapsed clock).
+    // median toward larger teams. MAX(time) per gid picks the longest-present user's
+    // clock — closest to total game duration, since each user's clock starts when
+    // they join. MIN would bias downward toward the latest joiner.
     // "Clean" solve: no reveal events ever fired for the game, non-zero time, under
     // the cap. game_events_gid_event_type_idx makes the NOT EXISTS cheap.
     const {rows} = await pool.query(
       `WITH game_times AS (
-         SELECT ps.gid, MIN(ps.time_taken_to_solve) AS time_ms
+         SELECT ps.gid, MAX(ps.time_taken_to_solve) AS time_ms
          FROM puzzle_solves ps
          WHERE ps.pid = $1
            AND ps.time_taken_to_solve > 0

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -477,8 +477,11 @@ export async function getPuzzleStats(pid: string): Promise<PuzzleStats> {
     // median toward larger teams. MAX(time) per gid picks the longest-present user's
     // clock — closest to total game duration, since each user's clock starts when
     // they join. MIN would bias downward toward the latest joiner.
-    // "Clean" solve: no reveal events ever fired for the game, non-zero time, under
-    // the cap. game_events_gid_event_type_idx makes the NOT EXISTS cheap.
+    // We do not exclude reveal-assisted solves: that would require joining game_events,
+    // whose history is deleted by the archival job once a game is solved. Filtering
+    // there would drift over time as old games get cleaned up. The median is robust
+    // enough to typical reveal usage at this sample threshold; a future revision can
+    // persist a durable per-solve "had_reveals" flag.
     const {rows} = await pool.query(
       `WITH game_times AS (
          SELECT ps.gid, MAX(ps.time_taken_to_solve) AS time_ms
@@ -486,10 +489,6 @@ export async function getPuzzleStats(pid: string): Promise<PuzzleStats> {
          WHERE ps.pid = $1
            AND ps.time_taken_to_solve > 0
            AND ps.time_taken_to_solve < $2
-           AND NOT EXISTS (
-             SELECT 1 FROM game_events ge
-             WHERE ge.gid = ps.gid AND ge.event_type = 'reveal'
-           )
          GROUP BY ps.gid
        )
        SELECT

--- a/src/api/puzzle.ts
+++ b/src/api/puzzle.ts
@@ -56,6 +56,21 @@ export async function fetchPuzzleInfo(pid: number): Promise<InfoJson | null> {
   }
 }
 
+export type PuzzleStats = {
+  sampleCount: number;
+  medianMs: number | null;
+};
+
+export async function fetchPuzzleStats(pid: string | number): Promise<PuzzleStats | null> {
+  try {
+    const resp = await fetch(`${SERVER_URL}/api/puzzle/${pid}/stats`);
+    if (!resp.ok) return null;
+    return resp.json();
+  } catch {
+    return null;
+  }
+}
+
 export async function recordSolve(
   pid: string,
   gid: string,

--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -13,8 +13,9 @@ import ConfirmDialog from '../components/common/ConfirmDialog';
 import actions from '../actions';
 import redirect from '../lib/redirect';
 import {createGame, dismissGame} from '../api/create_game';
-import {fetchPuzzleInfo} from '../api/puzzle';
+import {fetchPuzzleInfo, fetchPuzzleStats} from '../api/puzzle';
 import {fetchUserGames} from '../api/user_games';
+import {formatMilliseconds} from '../components/Toolbar/Clock';
 import getLocalId from '../localAuth';
 import AuthContext from '../lib/AuthContext';
 
@@ -39,6 +40,7 @@ class Play extends Component {
       games: null,
       creating: false,
       puzzleInfo: null,
+      puzzleStats: null,
       abandonGid: null,
       error: null,
     };
@@ -67,6 +69,10 @@ class Play extends Component {
 
     fetchPuzzleInfo(this.pid).then((info) => {
       if (info) this.setState({puzzleInfo: info});
+    });
+
+    fetchPuzzleStats(this.pid).then((stats) => {
+      if (stats) this.setState({puzzleStats: stats});
     });
   }
 
@@ -252,6 +258,12 @@ class Play extends Component {
               <div className="play--puzzle-original">
                 Originally: {this.state.puzzleInfo.title}
                 {this.state.puzzleInfo.authorOverride ? ` by ${this.state.puzzleInfo.author}` : ''}
+              </div>
+            )}
+            {this.state.puzzleStats && this.state.puzzleStats.medianMs != null && (
+              <div className="play--puzzle-stats">
+                Typical solve time: {formatMilliseconds(this.state.puzzleStats.medianMs)} (
+                {this.state.puzzleStats.sampleCount} solves)
               </div>
             )}
           </div>

--- a/src/pages/css/play.css
+++ b/src/pages/css/play.css
@@ -30,6 +30,12 @@
   margin-top: 2px;
 }
 
+.play--puzzle-stats {
+  font-size: 12px;
+  color: #666;
+  margin-top: 6px;
+}
+
 .play--table {
   width: 100%;
   border-collapse: collapse;
@@ -112,6 +118,10 @@
 
 .dark .play--puzzle-original {
   color: rgb(255 255 255 / 35%);
+}
+
+.dark .play--puzzle-stats {
+  color: #aaa;
 }
 
 .dark .play--table td {


### PR DESCRIPTION
New /api/puzzle/:pid/stats endpoint returns the median solve time across
"clean" solves (no reveal events, non-zero, under a 2-hour cap), gated at
a 25-solve minimum to keep the number stable. Combines solo + coop for v1.
Renders inline below the puzzle title/author on the Play page.