### PR TITLE
Cast rating-prior params in refreshPuzzleRatingStats

### DIFF
--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -531,13 +531,16 @@ async function refreshPuzzleSolveStats(client: DbClient, pid: string): Promise<v
 // Recompute rating_avg/count/weighted for a pid and write them to the puzzles
 // row. Caller is responsible for transaction + FOR UPDATE lock.
 export async function refreshPuzzleRatingStats(client: DbClient, pid: string): Promise<void> {
+  // Casts on the parameters: Postgres can't resolve `$2 * $3` when both
+  // sides arrive as untyped parameters ("operator is not unique: unknown *
+  // unknown"). Forcing float8 picks the unambiguous numeric multiply.
   await client.query(
     `WITH rating_agg AS (
        SELECT
          AVG(rating)::float AS avg,
          COUNT(*)::int AS count,
          CASE WHEN COUNT(*) > 0
-           THEN (($2 * $3) + SUM(rating))::float / ($2 + COUNT(*))
+           THEN (($2::float * $3::float) + SUM(rating))::float / ($2::float + COUNT(*))
            ELSE NULL
          END AS weighted
        FROM puzzle_ratings


### PR DESCRIPTION
## Summary

Hotfix for #510. Prod Sentry caught:

```
operator is not unique: unknown * unknown
  in refreshPuzzleRatingStats
```

In `refreshPuzzleRatingStats`, the Bayesian prior was parameterized as `$2 * $3`. Postgres can't resolve the multiply operator when both sides arrive as untyped parameters, so the transaction errored and rolled back. The 500 was caught by `RatingCompletionModal.handleSubmit`'s `catch` (which only logs to Sentry), so `setOpen(false)` never fired and the rating modal stayed open after submission.

## Fix

Force `float8` on the two parameters with `::float` casts so Postgres picks the unambiguous numeric multiply. One-line behavior change; no schema or interface change.

## Why tests didn't catch this

The Jest pool mock returns canned rows without parsing SQL, so Postgres's operator resolution never runs in unit tests. An integration test against a real Postgres would catch the whole class of bug; tracked separately rather than added here so this stays minimal.

## Test plan

- [x] `pnpm test:server --ci --testPathPatterns=puzzle` (74 pass)
- [x] `pnpm tsc --noEmit -p server/tsconfig.json`
- [ ] On prod after deploy: submit a 5★ rating at end of a puzzle, confirm modal closes and `puzzles.rating_avg/count/weighted` update for that pid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)