### PR TITLE
Clear stale state on pid/auth change in RatingWidget

### DIFF
--- a/src/components/Game/RatingWidget.tsx
+++ b/src/components/Game/RatingWidget.tsx
@@ -95,6 +95,8 @@ export default function RatingWidget({pid}: RatingWidgetProps) {
     // without a key in pages/Game.js so the same instance is reused.
     setAggregate(null);
     setEligibilityError(null);
+    setHover(0);
+    setSubmitting(false);
     fetchPuzzleRating(pid, accessToken)
       .then((data) => {
         if (!cancelled) setAggregate(data);

--- a/src/components/Game/RatingWidget.tsx
+++ b/src/components/Game/RatingWidget.tsx
@@ -89,6 +89,12 @@ export default function RatingWidget({pid}: RatingWidgetProps) {
 
   useEffect(() => {
     let cancelled = false;
+    // Clear stale state so an in-app navigation between puzzles doesn't
+    // flash the previous puzzle's aggregate (or a no-longer-applicable
+    // eligibility hint) while the new fetch is pending. Chat is mounted
+    // without a key in pages/Game.js so the same instance is reused.
+    setAggregate(null);
+    setEligibilityError(null);
     fetchPuzzleRating(pid, accessToken)
       .then((data) => {
         if (!cancelled) setAggregate(data);


### PR DESCRIPTION
## Summary

Same stale-data flash that Codex flagged on \`PuzzleStatsLine\` in #508 — \`RatingWidget\` has the equivalent bug from the Phase 1 ratings work. The pid/accessToken effect starts a new fetch but doesn't reset existing state, so:

- The previous puzzle's "★ 4.3 (12) · Your rating: 4" stays visible until the new request resolves
- The inline "Reach 25% to rate this puzzle" hint from one puzzle can briefly carry over to another where it doesn't apply

\`Chat\` (which renders the widget) is mounted without a key in [pages/Game.js](src/pages/Game.js), so the same component instance is reused on in-app pid changes — the flash is user-visible.

## Fix

\`setAggregate(null)\` and \`setEligibilityError(null)\` at the start of the effect, mirroring the \`PuzzleStatsLine\` fix.

## Test plan

- [x] \`pnpm test\` — 385 passing
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm eslint --max-warnings 0\` clean
- [ ] Verify on testing env: navigate between two puzzles with different ratings — the stars/label/eligibility hint should not flash old values

🤖 Generated with [Claude Code](https://claude.com/claude-code)