### PR TITLE
Denormalize puzzle solve + rating stats onto puzzles

### DIFF
--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -11,8 +11,6 @@ import {
   recordSolve,
   getPuzzleInfo,
   getPuzzleStats,
-  PUZZLE_STATS_MIN_SAMPLES,
-  PUZZLE_STATS_TIME_CAP_MS,
   clearPuzzleListCache,
   clearPuzzleStatsCache,
 } from '../../model/puzzle';
@@ -173,68 +171,57 @@ describe('listPuzzles', () => {
     await listPuzzles(defaultFilter, 50, 0);
     const sql = pool.query.mock.calls[0][0] as string;
     expect(sql).toContain('ORDER BY pid_numeric DESC');
-    expect(sql).not.toContain('r.weighted');
+    expect(sql).not.toContain('rating_weighted');
   });
 
   it('orders by weighted rating DESC when sortBy is rating_desc', async () => {
     pool.query.mockResolvedValue({rows: []});
     await listPuzzles({...defaultFilter, sortBy: 'rating_desc'}, 50, 0);
     const sql = pool.query.mock.calls[0][0] as string;
-    expect(sql).toContain('ORDER BY r.weighted DESC NULLS LAST, pid_numeric DESC');
+    expect(sql).toContain('ORDER BY rating_weighted DESC NULLS LAST, pid_numeric DESC');
   });
 
   it('orders by weighted rating ASC when sortBy is rating_asc', async () => {
     pool.query.mockResolvedValue({rows: []});
     await listPuzzles({...defaultFilter, sortBy: 'rating_asc'}, 50, 0);
     const sql = pool.query.mock.calls[0][0] as string;
-    expect(sql).toContain('ORDER BY r.weighted ASC NULLS LAST, pid_numeric DESC');
+    expect(sql).toContain('ORDER BY rating_weighted ASC NULLS LAST, pid_numeric DESC');
   });
 
   it('skips the rating filter clause when minRating is not set', async () => {
     pool.query.mockResolvedValue({rows: []});
     await listPuzzles(defaultFilter, 50, 0);
     const sql = pool.query.mock.calls[0][0] as string;
-    expect(sql).not.toContain('r.avg >=');
+    expect(sql).not.toContain('rating_avg >=');
   });
 
   it('applies the rating filter when minRating is between 1 and 5', async () => {
     pool.query.mockResolvedValue({rows: []});
     await listPuzzles({...defaultFilter, minRating: 3}, 50, 0);
     const sql = pool.query.mock.calls[0][0] as string;
-    expect(sql).toContain('r.avg IS NOT NULL AND r.avg >= 3');
+    expect(sql).toContain('rating_avg IS NOT NULL AND rating_avg >= 3');
   });
 
   it('ignores out-of-range minRating values', async () => {
     pool.query.mockResolvedValue({rows: []});
     await listPuzzles({...defaultFilter, minRating: 99}, 50, 0);
     const sql = pool.query.mock.calls[0][0] as string;
-    expect(sql).not.toContain('r.avg >=');
+    expect(sql).not.toContain('rating_avg >=');
   });
 
-  it('exposes a Bayesian-shrinkage weighted column for sort', async () => {
-    pool.query.mockResolvedValue({rows: []});
-    await listPuzzles({...defaultFilter, sortBy: 'rating_desc'}, 50, 0);
-    const sql = pool.query.mock.calls[0][0] as string;
-    // The exact constants are an implementation detail (5 phantom votes,
-    // prior mean 3.5) — we just check that the LATERAL emits a `weighted`
-    // expression that combines SUM(rating) and COUNT(*).
-    expect(sql).toContain('AS weighted');
-    expect(sql).toContain('SUM(rating)');
-    expect(sql).toContain('COUNT(*)');
-  });
-
-  it('joins a LATERAL median-solve-time aggregate over puzzle_solves', async () => {
+  it('selects denormalized rating + solve-time columns directly (no LATERAL aggregates)', async () => {
     pool.query.mockResolvedValue({rows: []});
     await listPuzzles(defaultFilter, 50, 0);
     const sql = pool.query.mock.calls[0][0] as string;
-    // Same shape as getPuzzleStats: group by gid first (co-op dedup), then
-    // PERCENTILE_CONT over the per-gid MAX times.
-    expect(sql).toContain('PERCENTILE_CONT(0.5)');
-    expect(sql).toContain('MAX(ps.time_taken_to_solve)');
-    expect(sql).toContain('FROM puzzle_solves ps');
-    expect(sql).toContain('GROUP BY ps.gid');
+    expect(sql).toContain('rating_avg');
+    expect(sql).toContain('rating_count');
     expect(sql).toContain('median_solve_ms');
     expect(sql).toContain('solve_sample_count');
+    // The previous implementation paid a per-row LATERAL cost; the whole
+    // point of the denormalization is that the list query does no joins.
+    expect(sql).not.toContain('PERCENTILE_CONT');
+    expect(sql).not.toContain('FROM puzzle_ratings');
+    expect(sql).not.toContain('FROM puzzle_solves');
   });
 
   it('maps median_solve_ms and solve_sample_count from row to camelCase fields', async () => {
@@ -554,14 +541,18 @@ describe('recordSolve', () => {
     mockClient.query.mockResolvedValueOnce({rows: [], rowCount: 1});
     // UPDATE times_solved
     mockClient.query.mockResolvedValueOnce({rows: []});
+    // refreshPuzzleSolveStats: recompute median + sample count into puzzles
+    mockClient.query.mockResolvedValueOnce({rows: []});
     // COMMIT
     mockClient.query.mockResolvedValueOnce({rows: []});
 
     await recordSolve('p1', 'g1', 300, 'user-1');
 
-    // Verify times_solved increment happened (5th client.query call)
-    const updateSql = mockClient.query.mock.calls[4][0] as string;
-    expect(updateSql).toContain('times_solved = times_solved + 1');
+    const allSql = mockClient.query.mock.calls.map((c: any[]) => c[0] as string);
+    expect(allSql.some((s) => s.includes('times_solved = times_solved + 1'))).toBe(true);
+    // The denorm refresh runs after the insert so the list query can read
+    // median_solve_ms / solve_sample_count as plain columns.
+    expect(allSql.some((s) => s.includes('PERCENTILE_CONT') && s.includes('UPDATE puzzles'))).toBe(true);
   });
 
   it('does not increment times_solved when game was already solved by someone else', async () => {
@@ -575,15 +566,17 @@ describe('recordSolve', () => {
     mockClient.query.mockResolvedValueOnce({rows: [{count: 1}]});
     // INSERT puzzle_solve (different user_id, no conflict)
     mockClient.query.mockResolvedValueOnce({rows: [], rowCount: 1});
+    // refreshPuzzleSolveStats — still runs whenever a new row was inserted
+    mockClient.query.mockResolvedValueOnce({rows: []});
     // COMMIT (no UPDATE times_solved)
     mockClient.query.mockResolvedValueOnce({rows: []});
 
     await recordSolve('p1', 'g1', 300, 'user-2');
 
-    // 5 client.query calls total (no times_solved increment)
-    expect(mockClient.query).toHaveBeenCalledTimes(5);
     const allSql = mockClient.query.mock.calls.map((c: any[]) => c[0] as string);
-    expect(allSql.some((s) => s.includes('times_solved'))).toBe(false);
+    expect(allSql.some((s) => s.includes('times_solved = times_solved + 1'))).toBe(false);
+    // Stats refresh fires on every successful insert regardless of first-solve status.
+    expect(allSql.some((s) => s.includes('PERCENTILE_CONT'))).toBe(true);
   });
 
   it('does not increment times_solved when concurrent insert hit the unique index (ON CONFLICT)', async () => {
@@ -597,14 +590,15 @@ describe('recordSolve', () => {
     mockClient.query.mockResolvedValueOnce({rows: [{count: 1}]});
     // INSERT with ON CONFLICT DO NOTHING — no row inserted (rowCount=0)
     mockClient.query.mockResolvedValueOnce({rows: [], rowCount: 0});
-    // COMMIT — no UPDATE times_solved
+    // COMMIT — no UPDATE times_solved, no refresh (insert was a no-op)
     mockClient.query.mockResolvedValueOnce({rows: []});
 
     await expect(recordSolve('p1', 'g1', 300)).resolves.not.toThrow();
 
-    expect(mockClient.query).toHaveBeenCalledTimes(5);
     const allSql = mockClient.query.mock.calls.map((c: any[]) => c[0] as string);
     expect(allSql.some((s) => s.includes('times_solved'))).toBe(false);
+    // No insert means no stats change; skip the refresh.
+    expect(allSql.some((s) => s.includes('PERCENTILE_CONT'))).toBe(false);
     // Verify the INSERT uses ON CONFLICT DO NOTHING
     expect(allSql[3]).toContain('ON CONFLICT DO NOTHING');
   });
@@ -621,6 +615,8 @@ describe('recordSolve', () => {
     mockClient.query.mockResolvedValueOnce({rows: [{count: 1}]});
     // INSERT puzzle_solve (anonymous)
     mockClient.query.mockResolvedValueOnce({rows: [], rowCount: 1});
+    // refreshPuzzleSolveStats
+    mockClient.query.mockResolvedValueOnce({rows: []});
     // COMMIT
     mockClient.query.mockResolvedValueOnce({rows: []});
 
@@ -668,13 +664,13 @@ describe('getPuzzleStats', () => {
   });
 
   it('returns the median and sample count when the threshold is met', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{sample_count: 42, median_ms: 1122334}]});
+    pool.query.mockResolvedValueOnce({rows: [{solve_sample_count: 42, median_solve_ms: 1122334}]});
     const result = await getPuzzleStats('p1');
     expect(result).toEqual({sampleCount: 42, medianMs: 1122334});
   });
 
   it('returns null median when below the sample threshold', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{sample_count: 7, median_ms: null}]});
+    pool.query.mockResolvedValueOnce({rows: [{solve_sample_count: 7, median_solve_ms: null}]});
     const result = await getPuzzleStats('p2');
     expect(result).toEqual({sampleCount: 7, medianMs: null});
   });
@@ -685,32 +681,22 @@ describe('getPuzzleStats', () => {
     expect(result).toEqual({sampleCount: 0, medianMs: null});
   });
 
-  it('filters by pid and excludes zero-time and over-cap solves', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{sample_count: 0, median_ms: null}]});
+  it('reads denormalized columns from puzzles instead of aggregating puzzle_solves', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{solve_sample_count: 0, median_solve_ms: null}]});
     await getPuzzleStats('p4');
     const [sql, params] = pool.query.mock.calls[0];
-    expect(sql).toContain('FROM puzzle_solves');
-    expect(sql).toContain('ps.time_taken_to_solve > 0');
-    expect(sql).toContain('ps.time_taken_to_solve < $2');
-    expect(sql).toContain('PERCENTILE_CONT(0.5)');
-    // No reveal-filter: that would require joining game_events, which is archived
-    // away on solved games. See comment in getPuzzleStats.
-    expect(sql).not.toContain('game_events');
-    expect(params).toEqual(['p4', PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]);
-  });
-
-  it('aggregates per gid so co-op games are counted once, not once per user', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{sample_count: 0, median_ms: null}]});
-    await getPuzzleStats('p4b');
-    const [sql] = pool.query.mock.calls[0];
-    // MAX over the per-user clocks approximates total game duration. MIN would
-    // bias downward toward whichever co-op user joined last.
-    expect(sql).toContain('MAX(ps.time_taken_to_solve)');
-    expect(sql).toContain('GROUP BY ps.gid');
+    expect(sql).toContain('FROM puzzles');
+    expect(sql).toContain('median_solve_ms');
+    expect(sql).toContain('solve_sample_count');
+    // The aggregation happens in refreshPuzzleSolveStats on the write path;
+    // the read path must not pay that cost per request.
+    expect(sql).not.toContain('PERCENTILE_CONT');
+    expect(sql).not.toContain('FROM puzzle_solves');
+    expect(params).toEqual(['p4']);
   });
 
   it('caches repeat lookups for the same pid', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{sample_count: 30, median_ms: 100000}]});
+    pool.query.mockResolvedValueOnce({rows: [{solve_sample_count: 30, median_solve_ms: 100000}]});
     await getPuzzleStats('p5');
     await getPuzzleStats('p5');
     expect(pool.query).toHaveBeenCalledTimes(1);
@@ -718,7 +704,7 @@ describe('getPuzzleStats', () => {
 
   it('invalidates the cache for a pid when a new solve is recorded', async () => {
     // Prime: cache pid="p6" stats
-    pool.query.mockResolvedValueOnce({rows: [{sample_count: 30, median_ms: 100000}]});
+    pool.query.mockResolvedValueOnce({rows: [{solve_sample_count: 30, median_solve_ms: 100000}]});
     await getPuzzleStats('p6');
     expect(pool.query).toHaveBeenCalledTimes(1);
 
@@ -730,11 +716,12 @@ describe('getPuzzleStats', () => {
       .mockResolvedValueOnce({rows: [{count: 0}]}) // first-solve COUNT
       .mockResolvedValueOnce({rows: [], rowCount: 1}) // INSERT
       .mockResolvedValueOnce({rows: []}) // UPDATE times_solved
+      .mockResolvedValueOnce({rows: []}) // refreshPuzzleSolveStats
       .mockResolvedValueOnce({rows: []}); // COMMIT
     await recordSolve('p6', 'g6', 300, 'user-6');
 
     // Cache should have been invalidated; the next stats call hits the DB again.
-    pool.query.mockResolvedValueOnce({rows: [{sample_count: 31, median_ms: 99000}]});
+    pool.query.mockResolvedValueOnce({rows: [{solve_sample_count: 31, median_solve_ms: 99000}]});
     const fresh = await getPuzzleStats('p6');
     expect(fresh).toEqual({sampleCount: 31, medianMs: 99000});
   });

--- a/server/__tests__/model/puzzle_rating.test.ts
+++ b/server/__tests__/model/puzzle_rating.test.ts
@@ -1,4 +1,4 @@
-import {pool, resetPoolMocks} from '../../__mocks__/pool';
+import {pool, resetPoolMocks, mockClient} from '../../__mocks__/pool';
 
 jest.mock('../../model/pool', () => require('../../__mocks__/pool'));
 
@@ -29,13 +29,23 @@ beforeEach(() => {
 
 describe('getRatingForPuzzle', () => {
   it('returns null average and zero count when no ratings exist', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{avg: null, count: 0}]});
+    pool.query.mockResolvedValueOnce({rows: [{rating_avg: null, rating_count: 0}]});
     const result = await getRatingForPuzzle('p1');
     expect(result).toEqual({average: null, count: 0, userRating: null});
   });
 
+  it('reads aggregate from denormalized columns on puzzles, not puzzle_ratings', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{rating_avg: 4.25, rating_count: 4}]});
+    await getRatingForPuzzle('p1');
+    const sql = pool.query.mock.calls[0][0] as string;
+    expect(sql).toContain('FROM puzzles');
+    expect(sql).toContain('rating_avg');
+    expect(sql).toContain('rating_count');
+    expect(sql).not.toContain('AVG(rating)');
+  });
+
   it('omits the user rating query when no userId is provided', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{avg: 4.25, count: 4}]});
+    pool.query.mockResolvedValueOnce({rows: [{rating_avg: 4.25, rating_count: 4}]});
     const result = await getRatingForPuzzle('p1');
     expect(result.average).toBe(4.25);
     expect(result.count).toBe(4);
@@ -45,37 +55,79 @@ describe('getRatingForPuzzle', () => {
 
   it('returns the user rating when authenticated and a rating exists', async () => {
     pool.query
-      .mockResolvedValueOnce({rows: [{avg: 4.0, count: 2}]})
+      .mockResolvedValueOnce({rows: [{rating_avg: 4.0, rating_count: 2}]})
       .mockResolvedValueOnce({rows: [{rating: 5}]});
     const result = await getRatingForPuzzle('p1', 'user-1');
     expect(result).toEqual({average: 4.0, count: 2, userRating: 5});
   });
 
   it('returns null userRating when authenticated but no personal rating exists', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{avg: 3.5, count: 1}]}).mockResolvedValueOnce({rows: []});
+    pool.query
+      .mockResolvedValueOnce({rows: [{rating_avg: 3.5, rating_count: 1}]})
+      .mockResolvedValueOnce({rows: []});
     const result = await getRatingForPuzzle('p1', 'user-1');
     expect(result.userRating).toBeNull();
   });
 });
 
 describe('upsertRating', () => {
-  it('issues an INSERT with ON CONFLICT for upsert semantics', async () => {
-    pool.query.mockResolvedValueOnce({rows: []});
+  it('runs the write + denormalized refresh inside a transaction', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({rows: []}) // BEGIN
+      .mockResolvedValueOnce({rows: []}) // SELECT 1 ... FOR UPDATE
+      .mockResolvedValueOnce({rows: []}) // INSERT INTO puzzle_ratings
+      .mockResolvedValueOnce({rows: []}) // refreshPuzzleRatingStats
+      .mockResolvedValueOnce({rows: []}); // COMMIT
+
     await upsertRating('p1', 'user-1', 4);
-    const sql = pool.query.mock.calls[0][0] as string;
-    expect(sql).toContain('INSERT INTO puzzle_ratings');
-    expect(sql).toContain('ON CONFLICT (pid, user_id) DO UPDATE');
-    expect(pool.query.mock.calls[0][1]).toEqual(['p1', 'user-1', 4]);
+
+    const allSql = mockClient.query.mock.calls.map((c: any[]) => c[0] as string);
+    expect(allSql[0]).toBe('BEGIN');
+    expect(allSql.some((s) => s.includes('FOR UPDATE'))).toBe(true);
+    const insertCall = mockClient.query.mock.calls.find((c: any[]) =>
+      (c[0] as string).includes('INSERT INTO puzzle_ratings')
+    );
+    expect(insertCall).toBeDefined();
+    expect(insertCall![0]).toContain('ON CONFLICT (pid, user_id) DO UPDATE');
+    expect(insertCall![1]).toEqual(['p1', 'user-1', 4]);
+    // Stats refresh writes rating_avg/count/weighted back to puzzles.
+    expect(allSql.some((s) => s.includes('UPDATE puzzles') && s.includes('rating_avg'))).toBe(true);
+    expect(allSql[allSql.length - 1]).toBe('COMMIT');
+  });
+
+  it('rolls back and releases the client on error', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({rows: []}) // BEGIN
+      .mockRejectedValueOnce(new Error('lock fail')); // SELECT FOR UPDATE blows up
+    mockClient.query.mockResolvedValueOnce({rows: []}); // ROLLBACK
+
+    await expect(upsertRating('p1', 'user-1', 4)).rejects.toThrow('lock fail');
+
+    const allSql = mockClient.query.mock.calls.map((c: any[]) => c[0] as string);
+    expect(allSql).toContain('ROLLBACK');
+    expect(mockClient.release).toHaveBeenCalled();
   });
 });
 
 describe('deleteRating', () => {
-  it('issues a DELETE keyed on (pid, user_id)', async () => {
-    pool.query.mockResolvedValueOnce({rows: []});
+  it('runs the delete + denormalized refresh inside a transaction', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({rows: []}) // BEGIN
+      .mockResolvedValueOnce({rows: []}) // SELECT 1 ... FOR UPDATE
+      .mockResolvedValueOnce({rows: []}) // DELETE
+      .mockResolvedValueOnce({rows: []}) // refresh
+      .mockResolvedValueOnce({rows: []}); // COMMIT
+
     await deleteRating('p1', 'user-1');
-    const sql = pool.query.mock.calls[0][0] as string;
-    expect(sql).toContain('DELETE FROM puzzle_ratings');
-    expect(pool.query.mock.calls[0][1]).toEqual(['p1', 'user-1']);
+
+    const allSql = mockClient.query.mock.calls.map((c: any[]) => c[0] as string);
+    const deleteCall = mockClient.query.mock.calls.find((c: any[]) =>
+      (c[0] as string).includes('DELETE FROM puzzle_ratings')
+    );
+    expect(deleteCall).toBeDefined();
+    expect(deleteCall![1]).toEqual(['p1', 'user-1']);
+    expect(allSql.some((s) => s.includes('UPDATE puzzles') && s.includes('rating_avg'))).toBe(true);
+    expect(allSql[allSql.length - 1]).toBe('COMMIT');
   });
 });
 

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -186,115 +186,49 @@ export async function listPuzzles(
       : 'is_public = true';
     const userIdParams = userId ? [userId] : [];
 
-    // Bayesian shrinkage so a single 5★ rating doesn't outrank an
-    // established 4.5★ with many ratings. Constants chosen to be gentle:
-    // ~5 phantom votes at the 3.5★ middle keep low-N puzzles from
-    // dominating but don't drown out real signal once a puzzle has 10+
-    // ratings. Tune later if rating_desc results feel off.
-    const ratingPriorWeight = 5;
-    const ratingPriorMean = 3.5;
-
     const rawMinRating = filter.minRating;
     const minRating =
       typeof rawMinRating === 'number' && rawMinRating >= 1 && rawMinRating <= 5 ? rawMinRating : 0;
-    const ratingFilterClause = minRating > 0 ? `AND r.avg IS NOT NULL AND r.avg >= ${minRating}` : '';
+    const ratingFilterClause =
+      minRating > 0 ? `AND rating_avg IS NOT NULL AND rating_avg >= ${minRating}` : '';
 
-    let orderBySpec: string;
+    let orderByClause: string;
     if (filter.sortBy === 'rating_desc') {
-      orderBySpec = `r.weighted DESC NULLS LAST, pid_numeric DESC`;
+      orderByClause = `ORDER BY rating_weighted DESC NULLS LAST, pid_numeric DESC`;
     } else if (filter.sortBy === 'rating_asc') {
-      orderBySpec = `r.weighted ASC NULLS LAST, pid_numeric DESC`;
+      orderByClause = `ORDER BY rating_weighted ASC NULLS LAST, pid_numeric DESC`;
     } else {
-      orderBySpec = `pid_numeric DESC`;
+      orderByClause = `ORDER BY pid_numeric DESC`;
     }
-    const orderByClause = `ORDER BY ${orderBySpec}`;
-    const windowOrderBy = `OVER (ORDER BY ${orderBySpec})`;
 
-    // Stats constants are parameterized for consistency with getPuzzleStats
-    // (and the rest of the codebase). Append them after the existing params
-    // so we don't have to renumber title/day/userId placeholders.
-    const statsTimeCapIndex = userIdParamIndex + (userId ? 1 : 0);
-    const statsMinSamplesIndex = statsTimeCapIndex + 1;
-
-    // Two-stage query so the expensive median LATERAL only runs over the
-    // returned page, not every matched puzzle. The rating aggregate has to
-    // be in the inner stage because filters/sort can reference its outputs;
-    // it's cheap enough (AVG/COUNT over a small puzzle_ratings) that paying
-    // the cost across all matched puzzles is fine. PERCENTILE_CONT is the
-    // one we don't want fanning out — see EXPLAIN notes in the PR.
-    //
-    // puzzle_ratings shares only `pid` with puzzles, so the filter clauses
-    // (content/is_public/uploaded_by/pid_numeric) remain unambiguous after
-    // the LATERAL join in the inner stage.
+    // Rating and solve-time aggregates are denormalized onto puzzles
+    // (maintained transactionally by recordSolve / upsertRating /
+    // deleteRating). Reading them as plain columns is what makes this
+    // query cheap enough to run on every filter change — see
+    // alter_puzzles_add_denorm_stats.sql.
     const {rows} = await pool.query(
       `
-      WITH page AS (
-        SELECT puzzles.pid, uploaded_at, is_public, times_solved,
-          content->'info' AS info,
-          jsonb_array_length(content->'grid') AS grid_rows,
-          jsonb_array_length(content->'grid'->0) AS grid_cols,
-          (content->>'contest')::boolean AS contest,
-          r.avg AS rating_avg,
-          COALESCE(r.count, 0) AS rating_count,
-          -- Tag each row with its sort position so the outer query can
-          -- preserve order after the median LATERAL join. SQL doesn't
-          -- guarantee row order survives subsequent joins.
-          ROW_NUMBER() ${windowOrderBy} AS sort_idx
-        FROM puzzles
-        LEFT JOIN LATERAL (
-          SELECT
-            AVG(rating)::float AS avg,
-            COUNT(*)::int AS count,
-            CASE WHEN COUNT(*) > 0
-                 THEN ((${ratingPriorWeight} * ${ratingPriorMean}) + SUM(rating))::float / (${ratingPriorWeight} + COUNT(*))
-                 ELSE NULL
-            END AS weighted
-          FROM puzzle_ratings
-          WHERE pid = puzzles.pid
-        ) r ON true
-        WHERE ${visibilityClause}
-        ${sizeClause}
-        ${typeClause}
-        ${parameterizedTitleAuthorFilter}
-        ${dayClause}
-        ${ratingFilterClause}
-        ${orderByClause}
-        LIMIT $1
-        OFFSET $2
-      )
-      SELECT page.*,
-        s.median_ms AS median_solve_ms,
-        COALESCE(s.sample_count, 0) AS solve_sample_count
-      FROM page
-      LEFT JOIN LATERAL (
-        -- Mirrors getPuzzleStats: collapse co-op solves to one per gid via
-        -- MAX(time), then median over those when we have a stable sample.
-        SELECT
-          COUNT(*)::int AS sample_count,
-          CASE WHEN COUNT(*) >= $${statsMinSamplesIndex}
-            THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY time_ms)::int
-            ELSE NULL
-          END AS median_ms
-        FROM (
-          SELECT MAX(ps.time_taken_to_solve) AS time_ms
-          FROM puzzle_solves ps
-          WHERE ps.pid = page.pid
-            AND ps.time_taken_to_solve > 0
-            AND ps.time_taken_to_solve < $${statsTimeCapIndex}
-          GROUP BY ps.gid
-        ) game_times
-      ) s ON true
-      ORDER BY page.sort_idx
+      SELECT puzzles.pid, uploaded_at, is_public, times_solved,
+        content->'info' AS info,
+        jsonb_array_length(content->'grid') AS grid_rows,
+        jsonb_array_length(content->'grid'->0) AS grid_cols,
+        (content->>'contest')::boolean AS contest,
+        rating_avg,
+        rating_count,
+        median_solve_ms,
+        solve_sample_count
+      FROM puzzles
+      WHERE ${visibilityClause}
+      ${sizeClause}
+      ${typeClause}
+      ${parameterizedTitleAuthorFilter}
+      ${dayClause}
+      ${ratingFilterClause}
+      ${orderByClause}
+      LIMIT $1
+      OFFSET $2
     `,
-      [
-        limit,
-        offset,
-        ...parametersForTitleAuthorFilter,
-        ...dayParams,
-        ...userIdParams,
-        PUZZLE_STATS_TIME_CAP_MS,
-        PUZZLE_STATS_MIN_SAMPLES,
-      ]
+      [limit, offset, ...parametersForTitleAuthorFilter, ...dayParams, ...userIdParams]
     );
     const puzzles: PuzzleListRow[] = rows.map(
       (row: {
@@ -492,9 +426,17 @@ export async function recordSolve(
     if (insertResult.rowCount === 1 && isFirstSolveForGame) {
       await client.query(`UPDATE puzzles SET times_solved = times_solved + 1 WHERE pid = $1`, [pid]);
     }
+    if (insertResult.rowCount === 1) {
+      // Refresh denormalized solve stats inside the same transaction so the
+      // homepage list query can read median_solve_ms/solve_sample_count as
+      // plain columns instead of running PERCENTILE_CONT per page render.
+      await refreshPuzzleSolveStats(client, pid);
+    }
     await client.query('COMMIT');
     if (insertResult.rowCount === 1) {
       puzzleStatsCache.delete(pid);
+      // Stat columns drive the list; invalidate so the next list render reflects the change.
+      clearPuzzleListCache();
     }
   } catch (e) {
     await client.query('ROLLBACK');
@@ -521,6 +463,12 @@ export const PUZZLE_STATS_TIME_CAP_MS = 2 * 60 * 60 * 1000;
 // difficulty signal.
 export const PUZZLE_STATS_MIN_SAMPLES = 25;
 
+// Bayesian shrinkage prior for the rating sort. ~5 phantom votes at the 3.5★
+// middle keep low-N puzzles from dominating but don't drown out real signal
+// once a puzzle has 10+ ratings.
+export const RATING_PRIOR_WEIGHT = 5;
+export const RATING_PRIOR_MEAN = 3.5;
+
 export type PuzzleStats = {
   sampleCount: number;
   medianMs: number | null;
@@ -528,38 +476,79 @@ export type PuzzleStats = {
 
 export async function getPuzzleStats(pid: string): Promise<PuzzleStats> {
   return puzzleStatsCache.getOrFetch(pid, async () => {
-    // Aggregate to one row per gid first: a co-op game has one puzzle_solves row per
-    // authenticated user, and counting each as a separate sample would weight the
-    // median toward larger teams. MAX(time) per gid picks the longest-present user's
-    // clock — closest to total game duration, since each user's clock starts when
-    // they join. MIN would bias downward toward the latest joiner.
-    // We do not exclude reveal-assisted solves: that would require joining game_events,
-    // whose history is deleted by the archival job once a game is solved. Filtering
-    // there would drift over time as old games get cleaned up. The median is robust
-    // enough to typical reveal usage at this sample threshold; a future revision can
-    // persist a durable per-solve "had_reveals" flag.
+    // Read from denormalized columns on puzzles — maintained by recordSolve.
+    // See alter_puzzles_add_denorm_stats.sql for the aggregation logic and
+    // why we don't filter reveal-assisted solves.
     const {rows} = await pool.query(
-      `WITH game_times AS (
-         SELECT ps.gid, MAX(ps.time_taken_to_solve) AS time_ms
-         FROM puzzle_solves ps
-         WHERE ps.pid = $1
-           AND ps.time_taken_to_solve > 0
-           AND ps.time_taken_to_solve < $2
-         GROUP BY ps.gid
-       )
+      `SELECT median_solve_ms, solve_sample_count FROM puzzles WHERE pid = $1`,
+      [pid]
+    );
+    const row = rows[0] || {median_solve_ms: null, solve_sample_count: 0};
+    return {
+      sampleCount: Number(row.solve_sample_count) || 0,
+      medianMs: row.median_solve_ms != null ? Number(row.median_solve_ms) : null,
+    };
+  });
+}
+
+// Recompute solve_sample_count and median_solve_ms for a pid and write them to
+// the puzzles row. Caller is responsible for transaction + FOR UPDATE lock on
+// the puzzles row. Co-op solves are collapsed to one sample per gid via
+// MAX(time), then PERCENTILE_CONT over those once we have a stable sample.
+// Reveal-assisted solves are intentionally included — see getPuzzleStats.
+type DbClient = {
+  query: (text: string, params?: unknown[]) => Promise<{rows: any[]; rowCount?: number | null}>;
+};
+
+async function refreshPuzzleSolveStats(client: DbClient, pid: string): Promise<void> {
+  await client.query(
+    `WITH game_times AS (
+       SELECT MAX(ps.time_taken_to_solve) AS time_ms
+       FROM puzzle_solves ps
+       WHERE ps.pid = $1
+         AND ps.time_taken_to_solve > 0
+         AND ps.time_taken_to_solve < $2
+       GROUP BY ps.gid
+     ),
+     stats AS (
        SELECT
          COUNT(*)::int AS sample_count,
          CASE WHEN COUNT(*) >= $3
            THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY time_ms)::int
            ELSE NULL
          END AS median_ms
-       FROM game_times`,
-      [pid, PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]
-    );
-    const row = rows[0] || {sample_count: 0, median_ms: null};
-    return {
-      sampleCount: Number(row.sample_count) || 0,
-      medianMs: row.median_ms != null ? Number(row.median_ms) : null,
-    };
-  });
+       FROM game_times
+     )
+     UPDATE puzzles
+     SET solve_sample_count = stats.sample_count,
+         median_solve_ms = stats.median_ms
+     FROM stats
+     WHERE puzzles.pid = $1`,
+    [pid, PUZZLE_STATS_TIME_CAP_MS, PUZZLE_STATS_MIN_SAMPLES]
+  );
+}
+
+// Recompute rating_avg/count/weighted for a pid and write them to the puzzles
+// row. Caller is responsible for transaction + FOR UPDATE lock.
+export async function refreshPuzzleRatingStats(client: DbClient, pid: string): Promise<void> {
+  await client.query(
+    `WITH rating_agg AS (
+       SELECT
+         AVG(rating)::float AS avg,
+         COUNT(*)::int AS count,
+         CASE WHEN COUNT(*) > 0
+           THEN (($2 * $3) + SUM(rating))::float / ($2 + COUNT(*))
+           ELSE NULL
+         END AS weighted
+       FROM puzzle_ratings
+       WHERE pid = $1
+     )
+     UPDATE puzzles
+     SET rating_avg = rating_agg.avg,
+         rating_count = rating_agg.count,
+         rating_weighted = rating_agg.weighted
+     FROM rating_agg
+     WHERE puzzles.pid = $1`,
+    [pid, RATING_PRIOR_WEIGHT, RATING_PRIOR_MEAN]
+  );
 }

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -423,10 +423,10 @@ export async function recordSolve(
        ON CONFLICT DO NOTHING`,
       [pid, gid, solved_time / 1000.0, timeToSolve, userId || null, playerCount || 1]
     );
-    if (insertResult.rowCount === 1 && isFirstSolveForGame) {
-      await client.query(`UPDATE puzzles SET times_solved = times_solved + 1 WHERE pid = $1`, [pid]);
-    }
     if (insertResult.rowCount === 1) {
+      if (isFirstSolveForGame) {
+        await client.query(`UPDATE puzzles SET times_solved = times_solved + 1 WHERE pid = $1`, [pid]);
+      }
       // Refresh denormalized solve stats inside the same transaction so the
       // homepage list query can read median_solve_ms/solve_sample_count as
       // plain columns instead of running PERCENTILE_CONT per page render.

--- a/server/model/puzzle_rating.ts
+++ b/server/model/puzzle_rating.ts
@@ -1,6 +1,7 @@
 import {pool} from './pool';
 import {getDfacIdsForUser} from './user';
 import {computeGamesProgress} from './game_progress';
+import {refreshPuzzleRatingStats, clearPuzzleListCache} from './puzzle';
 
 export const RATING_THRESHOLD_PERCENT = 25;
 
@@ -11,37 +12,65 @@ export type PuzzleRatingAggregate = {
 };
 
 export async function getRatingForPuzzle(pid: string, userId?: string): Promise<PuzzleRatingAggregate> {
-  const aggregateQuery = pool.query(
-    `SELECT AVG(rating)::float AS avg, COUNT(*)::int AS count
-     FROM puzzle_ratings WHERE pid = $1`,
-    [pid]
-  );
+  // Aggregate served by denormalized columns on puzzles, maintained by
+  // upsertRating/deleteRating. Per-user rating still comes from puzzle_ratings.
+  const aggregateQuery = pool.query(`SELECT rating_avg, rating_count FROM puzzles WHERE pid = $1`, [pid]);
   const userRatingQuery = userId
     ? pool.query(`SELECT rating FROM puzzle_ratings WHERE pid = $1 AND user_id = $2`, [pid, userId])
     : Promise.resolve({rows: [] as {rating: number}[]});
 
   const [aggResult, userResult] = await Promise.all([aggregateQuery, userRatingQuery]);
-  const aggRow = aggResult.rows[0] || {avg: null, count: 0};
+  const aggRow = aggResult.rows[0] || {rating_avg: null, rating_count: 0};
 
   return {
-    average: aggRow.avg !== null ? Number(aggRow.avg) : null,
-    count: Number(aggRow.count) || 0,
+    average: aggRow.rating_avg !== null ? Number(aggRow.rating_avg) : null,
+    count: Number(aggRow.rating_count) || 0,
     userRating: userResult.rows[0]?.rating ?? null,
   };
 }
 
+// Concurrent rating writes for the same puzzle must serialize so the
+// recomputed aggregate matches the final puzzle_ratings state. We do that
+// with FOR UPDATE on the puzzles row inside a transaction, the same pattern
+// recordSolve uses.
+async function withRatingTxn(pid: string, work: (client: DbClient) => Promise<void>): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`SELECT 1 FROM puzzles WHERE pid = $1 FOR UPDATE`, [pid]);
+    await work(client);
+    await refreshPuzzleRatingStats(client, pid);
+    await client.query('COMMIT');
+    // The list cache holds rating_avg/count/weighted from before the change.
+    clearPuzzleListCache();
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
+type DbClient = {
+  query: (text: string, params?: unknown[]) => Promise<{rows: any[]; rowCount?: number | null}>;
+};
+
 export async function upsertRating(pid: string, userId: string, rating: number): Promise<void> {
-  await pool.query(
-    `INSERT INTO puzzle_ratings (pid, user_id, rating)
-     VALUES ($1, $2, $3)
-     ON CONFLICT (pid, user_id) DO UPDATE
-       SET rating = EXCLUDED.rating, updated_at = NOW()`,
-    [pid, userId, rating]
-  );
+  await withRatingTxn(pid, async (client) => {
+    await client.query(
+      `INSERT INTO puzzle_ratings (pid, user_id, rating)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (pid, user_id) DO UPDATE
+         SET rating = EXCLUDED.rating, updated_at = NOW()`,
+      [pid, userId, rating]
+    );
+  });
 }
 
 export async function deleteRating(pid: string, userId: string): Promise<void> {
-  await pool.query(`DELETE FROM puzzle_ratings WHERE pid = $1 AND user_id = $2`, [pid, userId]);
+  await withRatingTxn(pid, async (client) => {
+    await client.query(`DELETE FROM puzzle_ratings WHERE pid = $1 AND user_id = $2`, [pid, userId]);
+  });
 }
 
 /**

--- a/server/sql/alter_puzzles_add_denorm_stats.sql
+++ b/server/sql/alter_puzzles_add_denorm_stats.sql
@@ -1,0 +1,70 @@
+-- Denormalize solve-time and rating aggregates onto puzzles so the homepage
+-- list query can read them as plain columns instead of running PERCENTILE_CONT
+-- + AVG/COUNT subqueries per page. Maintenance happens transactionally inside
+-- recordSolve / upsertRating / deleteRating.
+--
+-- Run on existing databases BEFORE deploying the code that reads from these
+-- columns. The new code also writes to them, so the order must be:
+--   1) run this migration (additive; old code ignores new columns)
+--   2) deploy code that reads and writes the new columns
+--
+-- Constants kept in sync with server/model/puzzle.ts:
+--   PUZZLE_STATS_TIME_CAP_MS = 7200000  (2 hours)
+--   PUZZLE_STATS_MIN_SAMPLES = 25
+-- and server/model/puzzle.ts rating prior:
+--   ratingPriorWeight = 5
+--   ratingPriorMean   = 3.5
+
+ALTER TABLE puzzles ADD COLUMN IF NOT EXISTS median_solve_ms integer;
+ALTER TABLE puzzles ADD COLUMN IF NOT EXISTS solve_sample_count integer NOT NULL DEFAULT 0;
+ALTER TABLE puzzles ADD COLUMN IF NOT EXISTS rating_avg double precision;
+ALTER TABLE puzzles ADD COLUMN IF NOT EXISTS rating_count integer NOT NULL DEFAULT 0;
+ALTER TABLE puzzles ADD COLUMN IF NOT EXISTS rating_weighted double precision;
+
+-- Sort by rating_weighted hits this often enough to want an index. Partial
+-- index skips rows with no ratings — they sort NULLS LAST anyway.
+CREATE INDEX IF NOT EXISTS puzzles_rating_weighted_idx
+  ON puzzles (rating_weighted DESC NULLS LAST)
+  WHERE rating_weighted IS NOT NULL;
+
+-- ----- Backfill solve stats -----
+-- Mirrors getPuzzleStats: collapse co-op solves to one per gid via MAX(time),
+-- then PERCENTILE_CONT over those once the per-pid sample count is stable.
+WITH game_times AS (
+  SELECT ps.pid, ps.gid, MAX(ps.time_taken_to_solve) AS time_ms
+  FROM puzzle_solves ps
+  WHERE ps.time_taken_to_solve > 0
+    AND ps.time_taken_to_solve < 7200000
+  GROUP BY ps.pid, ps.gid
+),
+solve_stats AS (
+  SELECT pid,
+    COUNT(*)::int AS sample_count,
+    CASE WHEN COUNT(*) >= 25
+      THEN PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY time_ms)::int
+      ELSE NULL
+    END AS median_ms
+  FROM game_times
+  GROUP BY pid
+)
+UPDATE puzzles p
+SET solve_sample_count = solve_stats.sample_count,
+    median_solve_ms = solve_stats.median_ms
+FROM solve_stats
+WHERE p.pid = solve_stats.pid;
+
+-- ----- Backfill rating stats -----
+WITH rating_agg AS (
+  SELECT pid,
+    AVG(rating)::float AS avg,
+    COUNT(*)::int AS count,
+    ((5 * 3.5) + SUM(rating))::float / (5 + COUNT(*)) AS weighted
+  FROM puzzle_ratings
+  GROUP BY pid
+)
+UPDATE puzzles p
+SET rating_avg = rating_agg.avg,
+    rating_count = rating_agg.count,
+    rating_weighted = rating_agg.weighted
+FROM rating_agg
+WHERE p.pid = rating_agg.pid;

--- a/server/sql/create_puzzles.sql
+++ b/server/sql/create_puzzles.sql
@@ -22,7 +22,19 @@ IF NOT EXISTS puzzles
   uploaded_by UUID REFERENCES users(id),
 
   -- SHA-256 hash for duplicate detection
-  content_hash text
+  content_hash text,
+
+  -- denormalized solve-time stats, maintained transactionally in recordSolve.
+  -- median_solve_ms is NULL until solve_sample_count reaches the min-samples
+  -- threshold (see PUZZLE_STATS_MIN_SAMPLES in model/puzzle.ts).
+  median_solve_ms integer,
+  solve_sample_count integer NOT NULL DEFAULT 0 CHECK (solve_sample_count >= 0),
+
+  -- denormalized rating stats, maintained transactionally in upsert/deleteRating.
+  -- rating_weighted is the Bayesian-shrunk score used for rating_desc sort.
+  rating_avg double precision,
+  rating_count integer NOT NULL DEFAULT 0 CHECK (rating_count >= 0),
+  rating_weighted double precision
 );
 
 ALTER TABLE public.puzzles


### PR DESCRIPTION
## Summary

Replaces the per-page LATERAL aggregates (PR #508) that were making the homepage slow to load and filter. Solve-time and rating stats are now denormalized columns on `puzzles`, maintained transactionally on the write path, and read as plain columns by `listPuzzles` / `getPuzzleStats` / `getRatingForPuzzle`.

## Schema

New columns on `puzzles`: `median_solve_ms`, `solve_sample_count`, `rating_avg`, `rating_count`, `rating_weighted` (Bayesian-shrunk for sort). Partial index on `rating_weighted DESC NULLS LAST` for the `rating_desc` sort. See `server/sql/create_puzzles.sql` for fresh DBs and `server/sql/alter_puzzles_add_denorm_stats.sql` for prod (additive ALTERs + backfill).

## Write paths

- `recordSolve` calls a new `refreshPuzzleSolveStats` inside the existing FOR-UPDATE-locked transaction, then invalidates the list cache.
- `upsertRating` / `deleteRating` now go through `withRatingTxn` (BEGIN → SELECT FOR UPDATE → write → `refreshPuzzleRatingStats` → COMMIT) so concurrent rating writes for the same puzzle serialize and the recomputed aggregate matches the final `puzzle_ratings` state.

## Read paths

- `listPuzzles` selects the columns directly — no joins, no `PERCENTILE_CONT` per page. Filter/sort by rating use the column.
- `getPuzzleStats` is now a single-row column read (5-minute cache unchanged).
- `getRatingForPuzzle` aggregate reads from `puzzles`; per-user rating still comes from `puzzle_ratings`.

UI from #508 is untouched — the field names the frontend expects (`medianSolveMs`, `solveSampleCount`, `ratingAverage`, `ratingCount`) are populated from the new columns.

## Deploy order

1. Run `server/sql/alter_puzzles_add_denorm_stats.sql` on prod (additive + backfill — old code ignores the new columns).
2. Merge + deploy this branch.
3. Unpin prod from the pre-#508 rollback.

## Test plan

- [x] `pnpm test:server --ci` (242 pass)
- [x] `pnpm test` (385 pass)
- [x] `pnpm tsc --noEmit` + `pnpm tsc --noEmit -p server/tsconfig.json`
- [x] `pnpm eslint --max-warnings 0 src/ server/`
- [x] `pnpm stylelint`
- [x] `pnpm build`
- [ ] On a staging DB: run the alter migration, verify the backfill populates expected pids, then deploy and confirm the homepage list query no longer shows `PERCENTILE_CONT` in `EXPLAIN`.
- [ ] On staging: solve a puzzle and a rating round-trip, verify the corresponding row's `median_solve_ms` / `solve_sample_count` / `rating_*` columns update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)