### PR TITLE
Find archived solved games in getUserGamesForPuzzle

### DIFF
--- a/server/__tests__/model/user_games.test.ts
+++ b/server/__tests__/model/user_games.test.ts
@@ -127,6 +127,32 @@ describe('getUserGamesForPuzzle', () => {
     expect(queryArgs[0]).toEqual(['same-dfac']);
   });
 
+  it('unions puzzle_solves into the participation lookup for authed users', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{dfac_id: 'dfac-abc'}]});
+    pool.query.mockResolvedValueOnce({rows: []});
+
+    await getUserGamesForPuzzle('123', {userId: 'user-1'});
+
+    // Authed lookup must look for puzzle_solves rows owned by the user,
+    // otherwise the user's own solved games become invisible after the
+    // game_events archival job runs (the create event has no uid/params.id
+    // tying it to the user).
+    const mainQuery = pool.query.mock.calls[1][0] as string;
+    expect(mainQuery).toContain('FROM puzzle_solves WHERE user_id = $3');
+  });
+
+  it('does not consult puzzle_solves for guest queries', async () => {
+    pool.query.mockResolvedValueOnce({rows: []});
+
+    await getUserGamesForPuzzle('456', {dfacId: 'guest-dfac-123'});
+
+    // Guests have no user_id, so the puzzle_solves UNION branch is omitted.
+    // (A guest equivalent would need a different identity bridge — see
+    // server/model/user_games.ts comment.)
+    const mainQuery = pool.query.mock.calls[0][0] as string;
+    expect(mainQuery).not.toContain('FROM puzzle_solves');
+  });
+
   it('handles null last_activity', async () => {
     pool.query.mockResolvedValueOnce({
       rows: [{gid: 'game-1', pid: '123', solved: false, last_activity: null, v2: true}],

--- a/server/__tests__/model/user_games.test.ts
+++ b/server/__tests__/model/user_games.test.ts
@@ -138,7 +138,9 @@ describe('getUserGamesForPuzzle', () => {
     // game_events archival job runs (the create event has no uid/params.id
     // tying it to the user).
     const mainQuery = pool.query.mock.calls[1][0] as string;
-    expect(mainQuery).toContain('FROM puzzle_solves WHERE user_id = $3');
+    // Filter on pid in the inner branch so power users with many solves
+    // (Mala has 2k+) don't materialize every solve before the outer filter.
+    expect(mainQuery).toContain('FROM puzzle_solves WHERE user_id = $3 AND pid = $2');
   });
 
   it('does not consult puzzle_solves for guest queries', async () => {

--- a/server/model/user_games.ts
+++ b/server/model/user_games.ts
@@ -180,12 +180,25 @@ export async function getUserGamesForPuzzle(
     const pidIntParam = options.userId ? '$4' : '$3';
     const result = await pool.query(
       `WITH user_games AS (
-         -- v2 games from game_events
+         -- v2 games from game_events. The inner UNION ALL also pulls in
+         -- gids from puzzle_solves for authenticated users so we still find
+         -- solved games after the archival job has deleted their
+         -- updateCell/check/reveal events. The create event's uid and
+         -- params.id don't carry a player identity, so without the
+         -- puzzle_solves branch the user's own solved game becomes
+         -- "unfindable" post-archival and Play.js autocreates a fresh
+         -- empty game on revisit (Maladroit's "puzzle revisits with empty
+         -- grid" report).
          SELECT gid, MAX(ts) AS last_activity, true AS v2, false AS fh_solved
          FROM (
            SELECT gid, ts FROM game_events WHERE uid = ANY($1)
            UNION ALL
            SELECT gid, ts FROM game_events WHERE (event_payload->'params'->>'id') = ANY($1)
+           ${
+             options.userId
+               ? 'UNION ALL SELECT gid, solved_time AS ts FROM puzzle_solves WHERE user_id = $3'
+               : ''
+           }
          ) all_events
          ${options.userId ? 'WHERE NOT EXISTS (SELECT 1 FROM game_dismissals gd WHERE gd.gid = all_events.gid AND gd.user_id = $3)' : ''}
          GROUP BY gid

--- a/server/model/user_games.ts
+++ b/server/model/user_games.ts
@@ -196,7 +196,7 @@ export async function getUserGamesForPuzzle(
            SELECT gid, ts FROM game_events WHERE (event_payload->'params'->>'id') = ANY($1)
            ${
              options.userId
-               ? 'UNION ALL SELECT gid, solved_time AS ts FROM puzzle_solves WHERE user_id = $3'
+               ? 'UNION ALL SELECT gid, solved_time AS ts FROM puzzle_solves WHERE user_id = $3 AND pid = $2'
                : ''
            }
          ) all_events


### PR DESCRIPTION
## Summary

Fixes Maladroit's long-standing "solved puzzle revisits with empty grid" report. After the archival job runs, the user's own solved games become invisible to \`getUserGamesForPuzzle\`, so \`Play.js\` autocreates a fresh empty game and redirects to a new gid. The blue completed checkmark stays correct (puzzle_solves intact), but the user lands on a brand-new empty game.

## Root cause

\`server/jobs/archive_game_events.ts\` Category 1 deletes a solved game's \`updateCell\`/\`check\`/\`reveal\` events and keeps only the \`create\` event. The create event's \`uid\` is empty and \`event_payload.params.id\` is unset, so the dfac_id lookup in \`getUserGamesForPuzzle\`'s CTE no longer matches anything for that game. The query returns 0 rows for that pid, \`Play.js:136-141\` interprets that as "no existing games" and calls \`create()\`, which mints a new gid.

Timing matches Mala's "~12 hours then it goes empty" observation — that's the daily archival cadence.

## Fix

Add a third branch to the participation CTE in \`server/model/user_games.ts\`:

\`\`\`sql
UNION ALL SELECT gid, solved_time AS ts FROM puzzle_solves WHERE user_id = $3
\`\`\`

(Only added when \`options.userId\` is set — guests have no user_id on puzzle_solves.) After this, the user's solved games stay findable post-archival without needing to preserve their events.

## Verified

Reproduced locally end-to-end (seed solve → seed event → simulate archival → call \`getUserGamesForPuzzle\`):
- Before fix: pre-archival 1 game, **post-archival 0 games** (this is the bug).
- After fix: 1 game in both states.

Also traced the full server→client pipeline (getGameEvents, JSON wire, castNullsToUndefined, create reducer) to confirm the saved snapshot grid does round-trip correctly. The data was never the problem; the user was just never landing on the right gid.

## Tests

- New: \`getUserGamesForPuzzle unions puzzle_solves into the participation lookup for authed users\`
- New: \`getUserGamesForPuzzle does not consult puzzle_solves for guest queries\`
- \`pnpm test:server --ci\` — 244 pass
- \`pnpm tsc --noEmit\` + server typecheck clean
- \`pnpm eslint --max-warnings 0\` clean

## Known gap

Guest users (no \`user_id\` on \`puzzle_solves\`) are still affected. They have a smaller blast radius and would need a different identity bridge — separate issue.

## Test plan

- [x] Server tests
- [x] Type/lint
- [ ] After deploy: ask Mala to revisit pid 100007961 and confirm the grid renders with the saved letters instead of empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)