### PR TITLE
Surface typical solve time on homepage cards and game page

### DIFF
--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -159,9 +159,13 @@ describe('listPuzzles', () => {
 
     await listPuzzles(filter, 50, 0, userId);
 
+    const sql = pool.query.mock.calls[0][0] as string;
     const params = pool.query.mock.calls[0][1] as any[];
-    // userId should be the last parameter
-    expect(params[params.length - 1]).toBe(userId);
+    // userId should be at whatever position the SQL's "uploaded_by = $N" refers to.
+    const match = sql.match(/uploaded_by = \$(\d+)/);
+    expect(match).not.toBeNull();
+    const userIdParamPos = Number.parseInt(match![1], 10);
+    expect(params[userIdParamPos - 1]).toBe(userId);
   });
 
   it('orders by pid_numeric DESC by default', async () => {

--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -218,6 +218,74 @@ describe('listPuzzles', () => {
     expect(sql).toContain('SUM(rating)');
     expect(sql).toContain('COUNT(*)');
   });
+
+  it('joins a LATERAL median-solve-time aggregate over puzzle_solves', async () => {
+    pool.query.mockResolvedValue({rows: []});
+    await listPuzzles(defaultFilter, 50, 0);
+    const sql = pool.query.mock.calls[0][0] as string;
+    // Same shape as getPuzzleStats: group by gid first (co-op dedup), then
+    // PERCENTILE_CONT over the per-gid MAX times.
+    expect(sql).toContain('PERCENTILE_CONT(0.5)');
+    expect(sql).toContain('MAX(ps.time_taken_to_solve)');
+    expect(sql).toContain('FROM puzzle_solves ps');
+    expect(sql).toContain('GROUP BY ps.gid');
+    expect(sql).toContain('median_solve_ms');
+    expect(sql).toContain('solve_sample_count');
+  });
+
+  it('maps median_solve_ms and solve_sample_count from row to camelCase fields', async () => {
+    pool.query.mockResolvedValue({
+      rows: [
+        {
+          pid: 'abc',
+          uploaded_at: '2026-05-01',
+          is_public: true,
+          info: {title: 'Test', author: 'A'},
+          grid_rows: 15,
+          grid_cols: 15,
+          contest: false,
+          times_solved: '300',
+          rating_avg: null,
+          rating_count: 0,
+          median_solve_ms: '780000',
+          solve_sample_count: '87',
+        },
+      ],
+    });
+
+    const result = await listPuzzles(defaultFilter, 50, 0);
+
+    expect(result[0].median_solve_ms).toBe(780000);
+    expect(result[0].solve_sample_count).toBe(87);
+    expect(typeof result[0].median_solve_ms).toBe('number');
+    expect(typeof result[0].solve_sample_count).toBe('number');
+  });
+
+  it('returns null median when there are not enough samples', async () => {
+    pool.query.mockResolvedValue({
+      rows: [
+        {
+          pid: 'abc',
+          uploaded_at: '2026-05-01',
+          is_public: true,
+          info: {title: 'Test', author: 'A'},
+          grid_rows: 15,
+          grid_cols: 15,
+          contest: false,
+          times_solved: '5',
+          rating_avg: null,
+          rating_count: 0,
+          median_solve_ms: null,
+          solve_sample_count: '5',
+        },
+      ],
+    });
+
+    const result = await listPuzzles(defaultFilter, 50, 0);
+
+    expect(result[0].median_solve_ms).toBeNull();
+    expect(result[0].solve_sample_count).toBe(5);
+  });
 });
 
 describe('getUserUploadedPuzzles', () => {

--- a/server/api/puzzle_list.ts
+++ b/server/api/puzzle_list.ts
@@ -104,6 +104,8 @@ router.get<{}, ListPuzzleResponse>('/', optionalAuth, async (req, res, next) => 
         numSolves: puzzle.times_solved,
         ratingAverage: puzzle.rating_avg,
         ratingCount: puzzle.rating_count,
+        medianSolveMs: puzzle.median_solve_ms,
+        solveSampleCount: puzzle.solve_sample_count,
       },
       isPublic: puzzle.is_public,
     }));

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -199,14 +199,22 @@ export async function listPuzzles(
       typeof rawMinRating === 'number' && rawMinRating >= 1 && rawMinRating <= 5 ? rawMinRating : 0;
     const ratingFilterClause = minRating > 0 ? `AND r.avg IS NOT NULL AND r.avg >= ${minRating}` : '';
 
-    let orderByClause: string;
+    let orderBySpec: string;
     if (filter.sortBy === 'rating_desc') {
-      orderByClause = `ORDER BY r.weighted DESC NULLS LAST, pid_numeric DESC`;
+      orderBySpec = `r.weighted DESC NULLS LAST, pid_numeric DESC`;
     } else if (filter.sortBy === 'rating_asc') {
-      orderByClause = `ORDER BY r.weighted ASC NULLS LAST, pid_numeric DESC`;
+      orderBySpec = `r.weighted ASC NULLS LAST, pid_numeric DESC`;
     } else {
-      orderByClause = `ORDER BY pid_numeric DESC`;
+      orderBySpec = `pid_numeric DESC`;
     }
+    const orderByClause = `ORDER BY ${orderBySpec}`;
+    const windowOrderBy = `OVER (ORDER BY ${orderBySpec})`;
+
+    // Stats constants are parameterized for consistency with getPuzzleStats
+    // (and the rest of the codebase). Append them after the existing params
+    // so we don't have to renumber title/day/userId placeholders.
+    const statsTimeCapIndex = userIdParamIndex + (userId ? 1 : 0);
+    const statsMinSamplesIndex = statsTimeCapIndex + 1;
 
     // Two-stage query so the expensive median LATERAL only runs over the
     // returned page, not every matched puzzle. The rating aggregate has to
@@ -227,7 +235,11 @@ export async function listPuzzles(
           jsonb_array_length(content->'grid'->0) AS grid_cols,
           (content->>'contest')::boolean AS contest,
           r.avg AS rating_avg,
-          COALESCE(r.count, 0) AS rating_count
+          COALESCE(r.count, 0) AS rating_count,
+          -- Tag each row with its sort position so the outer query can
+          -- preserve order after the median LATERAL join. SQL doesn't
+          -- guarantee row order survives subsequent joins.
+          ROW_NUMBER() ${windowOrderBy} AS sort_idx
         FROM puzzles
         LEFT JOIN LATERAL (
           SELECT
@@ -259,7 +271,7 @@ export async function listPuzzles(
         -- MAX(time), then median over those when we have a stable sample.
         SELECT
           COUNT(*)::int AS sample_count,
-          CASE WHEN COUNT(*) >= ${PUZZLE_STATS_MIN_SAMPLES}
+          CASE WHEN COUNT(*) >= $${statsMinSamplesIndex}
             THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY time_ms)::int
             ELSE NULL
           END AS median_ms
@@ -268,12 +280,21 @@ export async function listPuzzles(
           FROM puzzle_solves ps
           WHERE ps.pid = page.pid
             AND ps.time_taken_to_solve > 0
-            AND ps.time_taken_to_solve < ${PUZZLE_STATS_TIME_CAP_MS}
+            AND ps.time_taken_to_solve < $${statsTimeCapIndex}
           GROUP BY ps.gid
         ) game_times
       ) s ON true
+      ORDER BY page.sort_idx
     `,
-      [limit, offset, ...parametersForTitleAuthorFilter, ...dayParams, ...userIdParams]
+      [
+        limit,
+        offset,
+        ...parametersForTitleAuthorFilter,
+        ...dayParams,
+        ...userIdParams,
+        PUZZLE_STATS_TIME_CAP_MS,
+        PUZZLE_STATS_MIN_SAMPLES,
+      ]
     );
     const puzzles: PuzzleListRow[] = rows.map(
       (row: {

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -15,6 +15,8 @@ type PuzzleListRow = {
   is_public: boolean;
   rating_avg: number | null;
   rating_count: number;
+  median_solve_ms: number | null;
+  solve_sample_count: number;
 };
 
 // ---- Puzzle list cache ----
@@ -206,41 +208,70 @@ export async function listPuzzles(
       orderByClause = `ORDER BY pid_numeric DESC`;
     }
 
-    // Select only the JSONB fields the frontend needs (info, grid dimensions, contest flag)
-    // instead of the entire content column which includes clues, solution, circles, shades, and images.
-    // This dramatically reduces I/O and network transfer for the puzzle list page.
+    // Two-stage query so the expensive median LATERAL only runs over the
+    // returned page, not every matched puzzle. The rating aggregate has to
+    // be in the inner stage because filters/sort can reference its outputs;
+    // it's cheap enough (AVG/COUNT over a small puzzle_ratings) that paying
+    // the cost across all matched puzzles is fine. PERCENTILE_CONT is the
+    // one we don't want fanning out — see EXPLAIN notes in the PR.
+    //
     // puzzle_ratings shares only `pid` with puzzles, so the filter clauses
-    // (content/is_public/uploaded_by/pid_numeric) remain unambiguous after the LEFT JOIN.
+    // (content/is_public/uploaded_by/pid_numeric) remain unambiguous after
+    // the LATERAL join in the inner stage.
     const {rows} = await pool.query(
       `
-      SELECT puzzles.pid, uploaded_at, is_public, times_solved,
-        content->'info' AS info,
-        jsonb_array_length(content->'grid') AS grid_rows,
-        jsonb_array_length(content->'grid'->0) AS grid_cols,
-        (content->>'contest')::boolean AS contest,
-        r.avg AS rating_avg,
-        COALESCE(r.count, 0) AS rating_count
-      FROM puzzles
+      WITH page AS (
+        SELECT puzzles.pid, uploaded_at, is_public, times_solved,
+          content->'info' AS info,
+          jsonb_array_length(content->'grid') AS grid_rows,
+          jsonb_array_length(content->'grid'->0) AS grid_cols,
+          (content->>'contest')::boolean AS contest,
+          r.avg AS rating_avg,
+          COALESCE(r.count, 0) AS rating_count
+        FROM puzzles
+        LEFT JOIN LATERAL (
+          SELECT
+            AVG(rating)::float AS avg,
+            COUNT(*)::int AS count,
+            CASE WHEN COUNT(*) > 0
+                 THEN ((${ratingPriorWeight} * ${ratingPriorMean}) + SUM(rating))::float / (${ratingPriorWeight} + COUNT(*))
+                 ELSE NULL
+            END AS weighted
+          FROM puzzle_ratings
+          WHERE pid = puzzles.pid
+        ) r ON true
+        WHERE ${visibilityClause}
+        ${sizeClause}
+        ${typeClause}
+        ${parameterizedTitleAuthorFilter}
+        ${dayClause}
+        ${ratingFilterClause}
+        ${orderByClause}
+        LIMIT $1
+        OFFSET $2
+      )
+      SELECT page.*,
+        s.median_ms AS median_solve_ms,
+        COALESCE(s.sample_count, 0) AS solve_sample_count
+      FROM page
       LEFT JOIN LATERAL (
+        -- Mirrors getPuzzleStats: collapse co-op solves to one per gid via
+        -- MAX(time), then median over those when we have a stable sample.
         SELECT
-          AVG(rating)::float AS avg,
-          COUNT(*)::int AS count,
-          CASE WHEN COUNT(*) > 0
-               THEN ((${ratingPriorWeight} * ${ratingPriorMean}) + SUM(rating))::float / (${ratingPriorWeight} + COUNT(*))
-               ELSE NULL
-          END AS weighted
-        FROM puzzle_ratings
-        WHERE pid = puzzles.pid
-      ) r ON true
-      WHERE ${visibilityClause}
-      ${sizeClause}
-      ${typeClause}
-      ${parameterizedTitleAuthorFilter}
-      ${dayClause}
-      ${ratingFilterClause}
-      ${orderByClause}
-      LIMIT $1
-      OFFSET $2
+          COUNT(*)::int AS sample_count,
+          CASE WHEN COUNT(*) >= ${PUZZLE_STATS_MIN_SAMPLES}
+            THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY time_ms)::int
+            ELSE NULL
+          END AS median_ms
+        FROM (
+          SELECT MAX(ps.time_taken_to_solve) AS time_ms
+          FROM puzzle_solves ps
+          WHERE ps.pid = page.pid
+            AND ps.time_taken_to_solve > 0
+            AND ps.time_taken_to_solve < ${PUZZLE_STATS_TIME_CAP_MS}
+          GROUP BY ps.gid
+        ) game_times
+      ) s ON true
     `,
       [limit, offset, ...parametersForTitleAuthorFilter, ...dayParams, ...userIdParams]
     );
@@ -256,6 +287,8 @@ export async function listPuzzles(
         times_solved: string;
         rating_avg: number | null;
         rating_count: number;
+        median_solve_ms: number | string | null;
+        solve_sample_count: number | string;
         // NOTE: numeric returns as string in pg-promise
         // See https://stackoverflow.com/questions/39168501/pg-promise-returns-integers-as-strings
       }) => ({
@@ -264,6 +297,8 @@ export async function listPuzzles(
         times_solved: Number(row.times_solved),
         rating_avg: row.rating_avg !== null ? Number(row.rating_avg) : null,
         rating_count: Number(row.rating_count) || 0,
+        median_solve_ms: row.median_solve_ms !== null ? Number(row.median_solve_ms) : null,
+        solve_sample_count: Number(row.solve_sample_count) || 0,
         // Reconstruct a minimal content object with just the fields the frontend uses:
         // - info (title, author, type)
         // - grid (only dimensions matter — build a skeleton array)

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -13,6 +13,7 @@ import EditableSpan from '../common/EditableSpan';
 import ColorPicker from './ColorPicker.tsx';
 import {formatMilliseconds} from '../Toolbar/Clock';
 import RatingWidget from '../Game/RatingWidget';
+import PuzzleStatsLine from '../Game/PuzzleStatsLine';
 
 const isEmojis = (str) => {
   const res = str.match(/[A-Za-z,.0-9!-]/g);
@@ -222,6 +223,7 @@ export default class Chat extends Component {
             {bid}
           </div>
         )}
+        {pid && <PuzzleStatsLine pid={String(pid)} />}
         {pid && <RatingWidget pid={String(pid)} />}
         {this.renderFencingOptions()}
       </div>

--- a/src/components/Game/PuzzleStatsLine.tsx
+++ b/src/components/Game/PuzzleStatsLine.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react';
 import {MdAccessTime} from 'react-icons/md';
+import * as Sentry from '@sentry/react';
 import {fetchPuzzleStats, PuzzleStats} from '../../api/puzzle';
 import {formatMilliseconds} from '../Toolbar/Clock';
 import './css/PuzzleStatsLine.css';
@@ -13,9 +14,13 @@ export default function PuzzleStatsLine({pid}: Props) {
 
   useEffect(() => {
     let cancelled = false;
-    fetchPuzzleStats(pid).then((data) => {
-      if (!cancelled) setStats(data);
-    });
+    fetchPuzzleStats(pid)
+      .then((data) => {
+        if (!cancelled) setStats(data);
+      })
+      .catch((err) => {
+        Sentry.captureException(err);
+      });
     return () => {
       cancelled = true;
     };

--- a/src/components/Game/PuzzleStatsLine.tsx
+++ b/src/components/Game/PuzzleStatsLine.tsx
@@ -1,0 +1,33 @@
+import {useEffect, useState} from 'react';
+import {MdAccessTime} from 'react-icons/md';
+import {fetchPuzzleStats, PuzzleStats} from '../../api/puzzle';
+import {formatMilliseconds} from '../Toolbar/Clock';
+import './css/PuzzleStatsLine.css';
+
+interface Props {
+  pid: string;
+}
+
+export default function PuzzleStatsLine({pid}: Props) {
+  const [stats, setStats] = useState<PuzzleStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchPuzzleStats(pid).then((data) => {
+      if (!cancelled) setStats(data);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [pid]);
+
+  if (!stats || stats.medianMs == null) return null;
+
+  return (
+    <div className="puzzle-stats-line" title={`Median across ${stats.sampleCount} solves`}>
+      <MdAccessTime className="puzzle-stats-line--icon" />
+      <span>Typical solve: {formatMilliseconds(stats.medianMs)}</span>
+      <span className="puzzle-stats-line--sample">({stats.sampleCount} solves)</span>
+    </div>
+  );
+}

--- a/src/components/Game/PuzzleStatsLine.tsx
+++ b/src/components/Game/PuzzleStatsLine.tsx
@@ -14,6 +14,11 @@ export default function PuzzleStatsLine({pid}: Props) {
 
   useEffect(() => {
     let cancelled = false;
+    // Clear stale stats so an in-app navigation between puzzles doesn't
+    // flash the previous puzzle's median while the new fetch is pending.
+    // Chat (which renders us) is mounted without a key in pages/Game.js,
+    // so the same component instance is reused across pid changes.
+    setStats(null);
     fetchPuzzleStats(pid)
       .then((data) => {
         if (!cancelled) setStats(data);

--- a/src/components/Game/css/PuzzleStatsLine.css
+++ b/src/components/Game/css/PuzzleStatsLine.css
@@ -1,0 +1,23 @@
+.puzzle-stats-line {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: #666;
+  margin: 4px 0;
+}
+
+.puzzle-stats-line--icon {
+  font-size: 14px;
+  color: #888;
+}
+
+.puzzle-stats-line--sample {
+  color: #999;
+}
+
+.dark .puzzle-stats-line,
+.dark .puzzle-stats-line--icon,
+.dark .puzzle-stats-line--sample {
+  color: rgb(255 255 255 / 60%);
+}

--- a/src/components/PuzzleList/Entry.tsx
+++ b/src/components/PuzzleList/Entry.tsx
@@ -1,8 +1,9 @@
 import {Component} from 'react';
 import _ from 'lodash';
-import {MdRadioButtonUnchecked, MdCheckCircle, MdStar} from 'react-icons/md';
+import {MdRadioButtonUnchecked, MdCheckCircle, MdStar, MdAccessTime} from 'react-icons/md';
 import {GiCrossedSwords} from 'react-icons/gi';
 import {Link} from 'react-router';
+import {formatMilliseconds} from '../Toolbar/Clock';
 
 export interface EntryProps {
   info: {
@@ -20,6 +21,8 @@ export interface EntryProps {
     solves?: Array<any>;
     ratingAverage?: number | null;
     ratingCount?: number;
+    medianSolveMs?: number | null;
+    solveSampleCount?: number;
   };
   fencing?: boolean;
   isPublic?: boolean;
@@ -29,6 +32,11 @@ export interface EntryProps {
 function ratingTitle(average: number | null | undefined, count: number | undefined): string {
   if (average == null || !count) return 'No ratings yet';
   return `Average rating ${average.toFixed(1)} from ${count} ${count === 1 ? 'rating' : 'ratings'}`;
+}
+
+function typicalSolveTitle(medianMs: number | null | undefined, sampleCount: number | undefined): string {
+  if (medianMs == null || !sampleCount) return '';
+  return `Typical solve time: ${formatMilliseconds(medianMs)} across ${sampleCount} solves`;
 }
 
 const handleClick = () => {
@@ -119,6 +127,15 @@ export default class Entry extends Component<EntryProps> {
               Solved {numSolves} {numSolves === 1 ? 'time' : 'times'}
             </p>
             <div className="flex">
+              {stats?.medianSolveMs != null && (
+                <span
+                  className="entry--solve-time"
+                  title={typicalSolveTitle(stats.medianSolveMs, stats.solveSampleCount)}
+                >
+                  <MdAccessTime className="entry--solve-time-icon" />
+                  {formatMilliseconds(stats.medianSolveMs)}
+                </span>
+              )}
               <span className="entry--rating" title={ratingTitle(stats?.ratingAverage, stats?.ratingCount)}>
                 <MdStar className="entry--rating-icon" />
                 {stats?.ratingAverage != null

--- a/src/dark.css
+++ b/src/dark.css
@@ -427,6 +427,11 @@
   color: rgb(255 255 255 / 60%);
 }
 
+.dark .entry--solve-time,
+.dark .entry--solve-time-icon {
+  color: rgb(255 255 255 / 60%);
+}
+
 .dark .welcome--sort-select {
   background: #2a2a2a;
   color: rgb(255 255 255 / 87%);

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -203,6 +203,22 @@
   font-size: 12px;
 }
 
+.entry--solve-time {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 10px;
+  font-weight: 600;
+  color: #888;
+  white-space: nowrap;
+  margin-right: 6px;
+}
+
+.entry--solve-time-icon {
+  color: #888;
+  font-size: 12px;
+}
+
 .welcome--sort-select {
   margin-top: 6px;
   padding: 4px 6px;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -100,6 +100,8 @@ export interface PuzzleStatsJson {
   numSolves: number;
   ratingAverage: number | null;
   ratingCount: number;
+  medianSolveMs: number | null;
+  solveSampleCount: number;
 }
 
 export interface AddPuzzleRequest {


### PR DESCRIPTION
## Summary

PR #507 added the median solve-time endpoint and rendered it on the Play page — but `Play.renderMain` only fires when a user has 2+ games for a puzzle, so most users never see it. This puts the metric in front of users on the two surfaces where it actually helps them: when **picking** a puzzle (homepage cards) and when **playing** one (game page header).

### Homepage cards
- `listPuzzles` now returns `median_solve_ms` + `solve_sample_count` alongside the rating aggregate, so each card can show "★ 4.3 (12) · ⏱ 12:34" without a per-card fetch
- Hidden when median is `null` (fewer than `PUZZLE_STATS_MIN_SAMPLES = 25` samples) so new puzzles aren't labeled with noisy averages

### Game page chat header
- New `PuzzleStatsLine` component sits next to the rating widget under the puzzle title/description
- Reuses `fetchPuzzleStats` so it hits the per-pid `puzzleStatsCache`; zero DB cost on repeat visits

## Performance

The big concern was `PERCENTILE_CONT` fanning out across all matched puzzles. Restructured the SQL into a two-stage query:

1. **Inner CTE** applies filters + sort + LIMIT (with the cheap rating LATERAL inline so it can still drive rating filter/sort)
2. **Outer query** attaches the median LATERAL to the materialized page

This caps `PERCENTILE_CONT` evaluations at LIMIT (typically 50) per cache miss, instead of fanning out to every matched public puzzle (~25k). Verified with `EXPLAIN`:

```
->  Limit  (cost=...)                              -- inner CTE
      ->  Sort  Sort Key: pid_numeric DESC
            ->  Nested Loop Left Join              -- rating LATERAL (cheap AVG/COUNT)
                  ->  Seq Scan on puzzles
                  ->  Aggregate / Bitmap Index Scan on puzzle_ratings
->  Aggregate                                       -- median LATERAL on the 50-row page
      ->  GroupAggregate (gid)
            ->  Index Scan on puzzle_solves (pid)
```

The existing 5-min `puzzleListCache` TTL further amortizes the cost across viewers of the same filter combo.

## Test plan

- [x] `pnpm test` — 385 passing
- [x] `pnpm test:server --ci` — 242 passing (3 new for the median LATERAL shape + row mapping)
- [x] `pnpm tsc --noEmit` (frontend + server) clean
- [x] `pnpm eslint --max-warnings 0 src/ server/` clean
- [x] `pnpm stylelint` clean
- [x] `pnpm build` clean
- [x] Local `EXPLAIN` confirms median LATERAL runs only over the page CTE
- [ ] Verify on testing env: typical solve time appears on cards for popular puzzles, in the chat header on the game page, hidden for puzzles below the 25-sample threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)