### PR TITLE
Add owner-kick and game-lock moderation

### DIFF
--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -75,9 +75,15 @@ class SocketManager {
             return;
           }
           if (await isGameLocked(gid)) {
+            // Owner bypass only trusts the authenticated identity: the dfac
+            // id from the socket handshake is client-supplied and the owner's
+            // dfac id is visible to every player via the create event and
+            // /moderation.owner. Trusting it here would let any client spoof
+            // ownership and walk past the lock. lock/unlock require auth, so
+            // every lockable game has an authenticated owner — the linked
+            // dfac ids from the token are sufficient.
             const owner = await getGameOwner(gid);
             const dfacIds = identity.userId ? await getDfacIdsForUser(identity.userId) : [];
-            if (identity.dfacId && !dfacIds.includes(identity.dfacId)) dfacIds.push(identity.dfacId);
             if (!isOwner(owner, {userId: identity.userId, dfacIds})) {
               if (typeof ack === 'function') ack({error: 'locked'});
               return;

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -138,6 +138,16 @@ class SocketManager {
             if (typeof ack === 'function') ack({error: 'invalid gid'});
             return;
           }
+          // Require room membership so banned/locked clients can't read
+          // game history by calling this directly after a rejected
+          // join_game. join_game is what places the socket in the room
+          // (and is what enforces ban/lock), so this gate inherits the
+          // same checks for free. Mirrors the room-membership gate on
+          // game_event writes.
+          if (!socket.rooms.has(`game-${gid}`)) {
+            if (typeof ack === 'function') ack({error: 'not in game'});
+            return;
+          }
           const events = await getGameEvents(gid);
           if (typeof ack === 'function') ack(events);
         } catch (err) {

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -8,11 +8,10 @@ import {addRoomEvent, getRoomEvents} from './model/room';
 import {verifyAccessToken} from './auth/jwt';
 import {
   getGameOwner,
-  getLockedAt,
   isGameLocked,
   isIdentityBanned,
   isOwner,
-  wasParticipantBeforeLock,
+  wasParticipantOfGame,
 } from './model/game_moderation';
 import {getDfacIdsForUser} from './model/user';
 
@@ -93,15 +92,13 @@ class SocketManager {
             const dfacIds = identity.userId ? await getDfacIdsForUser(identity.userId) : [];
             const isCallerOwner = isOwner(owner, {userId: identity.userId, dfacIds});
             if (!isCallerOwner) {
-              // Pre-lock participants get through too — the lock contract is
+              // Prior participants get through too — the lock contract is
               // "block new joins, existing players keep playing". Without
               // this, a transient socket reconnect would re-issue join_game
               // and the client treats the {error: 'locked'} as terminal,
-              // effectively ejecting everyone on flaky networks.
-              const lockedAt = await getLockedAt(gid);
-              const wasParticipant = lockedAt
-                ? await wasParticipantBeforeLock(gid, identity, lockedAt)
-                : false;
+              // effectively ejecting everyone on flaky networks (and any
+              // page refresh).
+              const wasParticipant = await wasParticipantOfGame(gid, identity);
               if (!wasParticipant) {
                 if (typeof ack === 'function') ack({error: 'locked'});
                 return;

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -68,20 +68,17 @@ class SocketManager {
             if (typeof ack === 'function') ack({error: 'invalid gid'});
             return;
           }
-          // Require an identity (dfac_id from the handshake or a verified
-          // user id from the bearer). Without this, isIdentityBanned returns
-          // false vacuously for sockets that omit both, so a kicked guest
-          // could simply clear localStorage and reconnect to bypass the ban.
-          // Every real client sends a dfac_id (getLocalId always generates
-          // one), so this only closes the exploit path.
-          if (!socket.data.dfacId && !socket.data.authUser?.userId) {
-            if (typeof ack === 'function') ack({error: 'no identity'});
-            return;
-          }
           // Moderation gates: identity-based ban first, then lock (with an
           // owner bypass so the owner can always rejoin even on a locked
           // game). Both reads are cached per-gid; misses are still fast PK
           // lookups.
+          // We intentionally don't require an identity on the handshake:
+          // dfacId-in-handshake shipped in this PR, so stale tabs from
+          // before would be locked out of every game otherwise. Bans for
+          // unauthed guests are best-effort regardless — a guest can clear
+          // localStorage and reappear under a fresh dfacId either way.
+          // For authed targets we additionally ban the linked user_id in
+          // /kick, which is the layer that's actually robust.
           const identity = {
             userId: socket.data.authUser?.userId,
             dfacId: socket.data.dfacId,

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -147,6 +147,16 @@ class SocketManager {
             if (typeof ack === 'function') ack({error: 'banned'});
             return;
           }
+          // For everything other than the bootstrapping create event,
+          // require that the socket actually joined the room. Join is
+          // gated by isGameLocked + isIdentityBanned in join_game above,
+          // so this is what makes lock cover writes too: a new client
+          // that never joined can't smuggle in updateCell/chat directly.
+          // Existing players who joined before the lock keep their seat.
+          if (event.type !== 'create' && !socket.rooms.has(`game-${message.gid}`)) {
+            if (typeof ack === 'function') ack({error: 'not in game'});
+            return;
+          }
           // Reject persisted, non-create events for gids that don't have a
           // create event or snapshot — prevents orphan rows from accumulating
           // for legacy gids whose game was never bootstrapped server-side

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -6,6 +6,8 @@ import {Server} from 'socket.io';
 import {addGameEvent, gameExists, GameEvent, getGameEvents} from './model/game';
 import {addRoomEvent, getRoomEvents} from './model/room';
 import {verifyAccessToken} from './auth/jwt';
+import {getGameOwner, isGameLocked, isIdentityBanned, isOwner} from './model/game_moderation';
+import {getDfacIdsForUser} from './model/user';
 
 // Event types that are broadcast to connected clients but NOT persisted to the database.
 // updateCursor and addPing are high-frequency and only meaningful in real-time.
@@ -34,7 +36,9 @@ class SocketManager {
   }
 
   listen() {
-    // Auth middleware: verify JWT on connection if provided (guests still allowed)
+    // Auth middleware: verify JWT on connection if provided (guests still
+    // allowed). Also captures the client's dfac_id from the handshake so we
+    // can ban/lock-check both identities later.
     this.io.use((socket, next) => {
       const token = socket.handshake.auth?.token;
       if (token) {
@@ -42,6 +46,10 @@ class SocketManager {
         if (payload) {
           socket.data.authUser = payload;
         }
+      }
+      const dfacId = socket.handshake.auth?.dfacId;
+      if (typeof dfacId === 'string' && dfacId) {
+        socket.data.dfacId = dfacId;
       }
       next();
     });
@@ -53,6 +61,27 @@ class SocketManager {
           if (typeof gid !== 'string' || !gid) {
             if (typeof ack === 'function') ack({error: 'invalid gid'});
             return;
+          }
+          // Moderation gates: identity-based ban first, then lock (with an
+          // owner bypass so the owner can always rejoin even on a locked
+          // game). Both reads are cached per-gid; misses are still fast PK
+          // lookups.
+          const identity = {
+            userId: socket.data.authUser?.userId,
+            dfacId: socket.data.dfacId,
+          };
+          if (await isIdentityBanned(gid, identity)) {
+            if (typeof ack === 'function') ack({error: 'banned'});
+            return;
+          }
+          if (await isGameLocked(gid)) {
+            const owner = await getGameOwner(gid);
+            const dfacIds = identity.userId ? await getDfacIdsForUser(identity.userId) : [];
+            if (identity.dfacId && !dfacIds.includes(identity.dfacId)) dfacIds.push(identity.dfacId);
+            if (!isOwner(owner, {userId: identity.userId, dfacIds})) {
+              if (typeof ack === 'function') ack({error: 'locked'});
+              return;
+            }
           }
           socket.join(`game-${gid}`);
           if (typeof ack === 'function') ack();
@@ -104,6 +133,18 @@ class SocketManager {
           if (typeof message.gid !== 'string' || !message.gid) {
             console.error('Invalid game_event: missing or invalid gid');
             if (typeof ack === 'function') ack({error: 'invalid gid'});
+            return;
+          }
+          // Banned identities can't send events of any kind. Includes
+          // ephemeral cursor/ping — a kicked user shouldn't keep showing up
+          // in the live presence view.
+          if (
+            await isIdentityBanned(message.gid, {
+              userId: socket.data.authUser?.userId,
+              dfacId: socket.data.dfacId,
+            })
+          ) {
+            if (typeof ack === 'function') ack({error: 'banned'});
             return;
           }
           // Reject persisted, non-create events for gids that don't have a

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -68,6 +68,16 @@ class SocketManager {
             if (typeof ack === 'function') ack({error: 'invalid gid'});
             return;
           }
+          // Require an identity (dfac_id from the handshake or a verified
+          // user id from the bearer). Without this, isIdentityBanned returns
+          // false vacuously for sockets that omit both, so a kicked guest
+          // could simply clear localStorage and reconnect to bypass the ban.
+          // Every real client sends a dfac_id (getLocalId always generates
+          // one), so this only closes the exploit path.
+          if (!socket.data.dfacId && !socket.data.authUser?.userId) {
+            if (typeof ack === 'function') ack({error: 'no identity'});
+            return;
+          }
           // Moderation gates: identity-based ban first, then lock (with an
           // owner bypass so the owner can always rejoin even on a locked
           // game). Both reads are cached per-gid; misses are still fast PK

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -177,6 +177,16 @@ class SocketManager {
             if (typeof ack === 'function') ack({error: 'invalid gid'});
             return;
           }
+          // create events are HTTP-only. Allowing them over the socket lets
+          // any authed player emit a backdated create with their own
+          // params.creator, which getGameOwner (ORDER BY ts ASC LIMIT 1)
+          // would then return — turning every moderation endpoint into a
+          // privilege-escalation path. Real bootstrapping happens in
+          // /api/game POST → addInitialGameEvent with server-stamped ts.
+          if (event.type === 'create') {
+            if (typeof ack === 'function') ack({error: 'create not allowed over socket'});
+            return;
+          }
           // Banned identities can't send events of any kind. Includes
           // ephemeral cursor/ping — a kicked user shouldn't keep showing up
           // in the live presence view.
@@ -189,23 +199,22 @@ class SocketManager {
             if (typeof ack === 'function') ack({error: 'banned'});
             return;
           }
-          // For everything other than the bootstrapping create event,
-          // require that the socket actually joined the room. Join is
-          // gated by isGameLocked + isIdentityBanned in join_game above,
-          // so this is what makes lock cover writes too: a new client
-          // that never joined can't smuggle in updateCell/chat directly.
-          // Existing players who joined before the lock keep their seat.
-          if (event.type !== 'create' && !socket.rooms.has(`game-${message.gid}`)) {
+          // Require that the socket actually joined the room. Join is gated
+          // by isGameLocked + isIdentityBanned in join_game above, so this
+          // is what makes lock cover writes too: a new client that never
+          // joined can't smuggle in updateCell/chat directly. Existing
+          // players who joined before the lock keep their seat.
+          if (!socket.rooms.has(`game-${message.gid}`)) {
             if (typeof ack === 'function') ack({error: 'not in game'});
             return;
           }
-          // Reject persisted, non-create events for gids that don't have a
-          // create event or snapshot — prevents orphan rows from accumulating
-          // for legacy gids whose game was never bootstrapped server-side
-          // (#478). Ephemeral events (cursor, ping) bypass since they aren't
+          // Reject persisted events for gids that don't have a create event
+          // or snapshot — prevents orphan rows from accumulating for legacy
+          // gids whose game was never bootstrapped server-side (#478).
+          // Ephemeral events (cursor, ping) bypass since they aren't
           // persisted. Cache positive results per socket to avoid repeated
           // DB lookups.
-          if (event.type !== 'create' && !EPHEMERAL_EVENT_TYPES.has(event.type)) {
+          if (!EPHEMERAL_EVENT_TYPES.has(event.type)) {
             const verified: Set<string> = (socket.data.verifiedGids ||= new Set());
             if (!verified.has(message.gid)) {
               if (await gameExists(message.gid)) {
@@ -228,12 +237,6 @@ class SocketManager {
             delete event.verifiedUserId;
           }
           await this.addGameEvent(message.gid, event);
-          // A successful create persists the bootstrap row, so future events
-          // from this socket can skip the gameExists lookup.
-          if (event.type === 'create') {
-            const verified: Set<string> = (socket.data.verifiedGids ||= new Set());
-            verified.add(message.gid);
-          }
           if (typeof ack === 'function') ack();
         } catch (err) {
           console.error(`[Socket] game_event error:`, err);

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -144,12 +144,24 @@ class SocketManager {
           }
           // Require room membership so banned/locked clients can't read
           // game history by calling this directly after a rejected
-          // join_game. join_game is what places the socket in the room
-          // (and is what enforces ban/lock), so this gate inherits the
-          // same checks for free. Mirrors the room-membership gate on
-          // game_event writes.
+          // join_game.
           if (!socket.rooms.has(`game-${gid}`)) {
             if (typeof ack === 'function') ack({error: 'not in game'});
+            return;
+          }
+          // Re-check ban on every read: room membership alone isn't enough
+          // because kicks happen after join_game (the socket is already in
+          // the room) and a malicious/modified client can ignore the
+          // 'kicked' broadcast and keep calling this to read history.
+          // The /kick handler also evicts the socket from the room
+          // server-side, but this gate is the durable one.
+          if (
+            await isIdentityBanned(gid, {
+              userId: socket.data.authUser?.userId,
+              dfacId: socket.data.dfacId,
+            })
+          ) {
+            if (typeof ack === 'function') ack({error: 'banned'});
             return;
           }
           const events = await getGameEvents(gid);

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -6,7 +6,14 @@ import {Server} from 'socket.io';
 import {addGameEvent, gameExists, GameEvent, getGameEvents} from './model/game';
 import {addRoomEvent, getRoomEvents} from './model/room';
 import {verifyAccessToken} from './auth/jwt';
-import {getGameOwner, isGameLocked, isIdentityBanned, isOwner} from './model/game_moderation';
+import {
+  getGameOwner,
+  getLockedAt,
+  isGameLocked,
+  isIdentityBanned,
+  isOwner,
+  wasParticipantBeforeLock,
+} from './model/game_moderation';
 import {getDfacIdsForUser} from './model/user';
 
 // Event types that are broadcast to connected clients but NOT persisted to the database.
@@ -84,9 +91,21 @@ class SocketManager {
             // dfac ids from the token are sufficient.
             const owner = await getGameOwner(gid);
             const dfacIds = identity.userId ? await getDfacIdsForUser(identity.userId) : [];
-            if (!isOwner(owner, {userId: identity.userId, dfacIds})) {
-              if (typeof ack === 'function') ack({error: 'locked'});
-              return;
+            const isCallerOwner = isOwner(owner, {userId: identity.userId, dfacIds});
+            if (!isCallerOwner) {
+              // Pre-lock participants get through too — the lock contract is
+              // "block new joins, existing players keep playing". Without
+              // this, a transient socket reconnect would re-issue join_game
+              // and the client treats the {error: 'locked'} as terminal,
+              // effectively ejecting everyone on flaky networks.
+              const lockedAt = await getLockedAt(gid);
+              const wasParticipant = lockedAt
+                ? await wasParticipantBeforeLock(gid, identity, lockedAt)
+                : false;
+              if (!wasParticipant) {
+                if (typeof ack === 'function') ack({error: 'locked'});
+                return;
+              }
             }
           }
           socket.join(`game-${gid}`);

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -411,6 +411,21 @@ describe('SocketManager', () => {
       expect(pool.query).not.toHaveBeenCalled();
     });
 
+    it('rejects history sync from sockets that never joined the room', async () => {
+      const {io, socketHandlers} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+      // Without the room-membership gate, a client rejected by join_game
+      // (banned/locked) could still call this directly and read game/chat
+      // history. Use a gid that isn't in the pre-populated room set.
+
+      const ack = jest.fn();
+      await socketHandlers['sync_all_game_events']('unjoined-gid', ack);
+
+      expect(ack).toHaveBeenCalledWith({error: 'not in game'});
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
     it('catches DB errors and reports to Sentry', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const dbError = new Error('query timeout');

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -457,22 +457,6 @@ describe('SocketManager', () => {
       expect(ack).toHaveBeenCalledWith({error: 'invalid gid'});
     });
 
-    it('rejects join_game when the socket has neither dfacId nor authUser', async () => {
-      // Without this gate, a kicked guest could simply omit dfacId from the
-      // handshake and isIdentityBanned would return false vacuously, letting
-      // them re-enter the room.
-      const {io, socketHandlers, mockSocket} = createMockIo();
-      mockSocket.data = {};
-      const sm = new SocketManager(io);
-      sm.listen();
-
-      const ack = jest.fn();
-      await socketHandlers['join_game']('g1', ack);
-
-      expect(ack).toHaveBeenCalledWith({error: 'no identity'});
-      expect(pool.query).not.toHaveBeenCalled();
-    });
-
     it('rejects invalid gid for leave_game', async () => {
       const {io, socketHandlers} = createMockIo();
       const sm = new SocketManager(io);

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -319,29 +319,30 @@ describe('SocketManager', () => {
       expect(pool.query).toHaveBeenCalledTimes(1);
     });
 
-    it('primes the gameExists cache after a successful create event', async () => {
+    it('rejects create events over the socket (HTTP-only bootstrap)', async () => {
+      // Allowing socket-side creates lets any authed player emit a backdated
+      // create with their own params.creator. getGameOwner reads earliest by
+      // ts → the impostor's row → privilege escalation through /kick, /lock,
+      // /unlock. Real bootstrap happens via /api/game POST.
       const {io, socketHandlers} = createMockIo();
       const sm = new SocketManager(io);
       sm.listen();
 
-      // Create event passes through without a gameExists lookup
-      const ack1 = jest.fn();
+      const ack = jest.fn();
       await socketHandlers['game_event'](
-        {gid: 'g1', event: {type: 'create', timestamp: 1700000000000, params: {pid: 'p1'}}},
-        ack1
+        {
+          gid: 'g1',
+          event: {
+            type: 'create',
+            timestamp: 1, // backdated to win the ORDER BY ts ASC race
+            params: {pid: 'p1', creator: {dfacId: 'attacker'}},
+          },
+        },
+        ack
       );
-      expect(ack1).toHaveBeenCalledWith();
 
-      // Subsequent updateCell on the same socket+gid should NOT call gameExists —
-      // the create should have primed verifiedGids. Only the INSERT runs.
-      pool.query.mockClear();
-      const ack2 = jest.fn();
-      await socketHandlers['game_event'](
-        {gid: 'g1', event: {type: 'updateCell', timestamp: 1700000000001, params: {id: 'p1'}}},
-        ack2
-      );
-      expect(ack2).toHaveBeenCalledWith();
-      expect(pool.query).toHaveBeenCalledTimes(1);
+      expect(ack).toHaveBeenCalledWith({error: 'create not allowed over socket'});
+      expect(pool.query).not.toHaveBeenCalled();
     });
 
     it('allows ephemeral events to bypass the gate', async () => {

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -183,7 +183,9 @@ describe('SocketManager', () => {
       const sm = new SocketManager(io);
       sm.listen();
 
-      // isIdentityBanned reads game_bans + game_locks first (authed identity)
+      // isIdentityBanned reads moderation state (bans + locks + create event
+      // for owner caching) on first contact with this gid.
+      pool.query.mockResolvedValueOnce({rows: []});
       pool.query.mockResolvedValueOnce({rows: []});
       pool.query.mockResolvedValueOnce({rows: []});
       // gameExists check — game has a create event

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -456,6 +456,22 @@ describe('SocketManager', () => {
       expect(ack).toHaveBeenCalledWith({error: 'invalid gid'});
     });
 
+    it('rejects join_game when the socket has neither dfacId nor authUser', async () => {
+      // Without this gate, a kicked guest could simply omit dfacId from the
+      // handshake and isIdentityBanned would return false vacuously, letting
+      // them re-enter the room.
+      const {io, socketHandlers, mockSocket} = createMockIo();
+      mockSocket.data = {};
+      const sm = new SocketManager(io);
+      sm.listen();
+
+      const ack = jest.fn();
+      await socketHandlers['join_game']('g1', ack);
+
+      expect(ack).toHaveBeenCalledWith({error: 'no identity'});
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
     it('rejects invalid gid for leave_game', async () => {
       const {io, socketHandlers} = createMockIo();
       const sm = new SocketManager(io);

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -183,6 +183,9 @@ describe('SocketManager', () => {
       const sm = new SocketManager(io);
       sm.listen();
 
+      // isIdentityBanned reads game_bans + game_locks first (authed identity)
+      pool.query.mockResolvedValueOnce({rows: []});
+      pool.query.mockResolvedValueOnce({rows: []});
       // gameExists check — game has a create event
       pool.query.mockResolvedValueOnce({rowCount: 1, rows: [{}]});
       const ack = jest.fn();

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -20,11 +20,17 @@ function createMockIo() {
   const toFn = jest.fn(() => ({emit: emitFn}));
 
   const socketHandlers: Record<string, AnyFn> = {};
+  // Pre-populate `rooms` with the default test gid so handler tests that
+  // invoke game_event directly (without going through join_game) don't
+  // trip the production room-membership check. Tests that want to verify
+  // the rejection path can clear the set or use a different gid.
+  const rooms = new Set<string>(['game-g1']);
   const mockSocket = {
     handshake: {auth: {}},
     data: {} as any,
-    join: jest.fn(),
-    leave: jest.fn(),
+    rooms,
+    join: jest.fn((room: string) => rooms.add(room)),
+    leave: jest.fn((room: string) => rooms.delete(room)),
     on: jest.fn((event: string, handler: AnyFn) => {
       socketHandlers[event] = handler;
     }),
@@ -267,9 +273,12 @@ describe('SocketManager', () => {
     });
 
     it('rejects persisted events for gids without a create event or snapshot', async () => {
-      const {io, socketHandlers} = createMockIo();
+      const {io, socketHandlers, mockSocket} = createMockIo();
       const sm = new SocketManager(io);
       sm.listen();
+      // Pretend the socket joined this gid already so we exercise the
+      // gameExists gate rather than the upstream room-membership check.
+      mockSocket.rooms.add('game-orphan-gid');
 
       // gameExists: no create event, then no snapshot
       pool.query.mockResolvedValueOnce({rowCount: 0, rows: []}); // create event lookup
@@ -336,9 +345,13 @@ describe('SocketManager', () => {
     });
 
     it('allows ephemeral events to bypass the gate', async () => {
-      const {io, socketHandlers} = createMockIo();
+      const {io, socketHandlers, mockSocket} = createMockIo();
       const sm = new SocketManager(io);
       sm.listen();
+      // Ephemeral cursor/ping still require the socket to be in the room.
+      // The "gate" this test is about is the gameExists check, not the
+      // room-membership one — pretend we joined already.
+      mockSocket.rooms.add('game-orphan-gid');
 
       const ack = jest.fn();
       await socketHandlers['game_event'](
@@ -348,6 +361,23 @@ describe('SocketManager', () => {
 
       expect(ack).toHaveBeenCalledWith();
       // No DB query should have run for an ephemeral event
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-create events from sockets that never joined the room', async () => {
+      const {io, socketHandlers} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+      // No mockSocket.rooms.add — the new gid was never joined. Without
+      // this gate, a client could skip join_game (which is what enforces
+      // bans + locks) and still emit updateCell/chat directly.
+
+      const ack = jest.fn();
+      await socketHandlers['game_event'](
+        {gid: 'unjoined-gid', event: {type: 'updateCell', timestamp: 1000, params: {id: 'p1'}}},
+        ack
+      );
+      expect(ack).toHaveBeenCalledWith({error: 'not in game'});
       expect(pool.query).not.toHaveBeenCalled();
     });
   });

--- a/server/__tests__/model/game_moderation.test.ts
+++ b/server/__tests__/model/game_moderation.test.ts
@@ -32,7 +32,9 @@ function mockState({
 }): void {
   pool.query.mockResolvedValueOnce({rows: bans});
   pool.query.mockResolvedValueOnce({rows: locked ? [{gid: 'g1'}] : []});
-  pool.query.mockResolvedValueOnce({rows: creator ? [{event_payload: {params: {creator}}}] : []});
+  // The moderation loader extracts event_payload->'params'->'creator' as
+  // `creator` directly in SQL, so the mocked row matches that shape.
+  pool.query.mockResolvedValueOnce({rows: creator ? [{creator}] : []});
 }
 
 describe('isIdentityBanned', () => {
@@ -85,10 +87,10 @@ describe('getGameOwner', () => {
   });
 
   it('returns null when create event has no creator field (legacy game)', async () => {
-    // create event row present, no creator key
+    // create event row present, JSON path returns NULL for missing creator.
     pool.query.mockResolvedValueOnce({rows: []});
     pool.query.mockResolvedValueOnce({rows: []});
-    pool.query.mockResolvedValueOnce({rows: [{event_payload: {params: {pid: 'p1'}}}]});
+    pool.query.mockResolvedValueOnce({rows: [{creator: null}]});
     expect(await getGameOwner('g1')).toBeNull();
   });
 });

--- a/server/__tests__/model/game_moderation.test.ts
+++ b/server/__tests__/model/game_moderation.test.ts
@@ -6,13 +6,12 @@ import {
   addGameBan,
   clearModerationCache,
   getGameOwner,
-  getLockedAt,
   isGameLocked,
   isIdentityBanned,
   isOwner,
   lockGame,
   unlockGame,
-  wasParticipantBeforeLock,
+  wasParticipantOfGame,
 } from '../../model/game_moderation';
 
 beforeEach(() => {
@@ -25,16 +24,14 @@ beforeEach(() => {
 function mockState({
   bans = [],
   locked = false,
-  lockedAt = null,
   creator = null,
 }: {
   bans?: Array<{identity: string; identity_type: 'user' | 'dfac'}>;
   locked?: boolean;
-  lockedAt?: Date | null;
   creator?: {userId?: string; dfacId?: string} | null;
 }): void {
   pool.query.mockResolvedValueOnce({rows: bans});
-  pool.query.mockResolvedValueOnce({rows: locked ? [{locked_at: lockedAt ?? new Date()}] : []});
+  pool.query.mockResolvedValueOnce({rows: locked ? [{gid: 'g1'}] : []});
   pool.query.mockResolvedValueOnce({rows: creator ? [{event_payload: {params: {creator}}}] : []});
 }
 
@@ -114,47 +111,43 @@ describe('isOwner', () => {
   });
 });
 
-describe('getLockedAt', () => {
-  it('returns the lock timestamp when locked', async () => {
-    const lockedAt = new Date('2026-01-01T00:00:00Z');
-    mockState({locked: true, lockedAt});
-    expect(await getLockedAt('g1')).toEqual(lockedAt);
-  });
-
-  it('returns null when unlocked', async () => {
-    mockState({locked: false});
-    expect(await getLockedAt('g1')).toBeNull();
-  });
-});
-
-describe('wasParticipantBeforeLock', () => {
-  const lockedAt = new Date('2026-01-01T12:00:00Z');
-
-  it('returns true when a game_events row exists for the dfac_id before the lock', async () => {
+describe('wasParticipantOfGame', () => {
+  it('returns true when a game_events row exists for the dfac_id', async () => {
     pool.query.mockResolvedValueOnce({rows: [{exists: 1}]});
-    expect(await wasParticipantBeforeLock('g1', {dfacId: 'dfac-x'}, lockedAt)).toBe(true);
+    expect(await wasParticipantOfGame('g1', {dfacId: 'dfac-x'})).toBe(true);
     const [sql, params] = pool.query.mock.calls[0];
     expect(sql).toContain('FROM game_events');
     expect(sql).toContain('uid = $2');
-    expect(params).toEqual(['g1', 'dfac-x', lockedAt]);
+    expect(params).toEqual(['g1', 'dfac-x']);
   });
 
-  it('returns true when a verifiedUserId matches before the lock (cross-device reconnect)', async () => {
+  it('returns true when a verifiedUserId matches (cross-device reconnect)', async () => {
     pool.query.mockResolvedValueOnce({rows: []}); // no dfac match
     pool.query.mockResolvedValueOnce({rows: [{exists: 1}]}); // userId match
-    expect(await wasParticipantBeforeLock('g1', {userId: 'u1', dfacId: 'new-dfac'}, lockedAt)).toBe(true);
+    expect(await wasParticipantOfGame('g1', {userId: 'u1', dfacId: 'new-dfac'})).toBe(true);
     expect(pool.query.mock.calls[1][0]).toContain("event_payload->>'verifiedUserId'");
   });
 
-  it('returns false when neither identity has prior events', async () => {
+  it('returns false when neither identity has any events', async () => {
     pool.query.mockResolvedValueOnce({rows: []});
     pool.query.mockResolvedValueOnce({rows: []});
-    expect(await wasParticipantBeforeLock('g1', {userId: 'u1', dfacId: 'd1'}, lockedAt)).toBe(false);
+    expect(await wasParticipantOfGame('g1', {userId: 'u1', dfacId: 'd1'})).toBe(false);
   });
 
   it('returns false and skips the DB when identity is empty', async () => {
-    expect(await wasParticipantBeforeLock('g1', {}, lockedAt)).toBe(false);
+    expect(await wasParticipantOfGame('g1', {})).toBe(false);
     expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('does not constrain on timestamp (deliberate)', async () => {
+    // The temporal check was removed because event.timestamp is the
+    // client's clock; any forward skew would push legitimate pre-lock
+    // events past locked_at and break the bypass on refresh.
+    pool.query.mockResolvedValueOnce({rows: [{exists: 1}]});
+    await wasParticipantOfGame('g1', {dfacId: 'd1'});
+    const sql = pool.query.mock.calls[0][0] as string;
+    expect(sql).not.toContain('ts <');
+    expect(sql).not.toContain('locked_at');
   });
 });
 

--- a/server/__tests__/model/game_moderation.test.ts
+++ b/server/__tests__/model/game_moderation.test.ts
@@ -6,11 +6,13 @@ import {
   addGameBan,
   clearModerationCache,
   getGameOwner,
+  getLockedAt,
   isGameLocked,
   isIdentityBanned,
   isOwner,
   lockGame,
   unlockGame,
+  wasParticipantBeforeLock,
 } from '../../model/game_moderation';
 
 beforeEach(() => {
@@ -23,14 +25,16 @@ beforeEach(() => {
 function mockState({
   bans = [],
   locked = false,
+  lockedAt = null,
   creator = null,
 }: {
   bans?: Array<{identity: string; identity_type: 'user' | 'dfac'}>;
   locked?: boolean;
+  lockedAt?: Date | null;
   creator?: {userId?: string; dfacId?: string} | null;
 }): void {
   pool.query.mockResolvedValueOnce({rows: bans});
-  pool.query.mockResolvedValueOnce({rows: locked ? [{gid: 'g1'}] : []});
+  pool.query.mockResolvedValueOnce({rows: locked ? [{locked_at: lockedAt ?? new Date()}] : []});
   pool.query.mockResolvedValueOnce({rows: creator ? [{event_payload: {params: {creator}}}] : []});
 }
 
@@ -107,6 +111,50 @@ describe('isOwner', () => {
 
   it('returns false when owner is null (legacy game)', () => {
     expect(isOwner(null, {userId: 'u1', dfacIds: ['d1']})).toBe(false);
+  });
+});
+
+describe('getLockedAt', () => {
+  it('returns the lock timestamp when locked', async () => {
+    const lockedAt = new Date('2026-01-01T00:00:00Z');
+    mockState({locked: true, lockedAt});
+    expect(await getLockedAt('g1')).toEqual(lockedAt);
+  });
+
+  it('returns null when unlocked', async () => {
+    mockState({locked: false});
+    expect(await getLockedAt('g1')).toBeNull();
+  });
+});
+
+describe('wasParticipantBeforeLock', () => {
+  const lockedAt = new Date('2026-01-01T12:00:00Z');
+
+  it('returns true when a game_events row exists for the dfac_id before the lock', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{exists: 1}]});
+    expect(await wasParticipantBeforeLock('g1', {dfacId: 'dfac-x'}, lockedAt)).toBe(true);
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toContain('FROM game_events');
+    expect(sql).toContain('uid = $2');
+    expect(params).toEqual(['g1', 'dfac-x', lockedAt]);
+  });
+
+  it('returns true when a verifiedUserId matches before the lock (cross-device reconnect)', async () => {
+    pool.query.mockResolvedValueOnce({rows: []}); // no dfac match
+    pool.query.mockResolvedValueOnce({rows: [{exists: 1}]}); // userId match
+    expect(await wasParticipantBeforeLock('g1', {userId: 'u1', dfacId: 'new-dfac'}, lockedAt)).toBe(true);
+    expect(pool.query.mock.calls[1][0]).toContain("event_payload->>'verifiedUserId'");
+  });
+
+  it('returns false when neither identity has prior events', async () => {
+    pool.query.mockResolvedValueOnce({rows: []});
+    pool.query.mockResolvedValueOnce({rows: []});
+    expect(await wasParticipantBeforeLock('g1', {userId: 'u1', dfacId: 'd1'}, lockedAt)).toBe(false);
+  });
+
+  it('returns false and skips the DB when identity is empty', async () => {
+    expect(await wasParticipantBeforeLock('g1', {}, lockedAt)).toBe(false);
+    expect(pool.query).not.toHaveBeenCalled();
   });
 });
 

--- a/server/__tests__/model/game_moderation.test.ts
+++ b/server/__tests__/model/game_moderation.test.ts
@@ -1,0 +1,136 @@
+import {pool, resetPoolMocks} from '../../__mocks__/pool';
+
+jest.mock('../../model/pool', () => require('../../__mocks__/pool'));
+
+import {
+  addGameBan,
+  clearModerationCache,
+  getGameOwner,
+  isGameLocked,
+  isIdentityBanned,
+  isOwner,
+  lockGame,
+  unlockGame,
+} from '../../model/game_moderation';
+
+beforeEach(() => {
+  resetPoolMocks();
+  clearModerationCache();
+});
+
+describe('isIdentityBanned', () => {
+  it('returns true when the user_id matches a ban row', async () => {
+    // game_bans + game_locks lookup happens in parallel
+    pool.query.mockResolvedValueOnce({rows: [{identity: 'user-1', identity_type: 'user'}]});
+    pool.query.mockResolvedValueOnce({rows: []});
+    expect(await isIdentityBanned('g1', {userId: 'user-1'})).toBe(true);
+  });
+
+  it('returns true when the dfac_id matches', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{identity: 'dfac-x', identity_type: 'dfac'}]});
+    pool.query.mockResolvedValueOnce({rows: []});
+    expect(await isIdentityBanned('g1', {dfacId: 'dfac-x'})).toBe(true);
+  });
+
+  it('returns false when neither identity matches', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{identity: 'other', identity_type: 'user'}]});
+    pool.query.mockResolvedValueOnce({rows: []});
+    expect(await isIdentityBanned('g1', {userId: 'user-1', dfacId: 'dfac-x'})).toBe(false);
+  });
+
+  it('caches per-gid so back-to-back socket events skip the DB', async () => {
+    pool.query.mockResolvedValueOnce({rows: []});
+    pool.query.mockResolvedValueOnce({rows: []});
+    await isIdentityBanned('g1', {userId: 'user-1'});
+    await isIdentityBanned('g1', {userId: 'user-2'});
+    // First call hit the DB (2 queries), second call should be cached (0).
+    expect(pool.query).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isGameLocked', () => {
+  it('returns true when a game_locks row exists', async () => {
+    pool.query.mockResolvedValueOnce({rows: []});
+    pool.query.mockResolvedValueOnce({rows: [{gid: 'g1'}]});
+    expect(await isGameLocked('g1')).toBe(true);
+  });
+
+  it('returns false when no row exists', async () => {
+    pool.query.mockResolvedValueOnce({rows: []});
+    pool.query.mockResolvedValueOnce({rows: []});
+    expect(await isGameLocked('g1')).toBe(false);
+  });
+});
+
+describe('getGameOwner', () => {
+  it('reads creator from the create event payload', async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [{event_payload: {params: {creator: {userId: 'user-1', dfacId: 'dfac-x'}}}}],
+    });
+    expect(await getGameOwner('g1')).toEqual({userId: 'user-1', dfacId: 'dfac-x'});
+  });
+
+  it('returns null when no create event exists', async () => {
+    pool.query.mockResolvedValueOnce({rows: []});
+    expect(await getGameOwner('g1')).toBeNull();
+  });
+
+  it('returns null when create event has no creator field (legacy game)', async () => {
+    pool.query.mockResolvedValueOnce({rows: [{event_payload: {params: {pid: 'p1'}}}]});
+    expect(await getGameOwner('g1')).toBeNull();
+  });
+});
+
+describe('isOwner', () => {
+  it('matches on user_id', () => {
+    expect(isOwner({userId: 'u1'}, {userId: 'u1', dfacIds: []})).toBe(true);
+  });
+
+  it('matches on any dfac_id in the caller list', () => {
+    expect(isOwner({dfacId: 'd2'}, {userId: 'u1', dfacIds: ['d1', 'd2']})).toBe(true);
+  });
+
+  it('returns false on mismatch', () => {
+    expect(isOwner({userId: 'u1'}, {userId: 'u2', dfacIds: ['d1']})).toBe(false);
+  });
+
+  it('returns false when owner is null (legacy game)', () => {
+    expect(isOwner(null, {userId: 'u1', dfacIds: ['d1']})).toBe(false);
+  });
+});
+
+describe('addGameBan / lockGame / unlockGame', () => {
+  it('addGameBan upserts and invalidates cache', async () => {
+    // Prime cache
+    pool.query.mockResolvedValueOnce({rows: []});
+    pool.query.mockResolvedValueOnce({rows: []});
+    await isIdentityBanned('g1', {userId: 'u1'});
+
+    // Add ban
+    pool.query.mockResolvedValueOnce({rows: []});
+    await addGameBan('g1', {identity: 'u1', identityType: 'user'}, 'admin');
+    const insertSql = pool.query.mock.calls[pool.query.mock.calls.length - 1][0] as string;
+    expect(insertSql).toContain('INSERT INTO game_bans');
+    expect(insertSql).toContain('ON CONFLICT (gid, identity, identity_type) DO NOTHING');
+
+    // Next isIdentityBanned hits DB again (cache busted) and now sees the row
+    pool.query.mockResolvedValueOnce({rows: [{identity: 'u1', identity_type: 'user'}]});
+    pool.query.mockResolvedValueOnce({rows: []});
+    expect(await isIdentityBanned('g1', {userId: 'u1'})).toBe(true);
+  });
+
+  it('lockGame inserts a game_locks row', async () => {
+    pool.query.mockResolvedValueOnce({rows: []});
+    await lockGame('g1', {userId: 'u1', dfacId: 'd1'});
+    const sql = pool.query.mock.calls[0][0] as string;
+    expect(sql).toContain('INSERT INTO game_locks');
+    expect(sql).toContain('ON CONFLICT (gid) DO NOTHING');
+  });
+
+  it('unlockGame deletes the row', async () => {
+    pool.query.mockResolvedValueOnce({rows: []});
+    await unlockGame('g1');
+    const sql = pool.query.mock.calls[0][0] as string;
+    expect(sql).toContain('DELETE FROM game_locks');
+  });
+});

--- a/server/__tests__/model/game_moderation.test.ts
+++ b/server/__tests__/model/game_moderation.test.ts
@@ -18,64 +18,75 @@ beforeEach(() => {
   clearModerationCache();
 });
 
+// Moderation state is loaded with 3 parallel queries: bans, locks, and the
+// create event (for owner caching). Tests need to mock all three.
+function mockState({
+  bans = [],
+  locked = false,
+  creator = null,
+}: {
+  bans?: Array<{identity: string; identity_type: 'user' | 'dfac'}>;
+  locked?: boolean;
+  creator?: {userId?: string; dfacId?: string} | null;
+}): void {
+  pool.query.mockResolvedValueOnce({rows: bans});
+  pool.query.mockResolvedValueOnce({rows: locked ? [{gid: 'g1'}] : []});
+  pool.query.mockResolvedValueOnce({rows: creator ? [{event_payload: {params: {creator}}}] : []});
+}
+
 describe('isIdentityBanned', () => {
   it('returns true when the user_id matches a ban row', async () => {
-    // game_bans + game_locks lookup happens in parallel
-    pool.query.mockResolvedValueOnce({rows: [{identity: 'user-1', identity_type: 'user'}]});
-    pool.query.mockResolvedValueOnce({rows: []});
+    mockState({bans: [{identity: 'user-1', identity_type: 'user'}]});
     expect(await isIdentityBanned('g1', {userId: 'user-1'})).toBe(true);
   });
 
   it('returns true when the dfac_id matches', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{identity: 'dfac-x', identity_type: 'dfac'}]});
-    pool.query.mockResolvedValueOnce({rows: []});
+    mockState({bans: [{identity: 'dfac-x', identity_type: 'dfac'}]});
     expect(await isIdentityBanned('g1', {dfacId: 'dfac-x'})).toBe(true);
   });
 
   it('returns false when neither identity matches', async () => {
-    pool.query.mockResolvedValueOnce({rows: [{identity: 'other', identity_type: 'user'}]});
-    pool.query.mockResolvedValueOnce({rows: []});
+    mockState({bans: [{identity: 'other', identity_type: 'user'}]});
     expect(await isIdentityBanned('g1', {userId: 'user-1', dfacId: 'dfac-x'})).toBe(false);
   });
 
   it('caches per-gid so back-to-back socket events skip the DB', async () => {
-    pool.query.mockResolvedValueOnce({rows: []});
-    pool.query.mockResolvedValueOnce({rows: []});
+    mockState({});
     await isIdentityBanned('g1', {userId: 'user-1'});
     await isIdentityBanned('g1', {userId: 'user-2'});
-    // First call hit the DB (2 queries), second call should be cached (0).
-    expect(pool.query).toHaveBeenCalledTimes(2);
+    // First call hit the DB (3 queries — bans, locks, create event), second
+    // call should be cached (0 additional).
+    expect(pool.query).toHaveBeenCalledTimes(3);
   });
 });
 
 describe('isGameLocked', () => {
   it('returns true when a game_locks row exists', async () => {
-    pool.query.mockResolvedValueOnce({rows: []});
-    pool.query.mockResolvedValueOnce({rows: [{gid: 'g1'}]});
+    mockState({locked: true});
     expect(await isGameLocked('g1')).toBe(true);
   });
 
   it('returns false when no row exists', async () => {
-    pool.query.mockResolvedValueOnce({rows: []});
-    pool.query.mockResolvedValueOnce({rows: []});
+    mockState({locked: false});
     expect(await isGameLocked('g1')).toBe(false);
   });
 });
 
 describe('getGameOwner', () => {
   it('reads creator from the create event payload', async () => {
-    pool.query.mockResolvedValueOnce({
-      rows: [{event_payload: {params: {creator: {userId: 'user-1', dfacId: 'dfac-x'}}}}],
-    });
+    mockState({creator: {userId: 'user-1', dfacId: 'dfac-x'}});
     expect(await getGameOwner('g1')).toEqual({userId: 'user-1', dfacId: 'dfac-x'});
   });
 
   it('returns null when no create event exists', async () => {
-    pool.query.mockResolvedValueOnce({rows: []});
+    mockState({});
     expect(await getGameOwner('g1')).toBeNull();
   });
 
   it('returns null when create event has no creator field (legacy game)', async () => {
+    // create event row present, no creator key
+    pool.query.mockResolvedValueOnce({rows: []});
+    pool.query.mockResolvedValueOnce({rows: []});
     pool.query.mockResolvedValueOnce({rows: [{event_payload: {params: {pid: 'p1'}}}]});
     expect(await getGameOwner('g1')).toBeNull();
   });
@@ -102,8 +113,7 @@ describe('isOwner', () => {
 describe('addGameBan / lockGame / unlockGame', () => {
   it('addGameBan upserts and invalidates cache', async () => {
     // Prime cache
-    pool.query.mockResolvedValueOnce({rows: []});
-    pool.query.mockResolvedValueOnce({rows: []});
+    mockState({});
     await isIdentityBanned('g1', {userId: 'u1'});
 
     // Add ban
@@ -114,8 +124,7 @@ describe('addGameBan / lockGame / unlockGame', () => {
     expect(insertSql).toContain('ON CONFLICT (gid, identity, identity_type) DO NOTHING');
 
     // Next isIdentityBanned hits DB again (cache busted) and now sees the row
-    pool.query.mockResolvedValueOnce({rows: [{identity: 'u1', identity_type: 'user'}]});
-    pool.query.mockResolvedValueOnce({rows: []});
+    mockState({bans: [{identity: 'u1', identity_type: 'user'}]});
     expect(await isIdentityBanned('g1', {userId: 'u1'})).toBe(true);
   });
 

--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -12,6 +12,7 @@ import {getDfacIdsForUser} from '../model/user';
 import {
   addGameBan,
   getGameOwner,
+  getKickedDfacIds,
   isGameLocked,
   isOwner,
   lockGame,
@@ -244,8 +245,12 @@ router.post<{gid: string}>('/:gid/undismiss', async (req, res, next) => {
 router.get<{gid: string}>('/:gid/moderation', async (req, res, next) => {
   try {
     const {gid} = req.params;
-    const [locked, owner] = await Promise.all([isGameLocked(gid), getGameOwner(gid)]);
-    res.json({locked, owner});
+    const [locked, owner, kickedDfacIds] = await Promise.all([
+      isGameLocked(gid),
+      getGameOwner(gid),
+      getKickedDfacIds(gid),
+    ]);
+    res.json({locked, owner, kickedDfacIds});
   } catch (e) {
     next(e);
   }

--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -417,6 +417,18 @@ router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/unkick', as
 
     await removeGameBan(gid, {dfacId: target.dfac_id, userId: resolvedUserId});
 
+    // Mirror /kick's broadcast so other clients can update their local
+    // kickedDfacIds (un-grey the presence entry, re-allow as a real player)
+    // without a refresh.
+    const io = getSocketIo();
+    if (io) {
+      io.to(`game-${gid}`).emit('unkicked', {
+        gid,
+        dfac_id: target.dfac_id,
+        user_id: resolvedUserId,
+      });
+    }
+
     res.sendStatus(204);
   } catch (e) {
     next(e);

--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -250,7 +250,24 @@ router.get<{gid: string}>('/:gid/moderation', async (req, res, next) => {
       getGameOwner(gid),
       getKickedDfacIds(gid),
     ]);
-    res.json({locked, owner, kickedDfacIds});
+    // Resolve isOwner server-side when the caller is authenticated. The
+    // client-side equivalent only knows the local dfac_id, which misses the
+    // cross-device case: user creates as guest on device A (linking that
+    // dfac_id to their account when they sign in), then opens the same game
+    // on device B with a different dfac_id. The server tracks all dfac_ids
+    // linked to the user, so it can answer "are you the owner?" correctly
+    // where the client cannot. Mirrors what the moderation HTTP endpoints
+    // actually authorize against.
+    let isOwnerForCaller = false;
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      const payload = verifyAccessToken(authHeader.slice(7));
+      if (payload) {
+        const dfacIds = await getDfacIdsForUser(payload.userId);
+        isOwnerForCaller = isOwner(owner, {userId: payload.userId, dfacIds});
+      }
+    }
+    res.json({locked, owner, kickedDfacIds, isOwner: isOwnerForCaller});
   } catch (e) {
     next(e);
   }

--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -301,13 +301,16 @@ router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/kick', asyn
     }
 
     // Persist both identities if the caller supplied both — covers the
-    // sign-out-and-rejoin-as-guest case.
+    // sign-out-and-rejoin-as-guest case. Run them in parallel since the
+    // two rows are independent.
+    const banWrites: Promise<void>[] = [];
     if (target.user_id) {
-      await addGameBan(gid, {identity: target.user_id, identityType: 'user'}, payload.userId);
+      banWrites.push(addGameBan(gid, {identity: target.user_id, identityType: 'user'}, payload.userId));
     }
     if (target.dfac_id) {
-      await addGameBan(gid, {identity: target.dfac_id, identityType: 'dfac'}, payload.userId);
+      banWrites.push(addGameBan(gid, {identity: target.dfac_id, identityType: 'dfac'}, payload.userId));
     }
+    await Promise.all(banWrites);
 
     // Broadcast so the kicked client disconnects immediately rather than
     // waiting for their next event to be rejected.

--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -350,8 +350,13 @@ router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/kick', asyn
     }
     await Promise.all(banWrites);
 
-    // Broadcast so the kicked client disconnects immediately rather than
-    // waiting for their next event to be rejected.
+    // Broadcast first so well-behaved kicked clients can call
+    // forceDisconnect and show the blocker, then evict the matching
+    // sockets from the room server-side. The eviction matters because a
+    // malicious client could ignore the broadcast and keep receiving
+    // room messages / replaying history — leaving the room cuts off
+    // both even without client cooperation. sync_all_game_events also
+    // re-checks isIdentityBanned for the same reason.
     const io = getSocketIo();
     if (io) {
       io.to(`game-${gid}`).emit('kicked', {
@@ -359,6 +364,14 @@ router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/kick', asyn
         dfac_id: target.dfac_id,
         user_id: resolvedUserId,
       });
+      const sockets = await io.in(`game-${gid}`).fetchSockets();
+      for (const s of sockets) {
+        const matchesDfac = target.dfac_id && s.data.dfacId === target.dfac_id;
+        const matchesUser = resolvedUserId && s.data.authUser?.userId === resolvedUserId;
+        if (matchesDfac || matchesUser) {
+          s.leave(`game-${gid}`);
+        }
+      }
     }
 
     res.sendStatus(204);

--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -333,6 +333,14 @@ router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/kick', asyn
       resolvedUserId = (await getUserIdByDfacId(target.dfac_id)) || undefined;
     }
 
+    // Refuse self-kicks. The client UI suppresses the kick button for the
+    // owner's local dfac, but not for *other* devices of the same account,
+    // so clicking kick on a second-device entry would resolve to the
+    // owner's own user_id and ban every session. Fail loudly instead.
+    if (resolvedUserId === payload.userId || (target.dfac_id && dfacIds.includes(target.dfac_id))) {
+      return res.status(400).json({error: 'cannot kick yourself'});
+    }
+
     const banWrites: Promise<void>[] = [];
     if (resolvedUserId) {
       banWrites.push(addGameBan(gid, {identity: resolvedUserId, identityType: 'user'}, payload.userId));

--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -16,6 +16,7 @@ import {
   isGameLocked,
   isOwner,
   lockGame,
+  removeGameBan,
   unlockGame,
 } from '../model/game_moderation';
 import {getSocketIo} from '../socket_instance';
@@ -351,6 +352,70 @@ router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/kick', asyn
         user_id: resolvedUserId,
       });
     }
+
+    res.sendStatus(204);
+  } catch (e) {
+    next(e);
+  }
+  return undefined;
+});
+
+/**
+ * @openapi
+ * /game/{gid}/unkick:
+ *   post:
+ *     tags: [Games]
+ *     summary: Lift a kick (unban) a player
+ *     description: Owner-only. Removes the ban for the given target identity. Resolves the linked user_id so all device-local bans tied to the same account are lifted.
+ *     security: [{bearerAuth: []}]
+ *     parameters:
+ *       - in: path
+ *         name: gid
+ *         required: true
+ *         schema: {type: string}
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               dfac_id: {type: string}
+ *               user_id: {type: string}
+ *     responses:
+ *       204: {description: Player unkicked}
+ *       400: {description: Missing target identity}
+ *       401: {description: Not authenticated}
+ *       403: {description: Caller is not the owner}
+ */
+router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/unkick', async (req, res, next) => {
+  try {
+    const {gid} = req.params;
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) return res.sendStatus(401);
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!payload) return res.sendStatus(401);
+
+    const target = req.body || {};
+    if (!target.dfac_id && !target.user_id) {
+      return res.status(400).json({error: 'target dfac_id or user_id required'});
+    }
+
+    const owner = await getGameOwner(gid);
+    const dfacIds = await getDfacIdsForUser(payload.userId);
+    if (!isOwner(owner, {userId: payload.userId, dfacIds})) {
+      return res.status(403).json({error: 'only the game owner can unkick'});
+    }
+
+    // Mirror /kick: resolve the linked user_id so we remove the user-scoped
+    // ban too, not just the dfac-scoped one. Otherwise an authed player who
+    // was kicked from another device would still be banned on this device.
+    let resolvedUserId = target.user_id;
+    if (!resolvedUserId && target.dfac_id) {
+      resolvedUserId = (await getUserIdByDfacId(target.dfac_id)) || undefined;
+    }
+
+    await removeGameBan(gid, {dfacId: target.dfac_id, userId: resolvedUserId});
 
     res.sendStatus(204);
   } catch (e) {

--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -9,6 +9,15 @@ import {verifyAccessToken} from '../auth/jwt';
 import {dismissGameForUser, undismissGameForUser} from '../model/game_dismissal';
 import {invalidateUserGamesCacheForUser, invalidateAuthPuzzleStatusCache} from '../model/user_games';
 import {getDfacIdsForUser} from '../model/user';
+import {
+  addGameBan,
+  getGameOwner,
+  isGameLocked,
+  isOwner,
+  lockGame,
+  unlockGame,
+} from '../model/game_moderation';
+import {getSocketIo} from '../socket_instance';
 
 const router = express.Router();
 
@@ -42,7 +51,21 @@ const router = express.Router();
  */
 router.post<{}, CreateGameResponse | {error: string}, CreateGameRequest>('/', async (req, res, next) => {
   try {
-    const gid = await addInitialGameEvent(req.body.gid, req.body.pid);
+    // Optional auth — if the caller is signed in, stamp their user_id onto
+    // the create event's creator field. The dfac_id from the body is the
+    // fallback identity for guests. Either is enough to anchor ownership;
+    // both is best (covers sign-out -> rejoin as guest).
+    let userId: string | null = null;
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      const payload = verifyAccessToken(authHeader.slice(7));
+      if (payload) userId = payload.userId;
+    }
+
+    const gid = await addInitialGameEvent(req.body.gid, req.body.pid, {
+      userId,
+      dfacId: req.body.dfac_id,
+    });
     // Invalidate user games cache so the "Your Games" page reflects the new game immediately
     if (req.body.dfac_id) {
       invalidateUserGamesCacheForUser(req.body.dfac_id);
@@ -195,6 +218,188 @@ router.post<{gid: string}>('/:gid/undismiss', async (req, res, next) => {
     invalidateAuthPuzzleStatusCache(payload.userId);
     const dfacIds = await getDfacIdsForUser(payload.userId);
     for (const dfacId of dfacIds) invalidateUserGamesCacheForUser(dfacId);
+    res.sendStatus(204);
+  } catch (e) {
+    next(e);
+  }
+  return undefined;
+});
+
+/**
+ * @openapi
+ * /game/{gid}/moderation:
+ *   get:
+ *     tags: [Games]
+ *     summary: Get moderation state for a game
+ *     description: Returns current lock state and owner identity (if any). No auth required; the data is non-sensitive — clients use it to decide whether to render owner controls.
+ *     parameters:
+ *       - in: path
+ *         name: gid
+ *         required: true
+ *         schema: {type: string}
+ *     responses:
+ *       200:
+ *         description: Moderation state
+ */
+router.get<{gid: string}>('/:gid/moderation', async (req, res, next) => {
+  try {
+    const {gid} = req.params;
+    const [locked, owner] = await Promise.all([isGameLocked(gid), getGameOwner(gid)]);
+    res.json({locked, owner});
+  } catch (e) {
+    next(e);
+  }
+});
+
+type KickRequest = {dfac_id?: string; user_id?: string};
+
+/**
+ * @openapi
+ * /game/{gid}/kick:
+ *   post:
+ *     tags: [Games]
+ *     summary: Kick (ban) a player from a game
+ *     description: Owner-only. Bans the target identity from joining or sending events to this gid. Broadcasts a 'kicked' event so the target's client disconnects immediately.
+ *     security: [{bearerAuth: []}]
+ *     parameters:
+ *       - in: path
+ *         name: gid
+ *         required: true
+ *         schema: {type: string}
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               dfac_id: {type: string}
+ *               user_id: {type: string}
+ *     responses:
+ *       204: {description: Player kicked}
+ *       400: {description: Missing target identity}
+ *       401: {description: Not authenticated}
+ *       403: {description: Caller is not the owner}
+ */
+router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/kick', async (req, res, next) => {
+  try {
+    const {gid} = req.params;
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) return res.sendStatus(401);
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!payload) return res.sendStatus(401);
+
+    const target = req.body || {};
+    if (!target.dfac_id && !target.user_id) {
+      return res.status(400).json({error: 'target dfac_id or user_id required'});
+    }
+
+    const owner = await getGameOwner(gid);
+    const dfacIds = await getDfacIdsForUser(payload.userId);
+    if (!isOwner(owner, {userId: payload.userId, dfacIds})) {
+      return res.status(403).json({error: 'only the game owner can kick'});
+    }
+
+    // Persist both identities if the caller supplied both — covers the
+    // sign-out-and-rejoin-as-guest case.
+    if (target.user_id) {
+      await addGameBan(gid, {identity: target.user_id, identityType: 'user'}, payload.userId);
+    }
+    if (target.dfac_id) {
+      await addGameBan(gid, {identity: target.dfac_id, identityType: 'dfac'}, payload.userId);
+    }
+
+    // Broadcast so the kicked client disconnects immediately rather than
+    // waiting for their next event to be rejected.
+    const io = getSocketIo();
+    if (io) {
+      io.to(`game-${gid}`).emit('kicked', {
+        gid,
+        dfac_id: target.dfac_id,
+        user_id: target.user_id,
+      });
+    }
+
+    res.sendStatus(204);
+  } catch (e) {
+    next(e);
+  }
+  return undefined;
+});
+
+/**
+ * @openapi
+ * /game/{gid}/lock:
+ *   post:
+ *     tags: [Games]
+ *     summary: Lock a game so no new players can join
+ *     description: Owner-only. Existing players continue to play.
+ *     security: [{bearerAuth: []}]
+ *     parameters:
+ *       - in: path
+ *         name: gid
+ *         required: true
+ *         schema: {type: string}
+ *     responses:
+ *       204: {description: Game locked}
+ *       401: {description: Not authenticated}
+ *       403: {description: Caller is not the owner}
+ */
+router.post<{gid: string}>('/:gid/lock', async (req, res, next) => {
+  try {
+    const {gid} = req.params;
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) return res.sendStatus(401);
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!payload) return res.sendStatus(401);
+
+    const owner = await getGameOwner(gid);
+    const dfacIds = await getDfacIdsForUser(payload.userId);
+    if (!isOwner(owner, {userId: payload.userId, dfacIds})) {
+      return res.sendStatus(403);
+    }
+
+    await lockGame(gid, {userId: payload.userId, dfacId: dfacIds[0] || null});
+    res.sendStatus(204);
+  } catch (e) {
+    next(e);
+  }
+  return undefined;
+});
+
+/**
+ * @openapi
+ * /game/{gid}/unlock:
+ *   post:
+ *     tags: [Games]
+ *     summary: Unlock a game
+ *     description: Owner-only.
+ *     security: [{bearerAuth: []}]
+ *     parameters:
+ *       - in: path
+ *         name: gid
+ *         required: true
+ *         schema: {type: string}
+ *     responses:
+ *       204: {description: Game unlocked}
+ *       401: {description: Not authenticated}
+ *       403: {description: Caller is not the owner}
+ */
+router.post<{gid: string}>('/:gid/unlock', async (req, res, next) => {
+  try {
+    const {gid} = req.params;
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) return res.sendStatus(401);
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!payload) return res.sendStatus(401);
+
+    const owner = await getGameOwner(gid);
+    const dfacIds = await getDfacIdsForUser(payload.userId);
+    if (!isOwner(owner, {userId: payload.userId, dfacIds})) {
+      return res.sendStatus(403);
+    }
+
+    await unlockGame(gid);
     res.sendStatus(204);
   } catch (e) {
     next(e);

--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -8,7 +8,7 @@ import {getPuzzleInfo} from '../model/puzzle';
 import {verifyAccessToken} from '../auth/jwt';
 import {dismissGameForUser, undismissGameForUser} from '../model/game_dismissal';
 import {invalidateUserGamesCacheForUser, invalidateAuthPuzzleStatusCache} from '../model/user_games';
-import {getDfacIdsForUser} from '../model/user';
+import {getDfacIdsForUser, getUserIdByDfacId} from '../model/user';
 import {
   addGameBan,
   getGameOwner,
@@ -322,12 +322,19 @@ router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/kick', asyn
       return res.status(403).json({error: 'only the game owner can kick'});
     }
 
-    // Persist both identities if the caller supplied both — covers the
-    // sign-out-and-rejoin-as-guest case. Run them in parallel since the
-    // two rows are independent.
+    // The client only knows the target's dfac_id (presence list keys),
+    // but banning just that lets an authed target rejoin from another
+    // browser with a fresh dfac. Resolve the linked user_id server-side
+    // and ban both identities so the kick covers every device of the
+    // same account. No-op for guests with no linked account.
+    let resolvedUserId = target.user_id;
+    if (!resolvedUserId && target.dfac_id) {
+      resolvedUserId = (await getUserIdByDfacId(target.dfac_id)) || undefined;
+    }
+
     const banWrites: Promise<void>[] = [];
-    if (target.user_id) {
-      banWrites.push(addGameBan(gid, {identity: target.user_id, identityType: 'user'}, payload.userId));
+    if (resolvedUserId) {
+      banWrites.push(addGameBan(gid, {identity: resolvedUserId, identityType: 'user'}, payload.userId));
     }
     if (target.dfac_id) {
       banWrites.push(addGameBan(gid, {identity: target.dfac_id, identityType: 'dfac'}, payload.userId));
@@ -341,7 +348,7 @@ router.post<{gid: string}, {} | {error: string}, KickRequest>('/:gid/kick', asyn
       io.to(`game-${gid}`).emit('kicked', {
         gid,
         dfac_id: target.dfac_id,
-        user_id: target.user_id,
+        user_id: resolvedUserId,
       });
     }
 

--- a/server/model/game.ts
+++ b/server/model/game.ts
@@ -147,7 +147,9 @@ export async function addGameEvent(gid: string, event: GameEvent) {
   );
 }
 
-export async function addInitialGameEvent(gid: string, pid: string) {
+export type GameCreator = {userId?: string | null; dfacId?: string | null};
+
+export async function addInitialGameEvent(gid: string, pid: string, creator?: GameCreator) {
   const puzzle = await getPuzzle(pid);
   if (!puzzle) throw new Error(`Puzzle not found: ${pid}`);
   const {
@@ -163,6 +165,12 @@ export async function addInitialGameEvent(gid: string, pid: string) {
   const clues = gridObject.alignClues(puzzle.clues);
   const grid = gridObject.toArray();
 
+  // Persist creator identity so we can check ownership later for kick/lock.
+  // Only set keys that are actually present so the payload stays compact.
+  const creatorPayload: {userId?: string; dfacId?: string} = {};
+  if (creator?.userId) creatorPayload.userId = creator.userId;
+  if (creator?.dfacId) creatorPayload.dfacId = creator.dfacId;
+
   const initialEvent = {
     user: '',
     timestamp: Date.now(),
@@ -170,6 +178,7 @@ export async function addInitialGameEvent(gid: string, pid: string) {
     params: {
       pid,
       version: 1.0,
+      ...(Object.keys(creatorPayload).length > 0 ? {creator: creatorPayload} : {}),
       game: {
         info,
         grid,

--- a/server/model/game_moderation.ts
+++ b/server/model/game_moderation.ts
@@ -13,7 +13,6 @@ export type GameCreator = {userId?: string; dfacId?: string};
 type ModerationState = {
   banned: {userIds: Set<string>; dfacIds: Set<string>};
   locked: boolean;
-  lockedAt: Date | null;
   owner: GameCreator | null;
 };
 const moderationCache = new TTLCache<ModerationState>({ttlMs: 5 * 60_000, maxSize: 10_000});
@@ -32,7 +31,7 @@ async function loadModerationState(gid: string): Promise<ModerationState> {
       `SELECT identity, identity_type FROM game_bans WHERE gid = $1`,
       [gid]
     ),
-    pool.query<{locked_at: Date}>(`SELECT locked_at FROM game_locks WHERE gid = $1`, [gid]),
+    pool.query<{gid: string}>(`SELECT gid FROM game_locks WHERE gid = $1`, [gid]),
     pool.query<{event_payload: any}>(
       `SELECT event_payload FROM game_events WHERE gid = $1 AND event_type = 'create' ORDER BY ts ASC LIMIT 1`,
       [gid]
@@ -52,13 +51,7 @@ async function loadModerationState(gid: string): Promise<ModerationState> {
     if (creatorPayload.dfacId) owner.dfacId = creatorPayload.dfacId;
     if (Object.keys(owner).length === 0) owner = null;
   }
-  const lockRow = locks.rows[0];
-  return {
-    banned: {userIds, dfacIds},
-    locked: !!lockRow,
-    lockedAt: lockRow?.locked_at ?? null,
-    owner,
-  };
+  return {banned: {userIds, dfacIds}, locked: locks.rows.length > 0, owner};
 }
 
 async function getModerationState(gid: string): Promise<ModerationState> {
@@ -84,27 +77,26 @@ export async function isGameLocked(gid: string): Promise<boolean> {
   return state.locked;
 }
 
-// Pre-lock participants get an owner-equivalent bypass on the lock gate
+// Prior participants get an owner-equivalent bypass on the lock gate
 // so they survive transient reconnects: the moderation contract is
 // "lock blocks new joins; existing players keep playing". Without this,
 // any mobile/flaky reconnect would re-issue join_game on a locked game
 // and the client would treat the rejection as terminal.
 //
-// We define "participant before lock" as having any persisted event for
-// this gid before locked_at. The very first thing every client does on
-// join is emit updateDisplayName, which is persisted and indexed on
-// (gid, uid), so this query is cheap on a hot index.
-export async function wasParticipantBeforeLock(
-  gid: string,
-  identity: Identity,
-  lockedAt: Date
-): Promise<boolean> {
+// We define "participant" as having any persisted event for this gid.
+// We deliberately do NOT compare to locked_at: game_events.ts is the
+// client-supplied event.timestamp (client clock), while locked_at is
+// server NOW(). Even small clock skew (machine slightly ahead of the
+// server) would push a legitimate pre-lock event's ts past locked_at
+// and the bypass would fail. Lock is moderation, not security — being
+// permissive here doesn't materially weaken anything, and it eliminates
+// a confusing "I can play but refresh kicks me out" failure mode.
+export async function wasParticipantOfGame(gid: string, identity: Identity): Promise<boolean> {
   if (!identity.userId && !identity.dfacId) return false;
   if (identity.dfacId) {
-    const r = await pool.query(`SELECT 1 FROM game_events WHERE gid = $1 AND uid = $2 AND ts < $3 LIMIT 1`, [
+    const r = await pool.query(`SELECT 1 FROM game_events WHERE gid = $1 AND uid = $2 LIMIT 1`, [
       gid,
       identity.dfacId,
-      lockedAt,
     ]);
     if (r.rows.length > 0) return true;
   }
@@ -115,22 +107,13 @@ export async function wasParticipantBeforeLock(
     const r = await pool.query(
       `SELECT 1 FROM game_events
        WHERE gid = $1
-         AND ts < $2
-         AND (event_payload->>'verifiedUserId') = $3
+         AND (event_payload->>'verifiedUserId') = $2
        LIMIT 1`,
-      [gid, lockedAt, identity.userId]
+      [gid, identity.userId]
     );
     if (r.rows.length > 0) return true;
   }
   return false;
-}
-
-// Public accessor for the lock timestamp. Returns null if the game is
-// unlocked. Used by the join gate to decide whether to fall back to a
-// participation check.
-export async function getLockedAt(gid: string): Promise<Date | null> {
-  const state = await getModerationState(gid);
-  return state.lockedAt;
 }
 
 // Public list of kicked dfac_ids for a gid — used client-side to grey out

--- a/server/model/game_moderation.ts
+++ b/server/model/game_moderation.ts
@@ -77,6 +77,15 @@ export async function isGameLocked(gid: string): Promise<boolean> {
   return state.locked;
 }
 
+// Public list of kicked dfac_ids for a gid — used client-side to grey out
+// kicked players who left grid/chat history behind. User-id bans are kept
+// private since they identify accounts; dfac_ids are already broadcast on
+// kick and visible to every client in the room.
+export async function getKickedDfacIds(gid: string): Promise<string[]> {
+  const state = await getModerationState(gid);
+  return Array.from(state.banned.dfacIds);
+}
+
 // Owner identity is stamped onto the create event's params.creator at game
 // creation time. Games created before this feature have no creator → no
 // one can moderate them (returns null).

--- a/server/model/game_moderation.ts
+++ b/server/model/game_moderation.ts
@@ -32,8 +32,16 @@ async function loadModerationState(gid: string): Promise<ModerationState> {
       [gid]
     ),
     pool.query<{gid: string}>(`SELECT gid FROM game_locks WHERE gid = $1`, [gid]),
-    pool.query<{event_payload: any}>(
-      `SELECT event_payload FROM game_events WHERE gid = $1 AND event_type = 'create' ORDER BY ts ASC LIMIT 1`,
+    // Extract just the creator subtree from the create event's payload.
+    // Pulling the full event_payload would drag the whole bootstrap blob
+    // (grid + clues + solution) across the wire for every cache miss; the
+    // creator is the only field we actually use.
+    pool.query<{creator: {userId?: string; dfacId?: string} | null}>(
+      `SELECT event_payload->'params'->'creator' AS creator
+       FROM game_events
+       WHERE gid = $1 AND event_type = 'create'
+       ORDER BY ts ASC
+       LIMIT 1`,
       [gid]
     ),
   ]);
@@ -44,7 +52,7 @@ async function loadModerationState(gid: string): Promise<ModerationState> {
     else dfacIds.add(row.identity);
   }
   let owner: GameCreator | null = null;
-  const creatorPayload = creator.rows[0]?.event_payload?.params?.creator;
+  const creatorPayload = creator.rows[0]?.creator;
   if (creatorPayload) {
     owner = {};
     if (creatorPayload.userId) owner.userId = creatorPayload.userId;

--- a/server/model/game_moderation.ts
+++ b/server/model/game_moderation.ts
@@ -1,0 +1,119 @@
+import {pool} from './pool';
+import {TTLCache} from './ttl_cache';
+
+export type Identity = {userId?: string | null; dfacId?: string | null};
+
+// Per-gid cache so the socket fast-path doesn't hit Postgres on every event.
+// Bans and locks change rarely; 5 minutes is generous but bounded. Invalidated
+// explicitly on ban/lock/unlock writes.
+type ModerationState = {
+  banned: {userIds: Set<string>; dfacIds: Set<string>};
+  locked: boolean;
+};
+const moderationCache = new TTLCache<ModerationState>({ttlMs: 5 * 60_000, maxSize: 10_000});
+
+export function invalidateModerationCacheForGid(gid: string): void {
+  moderationCache.delete(gid);
+}
+
+export function clearModerationCache(): void {
+  moderationCache.clear();
+}
+
+async function loadModerationState(gid: string): Promise<ModerationState> {
+  const [bans, locks] = await Promise.all([
+    pool.query<{identity: string; identity_type: 'user' | 'dfac'}>(
+      `SELECT identity, identity_type FROM game_bans WHERE gid = $1`,
+      [gid]
+    ),
+    pool.query<{gid: string}>(`SELECT gid FROM game_locks WHERE gid = $1`, [gid]),
+  ]);
+  const userIds = new Set<string>();
+  const dfacIds = new Set<string>();
+  for (const row of bans.rows) {
+    if (row.identity_type === 'user') userIds.add(row.identity);
+    else dfacIds.add(row.identity);
+  }
+  return {banned: {userIds, dfacIds}, locked: locks.rows.length > 0};
+}
+
+async function getModerationState(gid: string): Promise<ModerationState> {
+  return moderationCache.getOrFetch(gid, () => loadModerationState(gid));
+}
+
+// True if either of the caller's identities is banned for this gid. The
+// socket layer calls this on every join + every persisted event, so the
+// cache matters here.
+export async function isIdentityBanned(gid: string, identity: Identity): Promise<boolean> {
+  // No identity → nothing to match against, skip the DB hit. This keeps the
+  // socket layer's per-event overhead at zero for unauthenticated callers
+  // whose client doesn't send a dfac_id either (legacy clients, tests).
+  if (!identity.userId && !identity.dfacId) return false;
+  const state = await getModerationState(gid);
+  if (identity.userId && state.banned.userIds.has(identity.userId)) return true;
+  if (identity.dfacId && state.banned.dfacIds.has(identity.dfacId)) return true;
+  return false;
+}
+
+export async function isGameLocked(gid: string): Promise<boolean> {
+  const state = await getModerationState(gid);
+  return state.locked;
+}
+
+export type GameCreator = {userId?: string; dfacId?: string};
+
+// Owner identity is stamped onto the create event's params.creator at game
+// creation time. Games created before this feature have no creator → no
+// one can moderate them (returns null).
+export async function getGameOwner(gid: string): Promise<GameCreator | null> {
+  const {rows} = await pool.query<{event_payload: any}>(
+    `SELECT event_payload FROM game_events WHERE gid = $1 AND event_type = 'create' ORDER BY ts ASC LIMIT 1`,
+    [gid]
+  );
+  if (rows.length === 0) return null;
+  const creator = rows[0].event_payload?.params?.creator;
+  if (!creator) return null;
+  const owner: GameCreator = {};
+  if (creator.userId) owner.userId = creator.userId;
+  if (creator.dfacId) owner.dfacId = creator.dfacId;
+  return Object.keys(owner).length > 0 ? owner : null;
+}
+
+export function isOwner(
+  owner: GameCreator | null,
+  caller: {userId?: string | null; dfacIds?: string[]}
+): boolean {
+  if (!owner) return false;
+  if (owner.userId && caller.userId && owner.userId === caller.userId) return true;
+  if (owner.dfacId && caller.dfacIds && caller.dfacIds.includes(owner.dfacId)) return true;
+  return false;
+}
+
+export async function addGameBan(
+  gid: string,
+  target: {identity: string; identityType: 'user' | 'dfac'},
+  bannedByUserId: string
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO game_bans (gid, identity, identity_type, banned_by_user_id)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (gid, identity, identity_type) DO NOTHING`,
+    [gid, target.identity, target.identityType, bannedByUserId]
+  );
+  invalidateModerationCacheForGid(gid);
+}
+
+export async function lockGame(gid: string, by: Identity): Promise<void> {
+  await pool.query(
+    `INSERT INTO game_locks (gid, locked_by_user_id, locked_by_dfac_id)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (gid) DO NOTHING`,
+    [gid, by.userId || null, by.dfacId || null]
+  );
+  invalidateModerationCacheForGid(gid);
+}
+
+export async function unlockGame(gid: string): Promise<void> {
+  await pool.query(`DELETE FROM game_locks WHERE gid = $1`, [gid]);
+  invalidateModerationCacheForGid(gid);
+}

--- a/server/model/game_moderation.ts
+++ b/server/model/game_moderation.ts
@@ -13,6 +13,7 @@ export type GameCreator = {userId?: string; dfacId?: string};
 type ModerationState = {
   banned: {userIds: Set<string>; dfacIds: Set<string>};
   locked: boolean;
+  lockedAt: Date | null;
   owner: GameCreator | null;
 };
 const moderationCache = new TTLCache<ModerationState>({ttlMs: 5 * 60_000, maxSize: 10_000});
@@ -31,7 +32,7 @@ async function loadModerationState(gid: string): Promise<ModerationState> {
       `SELECT identity, identity_type FROM game_bans WHERE gid = $1`,
       [gid]
     ),
-    pool.query<{gid: string}>(`SELECT gid FROM game_locks WHERE gid = $1`, [gid]),
+    pool.query<{locked_at: Date}>(`SELECT locked_at FROM game_locks WHERE gid = $1`, [gid]),
     pool.query<{event_payload: any}>(
       `SELECT event_payload FROM game_events WHERE gid = $1 AND event_type = 'create' ORDER BY ts ASC LIMIT 1`,
       [gid]
@@ -51,7 +52,13 @@ async function loadModerationState(gid: string): Promise<ModerationState> {
     if (creatorPayload.dfacId) owner.dfacId = creatorPayload.dfacId;
     if (Object.keys(owner).length === 0) owner = null;
   }
-  return {banned: {userIds, dfacIds}, locked: locks.rows.length > 0, owner};
+  const lockRow = locks.rows[0];
+  return {
+    banned: {userIds, dfacIds},
+    locked: !!lockRow,
+    lockedAt: lockRow?.locked_at ?? null,
+    owner,
+  };
 }
 
 async function getModerationState(gid: string): Promise<ModerationState> {
@@ -75,6 +82,55 @@ export async function isIdentityBanned(gid: string, identity: Identity): Promise
 export async function isGameLocked(gid: string): Promise<boolean> {
   const state = await getModerationState(gid);
   return state.locked;
+}
+
+// Pre-lock participants get an owner-equivalent bypass on the lock gate
+// so they survive transient reconnects: the moderation contract is
+// "lock blocks new joins; existing players keep playing". Without this,
+// any mobile/flaky reconnect would re-issue join_game on a locked game
+// and the client would treat the rejection as terminal.
+//
+// We define "participant before lock" as having any persisted event for
+// this gid before locked_at. The very first thing every client does on
+// join is emit updateDisplayName, which is persisted and indexed on
+// (gid, uid), so this query is cheap on a hot index.
+export async function wasParticipantBeforeLock(
+  gid: string,
+  identity: Identity,
+  lockedAt: Date
+): Promise<boolean> {
+  if (!identity.userId && !identity.dfacId) return false;
+  if (identity.dfacId) {
+    const r = await pool.query(`SELECT 1 FROM game_events WHERE gid = $1 AND uid = $2 AND ts < $3 LIMIT 1`, [
+      gid,
+      identity.dfacId,
+      lockedAt,
+    ]);
+    if (r.rows.length > 0) return true;
+  }
+  if (identity.userId) {
+    // verifiedUserId is server-stamped on every persisted event from
+    // authenticated sockets, so a logged-in user with a different local
+    // dfac id on reconnect still gets recognized as a prior participant.
+    const r = await pool.query(
+      `SELECT 1 FROM game_events
+       WHERE gid = $1
+         AND ts < $2
+         AND (event_payload->>'verifiedUserId') = $3
+       LIMIT 1`,
+      [gid, lockedAt, identity.userId]
+    );
+    if (r.rows.length > 0) return true;
+  }
+  return false;
+}
+
+// Public accessor for the lock timestamp. Returns null if the game is
+// unlocked. Used by the join gate to decide whether to fall back to a
+// participation check.
+export async function getLockedAt(gid: string): Promise<Date | null> {
+  const state = await getModerationState(gid);
+  return state.lockedAt;
 }
 
 // Public list of kicked dfac_ids for a gid — used client-side to grey out

--- a/server/model/game_moderation.ts
+++ b/server/model/game_moderation.ts
@@ -3,12 +3,17 @@ import {TTLCache} from './ttl_cache';
 
 export type Identity = {userId?: string | null; dfacId?: string | null};
 
+export type GameCreator = {userId?: string; dfacId?: string};
+
 // Per-gid cache so the socket fast-path doesn't hit Postgres on every event.
-// Bans and locks change rarely; 5 minutes is generous but bounded. Invalidated
-// explicitly on ban/lock/unlock writes.
+// Bans, locks, and ownership change rarely; 5 minutes is generous but
+// bounded. Invalidated explicitly on ban/lock/unlock writes. Ownership
+// itself is immutable but we still recompute it on cache miss for code
+// simplicity — the create event lookup is a single PK probe.
 type ModerationState = {
   banned: {userIds: Set<string>; dfacIds: Set<string>};
   locked: boolean;
+  owner: GameCreator | null;
 };
 const moderationCache = new TTLCache<ModerationState>({ttlMs: 5 * 60_000, maxSize: 10_000});
 
@@ -21,12 +26,16 @@ export function clearModerationCache(): void {
 }
 
 async function loadModerationState(gid: string): Promise<ModerationState> {
-  const [bans, locks] = await Promise.all([
+  const [bans, locks, creator] = await Promise.all([
     pool.query<{identity: string; identity_type: 'user' | 'dfac'}>(
       `SELECT identity, identity_type FROM game_bans WHERE gid = $1`,
       [gid]
     ),
     pool.query<{gid: string}>(`SELECT gid FROM game_locks WHERE gid = $1`, [gid]),
+    pool.query<{event_payload: any}>(
+      `SELECT event_payload FROM game_events WHERE gid = $1 AND event_type = 'create' ORDER BY ts ASC LIMIT 1`,
+      [gid]
+    ),
   ]);
   const userIds = new Set<string>();
   const dfacIds = new Set<string>();
@@ -34,7 +43,15 @@ async function loadModerationState(gid: string): Promise<ModerationState> {
     if (row.identity_type === 'user') userIds.add(row.identity);
     else dfacIds.add(row.identity);
   }
-  return {banned: {userIds, dfacIds}, locked: locks.rows.length > 0};
+  let owner: GameCreator | null = null;
+  const creatorPayload = creator.rows[0]?.event_payload?.params?.creator;
+  if (creatorPayload) {
+    owner = {};
+    if (creatorPayload.userId) owner.userId = creatorPayload.userId;
+    if (creatorPayload.dfacId) owner.dfacId = creatorPayload.dfacId;
+    if (Object.keys(owner).length === 0) owner = null;
+  }
+  return {banned: {userIds, dfacIds}, locked: locks.rows.length > 0, owner};
 }
 
 async function getModerationState(gid: string): Promise<ModerationState> {
@@ -60,23 +77,12 @@ export async function isGameLocked(gid: string): Promise<boolean> {
   return state.locked;
 }
 
-export type GameCreator = {userId?: string; dfacId?: string};
-
 // Owner identity is stamped onto the create event's params.creator at game
 // creation time. Games created before this feature have no creator → no
 // one can moderate them (returns null).
 export async function getGameOwner(gid: string): Promise<GameCreator | null> {
-  const {rows} = await pool.query<{event_payload: any}>(
-    `SELECT event_payload FROM game_events WHERE gid = $1 AND event_type = 'create' ORDER BY ts ASC LIMIT 1`,
-    [gid]
-  );
-  if (rows.length === 0) return null;
-  const creator = rows[0].event_payload?.params?.creator;
-  if (!creator) return null;
-  const owner: GameCreator = {};
-  if (creator.userId) owner.userId = creator.userId;
-  if (creator.dfacId) owner.dfacId = creator.dfacId;
-  return Object.keys(owner).length > 0 ? owner : null;
+  const state = await getModerationState(gid);
+  return state.owner;
 }
 
 export function isOwner(

--- a/server/model/game_moderation.ts
+++ b/server/model/game_moderation.ts
@@ -157,6 +157,34 @@ export async function addGameBan(
   invalidateModerationCacheForGid(gid);
 }
 
+// Lift a ban — owner reversed a kick. Removes both the dfac and user
+// rows so the target's other devices (linked via user_identity_map) also
+// regain access. Caller is expected to supply both identities when known.
+export async function removeGameBan(
+  gid: string,
+  target: {dfacId?: string | null; userId?: string | null}
+): Promise<void> {
+  const removals: Promise<unknown>[] = [];
+  if (target.dfacId) {
+    removals.push(
+      pool.query(`DELETE FROM game_bans WHERE gid = $1 AND identity = $2 AND identity_type = 'dfac'`, [
+        gid,
+        target.dfacId,
+      ])
+    );
+  }
+  if (target.userId) {
+    removals.push(
+      pool.query(`DELETE FROM game_bans WHERE gid = $1 AND identity = $2 AND identity_type = 'user'`, [
+        gid,
+        target.userId,
+      ])
+    );
+  }
+  await Promise.all(removals);
+  invalidateModerationCacheForGid(gid);
+}
+
 export async function lockGame(gid: string, by: Identity): Promise<void> {
   await pool.query(
     `INSERT INTO game_locks (gid, locked_by_user_id, locked_by_dfac_id)

--- a/server/server.ts
+++ b/server/server.ts
@@ -12,6 +12,7 @@ import _ from 'lodash';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import SocketManager from './SocketManager';
+import {setSocketIo} from './socket_instance';
 import apiRouter from './api/router';
 import {swaggerSpec} from './swagger';
 import passport from './auth/passport';
@@ -110,6 +111,7 @@ function logAllEvents(log: typeof console.log) {
 // ================== Main Entrypoint ================
 
 async function runServer() {
+  setSocketIo(io);
   const socketManager = new SocketManager(io);
   socketManager.listen();
   logAllEvents(console.log);

--- a/server/socket_instance.ts
+++ b/server/socket_instance.ts
@@ -1,0 +1,17 @@
+import type {Server} from 'socket.io';
+
+// Lazy holder for the Socket.IO Server instance. server.ts wires the real
+// Server in via setSocketIo() after construction; API handlers that need to
+// emit (e.g. kick → broadcast 'kicked' to the room) read it through
+// getSocketIo(). The API router is registered before the Socket.IO server is
+// constructed in server.ts, so we can't just import a constant.
+
+let io: Server | null = null;
+
+export function setSocketIo(server: Server): void {
+  io = server;
+}
+
+export function getSocketIo(): Server | null {
+  return io;
+}

--- a/server/sql/alter_add_game_moderation.sql
+++ b/server/sql/alter_add_game_moderation.sql
@@ -1,0 +1,5 @@
+-- Add game moderation tables. Run on existing databases before deploying
+-- the code. Additive only; old code ignores the new tables.
+
+\ir create_game_bans.sql
+\ir create_game_locks.sql

--- a/server/sql/create_fresh_db.sql
+++ b/server/sql/create_fresh_db.sql
@@ -84,3 +84,13 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 -- 13. puzzle_ratings (depends on puzzles + users)
 -- ============================================================
 \ir create_puzzle_ratings.sql
+
+-- ============================================================
+-- 14. game_bans (depends on users)
+-- ============================================================
+\ir create_game_bans.sql
+
+-- ============================================================
+-- 15. game_locks (depends on users)
+-- ============================================================
+\ir create_game_locks.sql

--- a/server/sql/create_game_bans.sql
+++ b/server/sql/create_game_bans.sql
@@ -17,10 +17,10 @@ CREATE TABLE IF NOT EXISTS game_bans (
   PRIMARY KEY (gid, identity, identity_type)
 );
 
--- Bans are typically queried "is this identity banned for this gid?" and
--- "list bans for this gid". The PK covers the first; this index covers
--- the second.
-CREATE INDEX IF NOT EXISTS game_bans_gid_idx ON game_bans (gid);
+-- Both "is this identity banned for this gid?" and "list bans for this
+-- gid" are covered by the PK index on (gid, identity, identity_type) —
+-- Postgres uses the leading column for gid-only filters. No standalone
+-- gid index needed.
 
 ALTER TABLE public.game_bans OWNER to dfacadmin;
 GRANT ALL ON TABLE public.game_bans TO dfacadmin;

--- a/server/sql/create_game_bans.sql
+++ b/server/sql/create_game_bans.sql
@@ -1,0 +1,26 @@
+-- psql < create_game_bans.sql
+--
+-- Per-game bans applied by the game owner. A "ban" is keyed on
+-- (gid, identity, identity_type) — identity is either a user UUID or a
+-- guest dfac_id; the type discriminates so a user_id ban and a dfac_id
+-- ban with the same string can't collide. Both row types can coexist
+-- for the same person (e.g. owner bans the dfac_id while the user is a
+-- guest, then the user later signs in — the dfac_id ban still applies
+-- because it's keyed on the dfac_id, not the user_id).
+
+CREATE TABLE IF NOT EXISTS game_bans (
+  gid text NOT NULL,
+  identity text NOT NULL,
+  identity_type text NOT NULL CHECK (identity_type IN ('user', 'dfac')),
+  banned_by_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+  banned_at timestamptz NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (gid, identity, identity_type)
+);
+
+-- Bans are typically queried "is this identity banned for this gid?" and
+-- "list bans for this gid". The PK covers the first; this index covers
+-- the second.
+CREATE INDEX IF NOT EXISTS game_bans_gid_idx ON game_bans (gid);
+
+ALTER TABLE public.game_bans OWNER to dfacadmin;
+GRANT ALL ON TABLE public.game_bans TO dfacadmin;

--- a/server/sql/create_game_locks.sql
+++ b/server/sql/create_game_locks.sql
@@ -1,0 +1,15 @@
+-- psql < create_game_locks.sql
+--
+-- Owner-toggleable lock that blocks all new joins to a game. Presence of
+-- a row = locked; absence = unlocked. Toggling is INSERT / DELETE; no
+-- boolean column to mutate.
+
+CREATE TABLE IF NOT EXISTS game_locks (
+  gid text PRIMARY KEY,
+  locked_by_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+  locked_by_dfac_id text,
+  locked_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.game_locks OWNER to dfacadmin;
+GRANT ALL ON TABLE public.game_locks TO dfacadmin;

--- a/src/api/create_game.ts
+++ b/src/api/create_game.ts
@@ -79,6 +79,7 @@ export async function unlockGame(gid: string, accessToken: string): Promise<bool
 export interface GameModerationState {
   locked: boolean;
   owner: {userId?: string; dfacId?: string} | null;
+  kickedDfacIds: string[];
 }
 
 export async function fetchGameModeration(gid: string): Promise<GameModerationState | null> {

--- a/src/api/create_game.ts
+++ b/src/api/create_game.ts
@@ -80,10 +80,20 @@ export interface GameModerationState {
   locked: boolean;
   owner: {userId?: string; dfacId?: string} | null;
   kickedDfacIds: string[];
+  // Server-resolved against the caller's bearer token (false for guests).
+  // The client can't compute this itself for the cross-device case where
+  // a user created the game as a guest on another device and the dfac id
+  // in the create event is one of their linked-but-not-local ids.
+  isOwner: boolean;
 }
 
-export async function fetchGameModeration(gid: string): Promise<GameModerationState | null> {
-  const resp = await fetch(`${SERVER_URL}/api/game/${gid}/moderation`);
+export async function fetchGameModeration(
+  gid: string,
+  accessToken?: string | null
+): Promise<GameModerationState | null> {
+  const headers: Record<string, string> = {};
+  if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+  const resp = await fetch(`${SERVER_URL}/api/game/${gid}/moderation`, {headers});
   if (!resp.ok) return null;
   return resp.json();
 }

--- a/src/api/create_game.ts
+++ b/src/api/create_game.ts
@@ -2,13 +2,16 @@ import * as Sentry from '@sentry/react';
 import {CreateGameRequest, CreateGameResponse} from '../shared/types';
 import {SERVER_URL} from './constants';
 
-export async function createGame(data: CreateGameRequest): Promise<CreateGameResponse> {
+export async function createGame(
+  data: CreateGameRequest,
+  accessToken?: string | null
+): Promise<CreateGameResponse> {
   const url = `${SERVER_URL}/api/game`;
+  const headers: Record<string, string> = {'Content-Type': 'application/json'};
+  if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
   const resp = await fetch(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers,
     body: JSON.stringify(data),
   });
   if (!resp.ok) {
@@ -39,4 +42,47 @@ export async function undismissGame(gid: string, accessToken: string): Promise<v
     method: 'POST',
     headers: {Authorization: `Bearer ${accessToken}`},
   });
+}
+
+export async function kickPlayer(
+  gid: string,
+  target: {dfac_id?: string; user_id?: string},
+  accessToken: string
+): Promise<boolean> {
+  const resp = await fetch(`${SERVER_URL}/api/game/${gid}/kick`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(target),
+  });
+  return resp.ok;
+}
+
+export async function lockGame(gid: string, accessToken: string): Promise<boolean> {
+  const resp = await fetch(`${SERVER_URL}/api/game/${gid}/lock`, {
+    method: 'POST',
+    headers: {Authorization: `Bearer ${accessToken}`},
+  });
+  return resp.ok;
+}
+
+export async function unlockGame(gid: string, accessToken: string): Promise<boolean> {
+  const resp = await fetch(`${SERVER_URL}/api/game/${gid}/unlock`, {
+    method: 'POST',
+    headers: {Authorization: `Bearer ${accessToken}`},
+  });
+  return resp.ok;
+}
+
+export interface GameModerationState {
+  locked: boolean;
+  owner: {userId?: string; dfacId?: string} | null;
+}
+
+export async function fetchGameModeration(gid: string): Promise<GameModerationState | null> {
+  const resp = await fetch(`${SERVER_URL}/api/game/${gid}/moderation`);
+  if (!resp.ok) return null;
+  return resp.json();
 }

--- a/src/api/create_game.ts
+++ b/src/api/create_game.ts
@@ -60,6 +60,22 @@ export async function kickPlayer(
   return resp.ok;
 }
 
+export async function unkickPlayer(
+  gid: string,
+  target: {dfac_id?: string; user_id?: string},
+  accessToken: string
+): Promise<boolean> {
+  const resp = await fetch(`${SERVER_URL}/api/game/${gid}/unkick`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(target),
+  });
+  return resp.ok;
+}
+
 export async function lockGame(gid: string, accessToken: string): Promise<boolean> {
   const resp = await fetch(`${SERVER_URL}/api/game/${gid}/lock`, {
     method: 'POST',

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -287,15 +287,15 @@ export default class Chat extends Component {
     );
   }
 
-  static renderUserPresent(id, displayName, color, kickHandler) {
-    const style = color && {
-      color,
-    };
+  static renderUserPresent(id, displayName, color, kickHandler, kicked) {
+    // Kicked users keep their entry for attribution but render greyed out
+    // with no live dot and no kick button (already gone).
+    const style = kicked ? {opacity: 0.45, textDecoration: 'line-through'} : color && {color};
     return (
-      <span key={id} style={style}>
-        <span className="dot">{'\u25CF'}</span>
+      <span key={id} style={style} title={kicked ? `${displayName} (kicked)` : undefined}>
+        {!kicked && <span className="dot">{'\u25CF'}</span>}
         {displayName}
-        {kickHandler && (
+        {kickHandler && !kicked && (
           <button
             type="button"
             className="chat--user--kick-btn"
@@ -303,26 +303,50 @@ export default class Chat extends Component {
             onClick={kickHandler}
             title={`Kick ${displayName}`}
           >
-            \u00D7
+            {'\u00D7'}
           </button>
         )}{' '}
       </span>
     );
   }
 
+  // Kicked players are hidden from the presence list unless they left grid
+  // or chat activity behind \u2014 in which case we keep them visible (greyed
+  // out) so other players can still see who placed each letter / sent each
+  // chat message.
+  hasUserActivity(id) {
+    const messages = this.props.data?.messages || [];
+    if (messages.some((m) => m.senderId === id)) return true;
+    const grid = this.props.game?.grid;
+    if (Array.isArray(grid)) {
+      for (const row of grid) {
+        if (!Array.isArray(row)) continue;
+        for (const cell of row) {
+          if (cell && cell.user_id === id) return true;
+        }
+      }
+    }
+    return false;
+  }
+
   renderUsersPresent(users) {
     if (this.props.hideChatBar) return null;
     const showKick = this.canModerate;
+    const kickedSet = new Set(this.props.kickedDfacIds || []);
     return (
       <div className="chat--users--present">
-        {Object.keys(users).map((id) =>
-          Chat.renderUserPresent(
-            id,
-            users[id].displayName,
-            users[id].color,
-            showKick && id !== this.props.id ? this.handleKickClick : null
-          )
-        )}
+        {Object.keys(users)
+          .filter((id) => !kickedSet.has(id) || this.hasUserActivity(id))
+          .map((id) => {
+            const kicked = kickedSet.has(id);
+            return Chat.renderUserPresent(
+              id,
+              users[id].displayName,
+              users[id].color,
+              showKick && !kicked && id !== this.props.id ? this.handleKickClick : null,
+              kicked
+            );
+          })}
       </div>
     );
   }

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -38,6 +38,11 @@ export default class Chat extends Component {
   }
 
   get isOwner() {
+    // Server-resolved when the user is signed in (covers the cross-device
+    // case where the local dfac_id differs from creator.dfacId but the
+    // creator dfac is linked to the authed account). Falls back to local
+    // identity comparison for the same-device guest case.
+    if (this.props.isOwnerFromServer) return true;
     const creator = this.props.game?.creator;
     if (!creator) return false;
     const userId = this.context?.user?.id;

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -5,6 +5,7 @@ import Linkify from 'linkify-react';
 import {Link} from 'react-router';
 import {MdClose} from 'react-icons/md';
 import {FaClone} from 'react-icons/fa6';
+import * as Sentry from '@sentry/react';
 import Emoji from '../common/Emoji';
 import * as emojiLib from '../../lib/emoji';
 import nameGenerator, {isFromNameGenerator} from '../../lib/nameGenerator';
@@ -14,6 +15,9 @@ import ColorPicker from './ColorPicker.tsx';
 import {formatMilliseconds} from '../Toolbar/Clock';
 import RatingWidget from '../Game/RatingWidget';
 import PuzzleStatsLine from '../Game/PuzzleStatsLine';
+import OwnerControls from './OwnerControls';
+import AuthContext from '../../lib/AuthContext';
+import {kickPlayer} from '../../api/create_game';
 
 const isEmojis = (str) => {
   const res = str.match(/[A-Za-z,.0-9!-]/g);
@@ -21,6 +25,8 @@ const isEmojis = (str) => {
 };
 
 export default class Chat extends Component {
+  static contextType = AuthContext;
+
   constructor() {
     super();
     // We'll set the username state when we mount the component.
@@ -30,6 +36,29 @@ export default class Chat extends Component {
     this.chatBar = React.createRef();
     this.usernameInput = React.createRef();
   }
+
+  get isOwner() {
+    const creator = this.props.game?.creator;
+    if (!creator) return false;
+    const userId = this.context?.user?.id;
+    if (creator.userId && userId && creator.userId === userId) return true;
+    if (creator.dfacId && this.props.id && creator.dfacId === this.props.id) return true;
+    return false;
+  }
+
+  handleKickClick = async (event) => {
+    const targetDfacId = event.currentTarget.dataset.dfacId;
+    if (!targetDfacId) return;
+    const accessToken = this.context?.accessToken;
+    if (!accessToken) return;
+    if (targetDfacId === this.props.id) return;
+    if (!window.confirm('Kick this player? They will be removed from the game and cannot rejoin.')) return;
+    try {
+      await kickPlayer(this.props.gid, {dfac_id: targetDfacId}, accessToken);
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+  };
 
   componentDidMount() {
     const username = this.props.initialUsername;
@@ -225,6 +254,7 @@ export default class Chat extends Component {
         )}
         {pid && <PuzzleStatsLine pid={String(pid)} />}
         {pid && <RatingWidget pid={String(pid)} />}
+        {this.isOwner && this.props.gid && <OwnerControls gid={this.props.gid} />}
         {this.renderFencingOptions()}
       </div>
     );
@@ -248,22 +278,42 @@ export default class Chat extends Component {
     );
   }
 
-  static renderUserPresent(id, displayName, color) {
+  static renderUserPresent(id, displayName, color, kickHandler) {
     const style = color && {
       color,
     };
     return (
       <span key={id} style={style}>
         <span className="dot">{'\u25CF'}</span>
-        {displayName}{' '}
+        {displayName}
+        {kickHandler && (
+          <button
+            type="button"
+            className="chat--user--kick-btn"
+            data-dfac-id={id}
+            onClick={kickHandler}
+            title={`Kick ${displayName}`}
+          >
+            \u00D7
+          </button>
+        )}{' '}
       </span>
     );
   }
 
   renderUsersPresent(users) {
-    return this.props.hideChatBar ? null : (
+    if (this.props.hideChatBar) return null;
+    const showKick = this.isOwner;
+    return (
       <div className="chat--users--present">
-        {Object.keys(users).map((id) => Chat.renderUserPresent(id, users[id].displayName, users[id].color))}
+        {Object.keys(users).map((id) =>
+          Chat.renderUserPresent(
+            id,
+            users[id].displayName,
+            users[id].color,
+            showKick && id !== this.props.id ? this.handleKickClick : null
+          )
+        )}
       </div>
     );
   }

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -18,7 +18,7 @@ import PuzzleStatsLine from '../Game/PuzzleStatsLine';
 import OwnerControls from './OwnerControls';
 import ConfirmDialog from '../common/ConfirmDialog';
 import AuthContext from '../../lib/AuthContext';
-import {kickPlayer} from '../../api/create_game';
+import {kickPlayer, unkickPlayer} from '../../api/create_game';
 
 const isEmojis = (str) => {
   const res = str.match(/[A-Za-z,.0-9!-]/g);
@@ -84,6 +84,19 @@ export default class Chat extends Component {
     if (!accessToken) return;
     try {
       await kickPlayer(this.props.gid, {dfac_id: target.dfacId}, accessToken);
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+  };
+
+  handleUnkickClick = async (event) => {
+    const targetDfacId = event.currentTarget.dataset.dfacId;
+    if (!targetDfacId) return;
+    const accessToken = this.context?.accessToken;
+    if (!accessToken) return;
+    try {
+      const ok = await unkickPlayer(this.props.gid, {dfac_id: targetDfacId}, accessToken);
+      if (ok && this.props.onUnkick) this.props.onUnkick(targetDfacId);
     } catch (err) {
       Sentry.captureException(err);
     }
@@ -307,7 +320,7 @@ export default class Chat extends Component {
     );
   }
 
-  static renderUserPresent(id, displayName, color, kickHandler, kicked, isOwner) {
+  static renderUserPresent(id, displayName, color, kickHandler, kicked, isOwner, unkickHandler) {
     // Kicked users keep their entry for attribution but render greyed out
     // with no live dot and no kick button (already gone).
     const style = kicked ? {opacity: 0.45, textDecoration: 'line-through'} : color && {color};
@@ -325,6 +338,18 @@ export default class Chat extends Component {
             title={`Kick ${displayName}`}
           >
             {'\u00D7'}
+          </button>
+        )}
+        {unkickHandler && kicked && (
+          <button
+            type="button"
+            className="chat--user--unkick-btn"
+            data-dfac-id={id}
+            onClick={unkickHandler}
+            title={`Unkick ${displayName}`}
+            aria-label={`Unkick ${displayName}`}
+          >
+            {'\u21A9'}
           </button>
         )}{' '}
       </span>
@@ -385,7 +410,8 @@ export default class Chat extends Component {
         users[id].color,
         showKick && !kicked && id !== this.props.id ? this.handleKickClick : null,
         kicked,
-        !!ownerDfacId && id === ownerDfacId
+        !!ownerDfacId && id === ownerDfacId,
+        showKick && kicked ? this.handleUnkickClick : null
       );
 
     return (

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -341,17 +341,26 @@ export default class Chat extends Component {
     const kickedSet = new Set(this.props.kickedDfacIds || []);
     const ownerDfacId = this.props.game?.creator?.dfacId || null;
 
-    // Split into players (have placed letters or sent chat) and spectators
-    // (joined and picked a name but haven't done anything yet). Kicked
-    // users with activity render in the players section (greyed); kicked
-    // users without activity are hidden entirely.
+    // Three sections: the owner gets their own slot at the top so they're
+    // always identifiable at a glance. Everyone else splits between
+    // players (have placed letters or sent chat) and spectators (joined
+    // and picked a name but haven't done anything yet). Kicked users with
+    // activity render in players (greyed for attribution); kicked users
+    // without activity are hidden entirely.
+    const owner = [];
     const players = [];
     const spectators = [];
     for (const id of Object.keys(users)) {
       const kicked = kickedSet.has(id);
       const active = this.hasUserActivity(id);
       if (kicked && !active) continue;
-      (active ? players : spectators).push({id, kicked});
+      if (ownerDfacId && id === ownerDfacId) {
+        owner.push({id, kicked});
+      } else if (active) {
+        players.push({id, kicked});
+      } else {
+        spectators.push({id, kicked});
+      }
     }
 
     const renderEntry = ({id, kicked}) =>
@@ -366,6 +375,12 @@ export default class Chat extends Component {
 
     return (
       <div className="chat--users--present">
+        {owner.length > 0 && (
+          <div className="chat--users--section">
+            <div className="chat--users--section-label">Game owner</div>
+            <div className="chat--users--section-list">{owner.map(renderEntry)}</div>
+          </div>
+        )}
         {players.length > 0 && (
           <div className="chat--users--section">
             <div className="chat--users--section-label">Players</div>

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -67,8 +67,10 @@ export default class Chat extends Component {
     if (!targetDfacId) return;
     if (!this.context?.accessToken) return;
     if (targetDfacId === this.props.id) return;
-    const displayName = this.props.users?.[targetDfacId]?.displayName || 'this player';
-    this.setState({kickTarget: {dfacId: targetDfacId, displayName}});
+    const user = this.props.users?.[targetDfacId];
+    const displayName = user?.displayName || 'this player';
+    const color = user?.color || null;
+    this.setState({kickTarget: {dfacId: targetDfacId, displayName, color}});
   };
 
   handleKickDialogChange = (open) => {
@@ -576,7 +578,19 @@ export default class Chat extends Component {
         <ConfirmDialog
           open={!!kickTarget}
           onOpenChange={this.handleKickDialogChange}
-          title={kickTarget ? `Kick ${kickTarget.displayName}?` : ''}
+          title={
+            kickTarget ? (
+              <>
+                Kick{' '}
+                <span style={kickTarget.color ? {color: kickTarget.color} : undefined}>
+                  {kickTarget.displayName}
+                </span>
+                ?
+              </>
+            ) : (
+              ''
+            )
+          }
           icon={<MdErrorOutline />}
           onConfirm={this.handleKickConfirm}
           confirmLabel="Kick"

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -46,6 +46,15 @@ export default class Chat extends Component {
     return false;
   }
 
+  // Moderation endpoints require auth (the server rejects dfac-only
+  // ownership because the creator.dfacId field is visible to anyone in
+  // the room — it would otherwise be trivially forgeable by another
+  // player). A guest owner needs to sign in to moderate. Gate the UI on
+  // this so the buttons aren't there to click in the first place.
+  get canModerate() {
+    return this.isOwner && !!this.context?.accessToken;
+  }
+
   handleKickClick = async (event) => {
     const targetDfacId = event.currentTarget.dataset.dfacId;
     if (!targetDfacId) return;
@@ -254,7 +263,7 @@ export default class Chat extends Component {
         )}
         {pid && <PuzzleStatsLine pid={String(pid)} />}
         {pid && <RatingWidget pid={String(pid)} />}
-        {this.isOwner && this.props.gid && <OwnerControls gid={this.props.gid} />}
+        {this.canModerate && this.props.gid && <OwnerControls gid={this.props.gid} />}
         {this.renderFencingOptions()}
       </div>
     );
@@ -303,7 +312,7 @@ export default class Chat extends Component {
 
   renderUsersPresent(users) {
     if (this.props.hideChatBar) return null;
-    const showKick = this.isOwner;
+    const showKick = this.canModerate;
     return (
       <div className="chat--users--present">
         {Object.keys(users).map((id) =>

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import _ from 'lodash';
 import Linkify from 'linkify-react';
 import {Link} from 'react-router';
-import {MdClose} from 'react-icons/md';
+import {MdClose, MdErrorOutline} from 'react-icons/md';
 import {FaClone, FaCrown} from 'react-icons/fa6';
 import * as Sentry from '@sentry/react';
 import Emoji from '../common/Emoji';
@@ -16,6 +16,7 @@ import {formatMilliseconds} from '../Toolbar/Clock';
 import RatingWidget from '../Game/RatingWidget';
 import PuzzleStatsLine from '../Game/PuzzleStatsLine';
 import OwnerControls from './OwnerControls';
+import ConfirmDialog from '../common/ConfirmDialog';
 import AuthContext from '../../lib/AuthContext';
 import {kickPlayer} from '../../api/create_game';
 
@@ -32,6 +33,7 @@ export default class Chat extends Component {
     // We'll set the username state when we mount the component.
     this.state = {
       username: '',
+      kickTarget: null,
     };
     this.chatBar = React.createRef();
     this.usernameInput = React.createRef();
@@ -60,15 +62,26 @@ export default class Chat extends Component {
     return this.isOwner && !!this.context?.accessToken;
   }
 
-  handleKickClick = async (event) => {
+  handleKickClick = (event) => {
     const targetDfacId = event.currentTarget.dataset.dfacId;
     if (!targetDfacId) return;
+    if (!this.context?.accessToken) return;
+    if (targetDfacId === this.props.id) return;
+    const displayName = this.props.users?.[targetDfacId]?.displayName || 'this player';
+    this.setState({kickTarget: {dfacId: targetDfacId, displayName}});
+  };
+
+  handleKickDialogChange = (open) => {
+    if (!open) this.setState({kickTarget: null});
+  };
+
+  handleKickConfirm = async () => {
+    const target = this.state.kickTarget;
+    if (!target) return;
     const accessToken = this.context?.accessToken;
     if (!accessToken) return;
-    if (targetDfacId === this.props.id) return;
-    if (!window.confirm('Kick this player? They will be removed from the game and cannot rejoin.')) return;
     try {
-      await kickPlayer(this.props.gid, {dfac_id: targetDfacId}, accessToken);
+      await kickPlayer(this.props.gid, {dfac_id: target.dfacId}, accessToken);
     } catch (err) {
       Sentry.captureException(err);
     }
@@ -556,9 +569,21 @@ export default class Chat extends Component {
 
   render() {
     const messages = Chat.mergeMessages(this.props.data, this.props.opponentData);
+    const {kickTarget} = this.state;
     return (
       <div className="flex--column flex--grow">
         {this.renderToolbar()}
+        <ConfirmDialog
+          open={!!kickTarget}
+          onOpenChange={this.handleKickDialogChange}
+          title={kickTarget ? `Kick ${kickTarget.displayName}?` : ''}
+          icon={<MdErrorOutline />}
+          onConfirm={this.handleKickConfirm}
+          confirmLabel="Kick"
+          danger
+        >
+          <p>They will be removed from the game and cannot rejoin.</p>
+        </ConfirmDialog>
         <div className="chat">
           {this.renderChatHeader()}
           {this.renderChatSubheader()}

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import Linkify from 'linkify-react';
 import {Link} from 'react-router';
 import {MdClose} from 'react-icons/md';
-import {FaClone} from 'react-icons/fa6';
+import {FaClone, FaCrown} from 'react-icons/fa6';
 import * as Sentry from '@sentry/react';
 import Emoji from '../common/Emoji';
 import * as emojiLib from '../../lib/emoji';
@@ -292,13 +292,14 @@ export default class Chat extends Component {
     );
   }
 
-  static renderUserPresent(id, displayName, color, kickHandler, kicked) {
+  static renderUserPresent(id, displayName, color, kickHandler, kicked, isOwner) {
     // Kicked users keep their entry for attribution but render greyed out
     // with no live dot and no kick button (already gone).
     const style = kicked ? {opacity: 0.45, textDecoration: 'line-through'} : color && {color};
     return (
       <span key={id} style={style} title={kicked ? `${displayName} (kicked)` : undefined}>
         {!kicked && <span className="dot">{'\u25CF'}</span>}
+        {isOwner && <FaCrown className="chat--user--owner-icon" title="Game owner" aria-label="Game owner" />}
         {displayName}
         {kickHandler && !kicked && (
           <button
@@ -338,20 +339,45 @@ export default class Chat extends Component {
     if (this.props.hideChatBar) return null;
     const showKick = this.canModerate;
     const kickedSet = new Set(this.props.kickedDfacIds || []);
+    const ownerDfacId = this.props.game?.creator?.dfacId || null;
+
+    // Split into players (have placed letters or sent chat) and spectators
+    // (joined and picked a name but haven't done anything yet). Kicked
+    // users with activity render in the players section (greyed); kicked
+    // users without activity are hidden entirely.
+    const players = [];
+    const spectators = [];
+    for (const id of Object.keys(users)) {
+      const kicked = kickedSet.has(id);
+      const active = this.hasUserActivity(id);
+      if (kicked && !active) continue;
+      (active ? players : spectators).push({id, kicked});
+    }
+
+    const renderEntry = ({id, kicked}) =>
+      Chat.renderUserPresent(
+        id,
+        users[id].displayName,
+        users[id].color,
+        showKick && !kicked && id !== this.props.id ? this.handleKickClick : null,
+        kicked,
+        !!ownerDfacId && id === ownerDfacId
+      );
+
     return (
       <div className="chat--users--present">
-        {Object.keys(users)
-          .filter((id) => !kickedSet.has(id) || this.hasUserActivity(id))
-          .map((id) => {
-            const kicked = kickedSet.has(id);
-            return Chat.renderUserPresent(
-              id,
-              users[id].displayName,
-              users[id].color,
-              showKick && !kicked && id !== this.props.id ? this.handleKickClick : null,
-              kicked
-            );
-          })}
+        {players.length > 0 && (
+          <div className="chat--users--section">
+            <div className="chat--users--section-label">Players</div>
+            <div className="chat--users--section-list">{players.map(renderEntry)}</div>
+          </div>
+        )}
+        {spectators.length > 0 && (
+          <div className="chat--users--section">
+            <div className="chat--users--section-label">Spectators</div>
+            <div className="chat--users--section-list">{spectators.map(renderEntry)}</div>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import _ from 'lodash';
 import Linkify from 'linkify-react';
 import {Link} from 'react-router';
-import {MdClose, MdErrorOutline} from 'react-icons/md';
+import {MdClose, MdErrorOutline, MdHelpOutline} from 'react-icons/md';
 import {FaClone, FaCrown} from 'react-icons/fa6';
 import * as Sentry from '@sentry/react';
 import Emoji from '../common/Emoji';
@@ -34,6 +34,7 @@ export default class Chat extends Component {
     this.state = {
       username: '',
       kickTarget: null,
+      unkickTarget: null,
     };
     this.chatBar = React.createRef();
     this.usernameInput = React.createRef();
@@ -89,14 +90,28 @@ export default class Chat extends Component {
     }
   };
 
-  handleUnkickClick = async (event) => {
+  handleUnkickClick = (event) => {
     const targetDfacId = event.currentTarget.dataset.dfacId;
     if (!targetDfacId) return;
+    if (!this.context?.accessToken) return;
+    const user = this.props.users?.[targetDfacId];
+    const displayName = user?.displayName || 'this player';
+    const color = user?.color || null;
+    this.setState({unkickTarget: {dfacId: targetDfacId, displayName, color}});
+  };
+
+  handleUnkickDialogChange = (open) => {
+    if (!open) this.setState({unkickTarget: null});
+  };
+
+  handleUnkickConfirm = async () => {
+    const target = this.state.unkickTarget;
+    if (!target) return;
     const accessToken = this.context?.accessToken;
     if (!accessToken) return;
     try {
-      const ok = await unkickPlayer(this.props.gid, {dfac_id: targetDfacId}, accessToken);
-      if (ok && this.props.onUnkick) this.props.onUnkick(targetDfacId);
+      const ok = await unkickPlayer(this.props.gid, {dfac_id: target.dfacId}, accessToken);
+      if (ok && this.props.onUnkick) this.props.onUnkick(target.dfacId);
     } catch (err) {
       Sentry.captureException(err);
     }
@@ -597,7 +612,7 @@ export default class Chat extends Component {
 
   render() {
     const messages = Chat.mergeMessages(this.props.data, this.props.opponentData);
-    const {kickTarget} = this.state;
+    const {kickTarget, unkickTarget} = this.state;
     return (
       <div className="flex--column flex--grow">
         {this.renderToolbar()}
@@ -623,6 +638,28 @@ export default class Chat extends Component {
           danger
         >
           <p>They will be removed from the game and cannot rejoin.</p>
+        </ConfirmDialog>
+        <ConfirmDialog
+          open={!!unkickTarget}
+          onOpenChange={this.handleUnkickDialogChange}
+          title={
+            unkickTarget ? (
+              <>
+                Unkick{' '}
+                <span style={unkickTarget.color ? {color: unkickTarget.color} : undefined}>
+                  {unkickTarget.displayName}
+                </span>
+                ?
+              </>
+            ) : (
+              ''
+            )
+          }
+          icon={<MdHelpOutline />}
+          onConfirm={this.handleUnkickConfirm}
+          confirmLabel="Unkick"
+        >
+          <p>They will be allowed back into the game.</p>
         </ConfirmDialog>
         <div className="chat">
           {this.renderChatHeader()}

--- a/src/components/Chat/OwnerControls.tsx
+++ b/src/components/Chat/OwnerControls.tsx
@@ -1,0 +1,59 @@
+import {useCallback, useContext, useEffect, useState} from 'react';
+import {MdLock, MdLockOpen} from 'react-icons/md';
+import * as Sentry from '@sentry/react';
+import AuthContext from '../../lib/AuthContext';
+import {fetchGameModeration, lockGame, unlockGame} from '../../api/create_game';
+import './css/OwnerControls.css';
+
+interface Props {
+  gid: string;
+}
+
+interface AuthCtx {
+  accessToken: string | null;
+}
+
+export default function OwnerControls({gid}: Props) {
+  const {accessToken} = useContext(AuthContext) as AuthCtx;
+  const [locked, setLocked] = useState<boolean | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchGameModeration(gid).then((state) => {
+      if (cancelled || !state) return;
+      setLocked(state.locked);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [gid]);
+
+  const handleToggle = useCallback(async () => {
+    if (!accessToken || busy || locked === null) return;
+    setBusy(true);
+    try {
+      const ok = locked ? await unlockGame(gid, accessToken) : await lockGame(gid, accessToken);
+      if (ok) setLocked(!locked);
+    } catch (err) {
+      Sentry.captureException(err);
+    } finally {
+      setBusy(false);
+    }
+  }, [accessToken, busy, gid, locked]);
+
+  if (locked === null) return null;
+  const Icon = locked ? MdLock : MdLockOpen;
+  return (
+    <button
+      type="button"
+      className="owner-controls--lock-btn"
+      onClick={handleToggle}
+      disabled={busy}
+      title={locked ? 'Unlock game (allow new players to join)' : 'Lock game (block new players)'}
+    >
+      <Icon className="owner-controls--lock-icon" />
+      {locked ? 'Locked' : 'Lock game'}
+    </button>
+  );
+}

--- a/src/components/Chat/OwnerControls.tsx
+++ b/src/components/Chat/OwnerControls.tsx
@@ -1,8 +1,9 @@
 import {useCallback, useContext, useEffect, useState} from 'react';
-import {MdLock, MdLockOpen} from 'react-icons/md';
+import {MdInfoOutline, MdLock, MdLockOpen} from 'react-icons/md';
 import * as Sentry from '@sentry/react';
 import AuthContext from '../../lib/AuthContext';
 import {fetchGameModeration, lockGame, unlockGame} from '../../api/create_game';
+import InfoDialog from '../common/InfoDialog';
 import './css/OwnerControls.css';
 
 interface Props {
@@ -17,6 +18,8 @@ export default function OwnerControls({gid}: Props) {
   const {accessToken} = useContext(AuthContext) as AuthCtx;
   const [locked, setLocked] = useState<boolean | null>(null);
   const [busy, setBusy] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
+  const handleShowInfo = useCallback(() => setShowInfo(true), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -45,15 +48,37 @@ export default function OwnerControls({gid}: Props) {
   if (locked === null) return null;
   const Icon = locked ? MdLock : MdLockOpen;
   return (
-    <button
-      type="button"
-      className="owner-controls--lock-btn"
-      onClick={handleToggle}
-      disabled={busy}
-      title={locked ? 'Unlock game (allow new players to join)' : 'Lock game (block new players)'}
-    >
-      <Icon className="owner-controls--lock-icon" />
-      {locked ? 'Locked' : 'Lock game'}
-    </button>
+    <div className="owner-controls--lock-row">
+      <button
+        type="button"
+        className="owner-controls--lock-btn"
+        onClick={handleToggle}
+        disabled={busy}
+        title={locked ? 'Unlock game (allow new players to join)' : 'Lock game (block new players)'}
+      >
+        <Icon className="owner-controls--lock-icon" />
+        {locked ? 'Locked' : 'Lock game'}
+      </button>
+      <button
+        type="button"
+        className="owner-controls--info-btn"
+        onClick={handleShowInfo}
+        aria-label="What does locking do?"
+        title="What does locking do?"
+      >
+        <MdInfoOutline />
+      </button>
+      <InfoDialog open={showInfo} onOpenChange={setShowInfo} title="Locking a game" icon={<MdInfoOutline />}>
+        <p>
+          Locking prevents <strong>new</strong> players from joining. Players who are already in the game keep
+          playing.
+        </p>
+        <p>
+          Locked games still appear in lists, but anyone who tries to open one for the first time sees a
+          &ldquo;game is locked&rdquo; message instead of the puzzle.
+        </p>
+        <p>You can unlock the game at any time.</p>
+      </InfoDialog>
+    </div>
   );
 }

--- a/src/components/Chat/css/OwnerControls.css
+++ b/src/components/Chat/css/OwnerControls.css
@@ -1,8 +1,14 @@
+.owner-controls--lock-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 4px 0;
+}
+
 .owner-controls--lock-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  margin: 4px 0;
   padding: 4px 10px;
   font-size: 12px;
   background: #f5f5f5;
@@ -10,6 +16,24 @@
   border-radius: 4px;
   cursor: pointer;
   color: #333;
+}
+
+.owner-controls--info-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  font-size: 16px;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  color: #888;
+}
+
+.owner-controls--info-btn:hover {
+  color: #333;
+  background: rgb(0 0 0 / 6%);
 }
 
 .owner-controls--lock-btn:hover:not(:disabled) {
@@ -48,6 +72,15 @@
 
 .dark .owner-controls--lock-btn:hover:not(:disabled) {
   background: #333;
+}
+
+.dark .owner-controls--info-btn {
+  color: rgb(255 255 255 / 60%);
+}
+
+.dark .owner-controls--info-btn:hover {
+  color: rgb(255 255 255 / 87%);
+  background: rgb(255 255 255 / 8%);
 }
 
 .dark .chat--user--kick-btn {

--- a/src/components/Chat/css/OwnerControls.css
+++ b/src/components/Chat/css/OwnerControls.css
@@ -64,6 +64,25 @@
   background: rgb(204 51 51 / 12%);
 }
 
+.chat--user--unkick-btn {
+  margin-left: 2px;
+  padding: 0 4px;
+  font-size: 11px;
+  background: transparent;
+  border: none;
+  color: #2a7a2a;
+  cursor: pointer;
+  border-radius: 3px;
+
+  /* Keep the button readable on the greyed-out kicked entry */
+  opacity: 1;
+  text-decoration: none;
+}
+
+.chat--user--unkick-btn:hover:not(:disabled) {
+  background: rgb(42 122 42 / 12%);
+}
+
 .dark .owner-controls--lock-btn {
   background: #2a2a2a;
   border-color: rgb(255 255 255 / 12%);
@@ -89,4 +108,12 @@
 
 .dark .chat--user--kick-btn:hover:not(:disabled) {
   background: rgb(229 115 115 / 18%);
+}
+
+.dark .chat--user--unkick-btn {
+  color: #81c784;
+}
+
+.dark .chat--user--unkick-btn:hover:not(:disabled) {
+  background: rgb(129 199 132 / 18%);
 }

--- a/src/components/Chat/css/OwnerControls.css
+++ b/src/components/Chat/css/OwnerControls.css
@@ -1,0 +1,59 @@
+.owner-controls--lock-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 4px 0;
+  padding: 4px 10px;
+  font-size: 12px;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #333;
+}
+
+.owner-controls--lock-btn:hover:not(:disabled) {
+  background: #eaeaea;
+}
+
+.owner-controls--lock-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.owner-controls--lock-icon {
+  font-size: 14px;
+}
+
+.chat--user--kick-btn {
+  margin-left: 2px;
+  padding: 0 4px;
+  font-size: 11px;
+  background: transparent;
+  border: none;
+  color: #c33;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.chat--user--kick-btn:hover:not(:disabled) {
+  background: rgb(204 51 51 / 12%);
+}
+
+.dark .owner-controls--lock-btn {
+  background: #2a2a2a;
+  border-color: rgb(255 255 255 / 12%);
+  color: rgb(255 255 255 / 87%);
+}
+
+.dark .owner-controls--lock-btn:hover:not(:disabled) {
+  background: #333;
+}
+
+.dark .chat--user--kick-btn {
+  color: #e57373;
+}
+
+.dark .chat--user--kick-btn:hover:not(:disabled) {
+  background: rgb(229 115 115 / 18%);
+}

--- a/src/components/Chat/css/index.css
+++ b/src/components/Chat/css/index.css
@@ -85,13 +85,43 @@
   margin-bottom: 5px;
 }
 
-.chat--users--present > span {
+.chat--users--section {
+  margin-bottom: 4px;
+}
+
+.chat--users--section-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #888;
+  margin-left: 5px;
+  margin-bottom: 2px;
+}
+
+.chat--users--section-list > span {
   margin-left: 5px;
   margin-right: 8px;
 }
 
-.chat--users--present .dot {
+.chat--users--section-list .dot {
   padding-right: 5px;
+}
+
+.chat--user--owner-icon {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 4px;
+  color: #d4a017;
+  font-size: 12px;
+}
+
+.dark .chat--users--section-label {
+  color: rgb(255 255 255 / 50%);
+}
+
+.dark .chat--user--owner-icon {
+  color: #e6b800;
 }
 
 .chat--messages {

--- a/src/lib/reducers/game.js
+++ b/src/lib/reducers/game.js
@@ -40,7 +40,7 @@ function isSolved(game) {
 
 const reducers = {
   create: (game, params) => {
-    const {pid} = params;
+    const {pid, creator} = params;
     const {
       info = {},
       grid = [[{}]],
@@ -70,6 +70,7 @@ const reducers = {
 
     return {
       pid,
+      creator,
       info,
       grid,
       solution,

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -154,6 +154,12 @@ class Game extends Component {
     // joinRejected fires when the server refused our join because we're
     // banned or the game is locked.
     this.gameModel.on('kicked', (msg) => {
+      // initializeGame() runs on every gid change without explicitly
+      // tearing down the prior gameModel's listeners, so a 'kicked' event
+      // from the old game can fire after we've already navigated to a
+      // new one. Without this gid check, we'd forceDisconnect the new
+      // session and show the blocker for a kick that wasn't ours.
+      if (msg.gid !== this.state.gid) return;
       const myDfacId = this.userId;
       const myUserId = this.context?.user?.id;
       const isTarget = (msg.dfac_id && msg.dfac_id === myDfacId) || (msg.user_id && msg.user_id === myUserId);
@@ -177,6 +183,13 @@ class Game extends Component {
       // 'banned' or 'locked' — both render the same blocker screen, just
       // with different copy.
       this.setState({moderationError: reason});
+    });
+    this.gameModel.on('unkicked', (msg) => {
+      if (msg.gid !== this.state.gid) return;
+      if (!msg.dfac_id) return;
+      this.setState((prev) => ({
+        kickedDfacIds: prev.kickedDfacIds.filter((id) => id !== msg.dfac_id),
+      }));
     });
 
     // Defer updateDisplayName until after we confirm the game has a create

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -43,6 +43,7 @@ class Game extends Component {
       savingReplay: false,
       connectionFailed: false,
       kickedDfacIds: [],
+      isOwnerFromServer: false,
     };
     this.initializeUser();
     window.addEventListener('resize', () => {
@@ -200,11 +201,15 @@ class Game extends Component {
       gameNotFound: false,
       moderationError: undefined,
       kickedDfacIds: [],
+      isOwnerFromServer: false,
     });
-    // Seed the kicked-id list from the server. The socket 'kicked' broadcast
-    // covers kicks that happen while we're connected; this covers kicks that
-    // happened before we joined (or before a refresh).
-    this.fetchKickedDfacIds(this.state.gid);
+    // Seed kicked-id list + owner status from the server. The socket
+    // 'kicked' broadcast covers kicks that happen while we're connected;
+    // the fetch covers kicks that happened before we joined (or before a
+    // refresh). isOwner is server-resolved to handle the case where the
+    // owner's creator.dfacId is linked to the authed user but doesn't
+    // match the local dfac id (different device, same account).
+    this.fetchModerationState(this.state.gid);
     if (this._connectionTimer) clearTimeout(this._connectionTimer);
     this._connectionTimer = setTimeout(() => {
       if (!this.historyWrapper || !this.historyWrapper.ready) {
@@ -220,11 +225,15 @@ class Game extends Component {
     this.maybeUndismiss();
   }
 
-  fetchKickedDfacIds = async (gid) => {
+  fetchModerationState = async (gid) => {
     try {
-      const state = await fetchGameModeration(gid);
+      const accessToken = this.context?.accessToken;
+      const state = await fetchGameModeration(gid, accessToken);
       if (!state || this.state.gid !== gid) return;
-      this.setState({kickedDfacIds: state.kickedDfacIds || []});
+      this.setState({
+        kickedDfacIds: state.kickedDfacIds || [],
+        isOwnerFromServer: !!state.isOwner,
+      });
     } catch (e) {
       Sentry.captureException(e);
     }
@@ -252,6 +261,13 @@ class Game extends Component {
     }
     if (!this._undismissed) {
       this.maybeUndismiss();
+    }
+    // Re-fetch moderation when the user signs in/out mid-game so the
+    // server-resolved isOwner reflects the new token.
+    const token = this.context?.accessToken || null;
+    if (this._lastModerationToken !== token && this.state.gid) {
+      this._lastModerationToken = token;
+      this.fetchModerationState(this.state.gid);
     }
   }
 
@@ -483,6 +499,7 @@ class Game extends Component {
         gid={this.state.gid}
         users={this.game.users}
         kickedDfacIds={this.state.kickedDfacIds}
+        isOwnerFromServer={this.state.isOwnerFromServer}
         id={id}
         myColor={color}
         onChat={this.handleChat}

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -20,7 +20,7 @@ import getLocalId from '../localAuth';
 import {recordSolve} from '../api/puzzle.ts';
 import AuthContext from '../lib/AuthContext';
 import {SERVER_URL} from '../api/constants';
-import {undismissGame} from '../api/create_game.ts';
+import {undismissGame, fetchGameModeration} from '../api/create_game.ts';
 
 import nameGenerator from '../lib/nameGenerator';
 
@@ -42,6 +42,7 @@ class Game extends Component {
       replayRetained: null, // null = no snapshot yet, false = snapshot exists but not retained, true = retained
       savingReplay: false,
       connectionFailed: false,
+      kickedDfacIds: [],
     };
     this.initializeUser();
     window.addEventListener('resize', () => {
@@ -161,6 +162,14 @@ class Game extends Component {
         // but the room broadcasts still hit us until we disconnect.
         if (this.gameModel.forceDisconnect) this.gameModel.forceDisconnect();
         this.setState({moderationError: 'kicked'});
+      } else if (msg.dfac_id) {
+        // Track for the presence-list filter — kicked players are hidden
+        // unless they left activity behind, in which case they render as
+        // greyed out for attribution. See Chat.renderUsersPresent.
+        this.setState((prev) => {
+          if (prev.kickedDfacIds.includes(msg.dfac_id)) return null;
+          return {kickedDfacIds: [...prev.kickedDfacIds, msg.dfac_id]};
+        });
       }
     });
     this.gameModel.on('joinRejected', (reason) => {
@@ -186,7 +195,16 @@ class Game extends Component {
     // Also clear any moderation blocker carried over from a previous gid —
     // navigating to a fresh game in the same SPA session shouldn't show
     // "you were removed" once we successfully connect to the new one.
-    this.setState({connectionFailed: false, gameNotFound: false, moderationError: undefined});
+    this.setState({
+      connectionFailed: false,
+      gameNotFound: false,
+      moderationError: undefined,
+      kickedDfacIds: [],
+    });
+    // Seed the kicked-id list from the server. The socket 'kicked' broadcast
+    // covers kicks that happen while we're connected; this covers kicks that
+    // happened before we joined (or before a refresh).
+    this.fetchKickedDfacIds(this.state.gid);
     if (this._connectionTimer) clearTimeout(this._connectionTimer);
     this._connectionTimer = setTimeout(() => {
       if (!this.historyWrapper || !this.historyWrapper.ready) {
@@ -201,6 +219,16 @@ class Game extends Component {
     this.initializeGame();
     this.maybeUndismiss();
   }
+
+  fetchKickedDfacIds = async (gid) => {
+    try {
+      const state = await fetchGameModeration(gid);
+      if (!state || this.state.gid !== gid) return;
+      this.setState({kickedDfacIds: state.kickedDfacIds || []});
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  };
 
   maybeUndismiss() {
     const accessToken = this.context?.accessToken;
@@ -454,6 +482,7 @@ class Game extends Component {
         game={this.game}
         gid={this.state.gid}
         users={this.game.users}
+        kickedDfacIds={this.state.kickedDfacIds}
         id={id}
         myColor={color}
         onChat={this.handleChat}

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -179,10 +179,14 @@ class Game extends Component {
         });
       }
     });
-    this.gameModel.on('joinRejected', (reason) => {
+    this.gameModel.on('joinRejected', (msg) => {
       // 'banned' or 'locked' — both render the same blocker screen, just
-      // with different copy.
-      this.setState({moderationError: reason});
+      // with different copy. Gate on gid for the same reason the kicked
+      // listener does: stale gameModel instances from prior gids can still
+      // emit joinRejected on reconnect, and without this check they'd
+      // incorrectly drop a blocker on the currently active game.
+      if (msg.gid !== this.state.gid) return;
+      this.setState({moderationError: msg.reason});
     });
     this.gameModel.on('unkicked', (msg) => {
       if (msg.gid !== this.state.gid) return;

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -147,6 +147,24 @@ class Game extends Component {
       this.setState({gameNotFound: true});
     });
 
+    // Owner-driven moderation events from the socket layer. The kick
+    // broadcast goes to everyone in the room; only the target acts on it.
+    // joinRejected fires when the server refused our join because we're
+    // banned or the game is locked.
+    this.gameModel.on('kicked', (msg) => {
+      const myDfacId = this.userId;
+      const myUserId = this.context?.user?.id;
+      const isTarget = (msg.dfac_id && msg.dfac_id === myDfacId) || (msg.user_id && msg.user_id === myUserId);
+      if (isTarget) {
+        this.setState({moderationError: 'kicked'});
+      }
+    });
+    this.gameModel.on('joinRejected', (reason) => {
+      // 'banned' or 'locked' — both render the same blocker screen, just
+      // with different copy.
+      this.setState({moderationError: reason});
+    });
+
     // Defer updateDisplayName until after we confirm the game has a create
     // event server-side. Emitting on mount produced orphan rows in
     // game_events for legacy gids that never had a create (#478).
@@ -490,6 +508,29 @@ class Game extends Component {
         <Helmet>
           <title>{this.getPuzzleTitle()}</title>
         </Helmet>
+        {this.state.moderationError && (
+          <div className="game-moderation-blocker">
+            <div className="game-moderation-blocker--card">
+              <h2>
+                {this.state.moderationError === 'kicked'
+                  ? 'You were removed from this game'
+                  : this.state.moderationError === 'locked'
+                    ? 'This game is locked'
+                    : "You can't join this game"}
+              </h2>
+              <p>
+                {this.state.moderationError === 'kicked'
+                  ? 'The game owner removed you.'
+                  : this.state.moderationError === 'locked'
+                    ? 'The game owner closed this game to new players.'
+                    : 'The game owner has banned this account from the game.'}
+              </p>
+              <a href="/" className="btn btn--contained btn--primary">
+                Back to home
+              </a>
+            </div>
+          </div>
+        )}
         {this.state.syncWarning === 'retrying' && (
           <div
             style={{

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -330,6 +330,12 @@ class Game extends Component {
     }
   };
 
+  handleUnkick = (dfacId) => {
+    this.setState((prev) => ({
+      kickedDfacIds: prev.kickedDfacIds.filter((id) => id !== dfacId),
+    }));
+  };
+
   handleChat = (username, id, message) => {
     this.gameModel.chat(username, id, message);
   };
@@ -500,6 +506,7 @@ class Game extends Component {
         users={this.game.users}
         kickedDfacIds={this.state.kickedDfacIds}
         isOwnerFromServer={this.state.isOwnerFromServer}
+        onUnkick={this.handleUnkick}
         id={id}
         myColor={color}
         onChat={this.handleChat}

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -183,7 +183,10 @@ class Game extends Component {
     });
 
     // Show error if socket doesn't connect within 10 seconds
-    this.setState({connectionFailed: false, gameNotFound: false});
+    // Also clear any moderation blocker carried over from a previous gid —
+    // navigating to a fresh game in the same SPA session shouldn't show
+    // "you were removed" once we successfully connect to the new one.
+    this.setState({connectionFailed: false, gameNotFound: false, moderationError: undefined});
     if (this._connectionTimer) clearTimeout(this._connectionTimer);
     this._connectionTimer = setTimeout(() => {
       if (!this.historyWrapper || !this.historyWrapper.ready) {

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -156,6 +156,10 @@ class Game extends Component {
       const myUserId = this.context?.user?.id;
       const isTarget = (msg.dfac_id && msg.dfac_id === myDfacId) || (msg.user_id && msg.user_id === myUserId);
       if (isTarget) {
+        // Cut the live socket so we stop receiving updates/chat from the
+        // room. The server-side ban already blocks our outgoing events,
+        // but the room broadcasts still hit us until we disconnect.
+        if (this.gameModel.forceDisconnect) this.gameModel.forceDisconnect();
         this.setState({moderationError: 'kicked'});
       }
     });

--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -158,10 +158,11 @@ class Play extends Component {
 
   create() {
     this.setState({creating: true, error: null});
+    const accessToken = this.context?.accessToken ?? null;
     actions
       .getNextGid(async (gid) => {
         try {
-          await createGame({gid, pid: this.pid, dfac_id: getLocalId()});
+          await createGame({gid, pid: this.pid, dfac_id: getLocalId()}, accessToken);
           redirect(this.is_fencing ? `/fencing/${gid}` : `/beta/game/${gid}`);
         } catch (e) {
           console.error('Failed to create game:', e);
@@ -177,10 +178,11 @@ class Play extends Component {
 
   createFencing() {
     this.setState({creating: true, error: null});
+    const accessToken = this.context?.accessToken ?? null;
     actions
       .getNextGid(async (gid) => {
         try {
-          await createGame({gid, pid: this.pid, dfac_id: getLocalId()});
+          await createGame({gid, pid: this.pid, dfac_id: getLocalId()}, accessToken);
           redirect(`/fencing/${gid}`);
         } catch (e) {
           console.error('Failed to create fencing game:', e);

--- a/src/pages/css/game.css
+++ b/src/pages/css/game.css
@@ -8,3 +8,41 @@
     overflow: auto;
   }
 }
+
+.game-moderation-blocker {
+  position: fixed;
+  inset: 0;
+  background: rgb(0 0 0 / 60%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.game-moderation-blocker--card {
+  background: white;
+  padding: 24px 32px;
+  border-radius: 8px;
+  max-width: 420px;
+  text-align: center;
+  box-shadow: 0 4px 20px rgb(0 0 0 / 30%);
+}
+
+.game-moderation-blocker--card h2 {
+  margin: 0 0 12px;
+  font-size: 20px;
+}
+
+.game-moderation-blocker--card p {
+  margin: 0 0 20px;
+  color: #555;
+}
+
+.dark .game-moderation-blocker--card {
+  background: #1e1e1e;
+  color: rgb(255 255 255 / 87%);
+}
+
+.dark .game-moderation-blocker--card p {
+  color: rgb(255 255 255 / 60%);
+}

--- a/src/sockets/getSocket.ts
+++ b/src/sockets/getSocket.ts
@@ -2,11 +2,22 @@ import {io, Socket} from 'socket.io-client';
 import {SOCKET_HOST} from '../api/constants';
 import getLocalId from '../localAuth';
 
-let websocketPromise: Promise<Socket>;
+let websocketPromise: Promise<Socket> | undefined;
 let currentAuthToken: string | null = null;
 
 export function setSocketAuthToken(token: string | null) {
   currentAuthToken = token;
+}
+
+// Drop the cached socket promise. Used after we deliberately disconnect
+// the underlying socket (e.g. forceDisconnect on kick) so the next caller
+// gets a fresh connection instead of a dead one. Without this, subsequent
+// game sessions in the same SPA tab would reuse the disconnected socket
+// and never rejoin/sync until a full page reload.
+export function resetSocket() {
+  websocketPromise = undefined;
+  (window as any).socket = undefined;
+  (window as any).connectionStatus = undefined;
 }
 
 export const getSocket = () => {

--- a/src/sockets/getSocket.ts
+++ b/src/sockets/getSocket.ts
@@ -5,15 +5,40 @@ import getLocalId from '../localAuth';
 let websocketPromise: Promise<Socket> | undefined;
 let currentAuthToken: string | null = null;
 
+function buildAuth(): Record<string, string> {
+  const auth: Record<string, string> = {};
+  if (currentAuthToken) auth.token = currentAuthToken;
+  const dfacId = getLocalId();
+  if (dfacId) auth.dfacId = dfacId;
+  return auth;
+}
+
 export function setSocketAuthToken(token: string | null) {
+  if (currentAuthToken === token) return;
   currentAuthToken = token;
+  // The active socket's handshake.auth was sealed at io() creation time, so
+  // a guest socket keeps presenting null/old tokens even after sign-in.
+  // Mutate socket.auth in place and bounce the connection so the server-side
+  // checks that depend on socket.data.authUser (owner bypass in join_game,
+  // verifiedUserId stamping on game_event) see the new identity. We reuse
+  // the same Socket instance so GameModel's reference + 'kicked'/'connect'
+  // listeners stay attached, and the reconnect handler re-issues join_game.
+  if (websocketPromise) {
+    websocketPromise
+      .then((socket) => {
+        socket.auth = buildAuth();
+        if (socket.connected) socket.disconnect();
+        socket.connect();
+      })
+      .catch(() => {});
+  }
 }
 
 // Drop the cached socket promise. Used after we deliberately disconnect
-// the underlying socket (e.g. forceDisconnect on kick) so the next caller
-// gets a fresh connection instead of a dead one. Without this, subsequent
-// game sessions in the same SPA tab would reuse the disconnected socket
-// and never rejoin/sync until a full page reload.
+// the underlying socket (forceDisconnect on kick) so the next caller gets
+// a fresh connection instead of a dead one. Without this, subsequent game
+// sessions in the same SPA tab would reuse the disconnected socket and
+// never rejoin/sync until a full page reload.
 export function resetSocket() {
   websocketPromise = undefined;
   (window as any).socket = undefined;
@@ -26,12 +51,9 @@ export const getSocket = () => {
       // Note: In attempt to increase websocket limit, use upgrade false
       // https://stackoverflow.com/questions/15872788/maximum-concurrent-socket-io-connections
       const socketOptions: Record<string, any> = {upgrade: false, transports: ['websocket']};
-      const auth: Record<string, string> = {};
-      if (currentAuthToken) auth.token = currentAuthToken;
       // dfacId always travels — it's the guest identity. The server uses
       // both this and the JWT-derived userId for ban/lock checks.
-      const dfacId = getLocalId();
-      if (dfacId) auth.dfacId = dfacId;
+      const auth = buildAuth();
       if (Object.keys(auth).length > 0) socketOptions.auth = auth;
       const socket = io(SOCKET_HOST, socketOptions);
 

--- a/src/sockets/getSocket.ts
+++ b/src/sockets/getSocket.ts
@@ -1,5 +1,6 @@
 import {io, Socket} from 'socket.io-client';
 import {SOCKET_HOST} from '../api/constants';
+import getLocalId from '../localAuth';
 
 let websocketPromise: Promise<Socket>;
 let currentAuthToken: string | null = null;
@@ -14,9 +15,13 @@ export const getSocket = () => {
       // Note: In attempt to increase websocket limit, use upgrade false
       // https://stackoverflow.com/questions/15872788/maximum-concurrent-socket-io-connections
       const socketOptions: Record<string, any> = {upgrade: false, transports: ['websocket']};
-      if (currentAuthToken) {
-        socketOptions.auth = {token: currentAuthToken};
-      }
+      const auth: Record<string, string> = {};
+      if (currentAuthToken) auth.token = currentAuthToken;
+      // dfacId always travels — it's the guest identity. The server uses
+      // both this and the JWT-derived userId for ban/lock checks.
+      const dfacId = getLocalId();
+      if (dfacId) auth.dfacId = dfacId;
+      if (Object.keys(auth).length > 0) socketOptions.auth = auth;
       const socket = io(SOCKET_HOST, socketOptions);
 
       (window as any).socket = socket;

--- a/src/store/__tests__/game.test.js
+++ b/src/store/__tests__/game.test.js
@@ -52,7 +52,9 @@ describe('offline event queue', () => {
     const game = makeGame();
     await game.addEvent({type: 'updateCell', timestamp: 1});
 
-    expect(emitAsyncWithTimeout).toHaveBeenCalledTimes(1);
+    // 2 calls: join_game (from the implicit connectToWebsocket) + game_event
+    expect(emitAsyncWithTimeout).toHaveBeenCalledTimes(2);
+    expect(emitAsyncWithTimeout.mock.calls.some((c) => c[2] === 'game_event')).toBe(true);
     expect(localStorage.getItem('offline_queue_test-123')).toBeNull();
   });
 
@@ -157,6 +159,7 @@ describe('flushOfflineQueue', () => {
   it('sends all queued events and clears localStorage', async () => {
     const game = makeGame();
     await game.connectToWebsocket();
+    emitAsyncWithTimeout.mockClear(); // discard the implicit join_game emit
 
     // Seed the queue as if we were offline earlier
     localStorage.setItem(
@@ -212,6 +215,7 @@ describe('flushOfflineQueue', () => {
   it('does nothing when queue is empty', async () => {
     const game = makeGame();
     await game.connectToWebsocket();
+    emitAsyncWithTimeout.mockClear(); // discard the implicit join_game emit
 
     await game.flushOfflineQueue();
 
@@ -221,6 +225,7 @@ describe('flushOfflineQueue', () => {
   it('prevents concurrent flushes', async () => {
     const game = makeGame();
     await game.connectToWebsocket();
+    emitAsyncWithTimeout.mockClear(); // discard the implicit join_game emit
 
     localStorage.setItem(
       'offline_queue_test-123',
@@ -240,6 +245,7 @@ describe('flushOfflineQueue', () => {
   it('does not lose events appended during flush', async () => {
     const game = makeGame();
     await game.connectToWebsocket();
+    emitAsyncWithTimeout.mockClear(); // discard the implicit join_game emit
 
     localStorage.setItem(
       'offline_queue_test-123',

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -52,6 +52,16 @@ function saveOfflineQueue(gid, queue) {
 // a wrapper class that models Game
 
 const CURRENT_VERSION = 1.0;
+
+// Errors from join_game that should permanently fail the connection (the
+// page shows a blocker screen and doesn't retry). Anything else — most
+// notably the server's catch-all 'internal error' — is transient and should
+// fall through so the socket reconnect machinery can retry.
+const TERMINAL_JOIN_ERRORS = new Set(['banned', 'locked']);
+function isTerminalJoinError(error) {
+  return TERMINAL_JOIN_ERRORS.has(error);
+}
+
 export default class Game extends EventEmitter {
   constructor(path) {
     super();
@@ -74,13 +84,20 @@ export default class Game extends EventEmitter {
     this.socket = socket;
     const joinAck = await emitAsync(socket, 'join_game', this.gid);
     if (joinAck && joinAck.error) {
-      // Server refused (banned/locked). Mark this connection terminal and
-      // bail before subscribing — otherwise attach() would still call
-      // sync_all_game_events and the client could load full game history
-      // for a game they're not allowed in.
-      this.joinRejected = joinAck.error;
-      this.emit('joinRejected', joinAck.error);
-      return;
+      if (isTerminalJoinError(joinAck.error)) {
+        // Server refused (banned/locked). Mark this connection terminal and
+        // bail before subscribing — otherwise attach() would still call
+        // sync_all_game_events and the client could load full game history
+        // for a game they're not allowed in.
+        this.joinRejected = joinAck.error;
+        this.emit('joinRejected', joinAck.error);
+        return;
+      }
+      // Transient (e.g. 'internal error') — log and continue. The socket's
+      // own reconnect handler will re-issue join_game when the connection
+      // re-establishes; treating these as terminal would lock the user out
+      // until a full refresh.
+      console.warn('join_game returned non-terminal error:', joinAck.error);
     }
 
     socket.on('disconnect', () => {
@@ -96,14 +113,25 @@ export default class Game extends EventEmitter {
       }
     });
 
+    // And 'unkicked' when a kick is reversed, so other tabs can drop the
+    // dfac_id from their local kicked list without a full reload.
+    socket.on('unkicked', (msg) => {
+      if (msg && msg.gid === this.gid) {
+        this.emit('unkicked', msg);
+      }
+    });
+
     // handle future reconnects
     socket.on('connect', async () => {
       console.log('reconnecting...');
       const ack = await emitAsync(socket, 'join_game', this.gid);
       if (ack && ack.error) {
-        this.joinRejected = ack.error;
-        this.emit('joinRejected', ack.error);
-        return;
+        if (isTerminalJoinError(ack.error)) {
+          this.joinRejected = ack.error;
+          this.emit('joinRejected', ack.error);
+          return;
+        }
+        console.warn('join_game on reconnect returned non-terminal error:', ack.error);
       }
       console.log('reconnected...');
       this.syncState = null;

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -107,6 +107,15 @@ export default class Game extends EventEmitter {
       }
       console.log('reconnected...');
       this.syncState = null;
+      // If the initial history sync never completed (e.g. socket bounced
+      // mid-sync because the auth token resolved late and setSocketAuthToken
+      // rebuilt the handshake), do it now. Without this, the client never
+      // receives the create event and the page sits on the connection-failed
+      // timeout. Safe to call on every reconnect — syncAllGameEvents is
+      // idempotent and the game_event listener is added separately.
+      if (!this._initialSyncCompleted) {
+        await this.syncAllGameEvents();
+      }
       await this.flushOfflineQueue();
       this.emitReconnect();
     });
@@ -231,6 +240,11 @@ export default class Game extends EventEmitter {
       event = castNullsToUndefined(event);
       this.emitWSEvent(event);
     });
+    await this.syncAllGameEvents();
+  }
+
+  async syncAllGameEvents() {
+    if (!this.socket || !this.socket.connected) return;
     const response = await emitAsync(this.socket, 'sync_all_game_events', this.gid);
     // Server returns an array of events on success, or {error: ...} on failure.
     // Only process and check for gameNotFound on a valid array response.
@@ -243,6 +257,7 @@ export default class Game extends EventEmitter {
       this.emitWSEvent(event);
     });
     if (response.some((event) => event && event.type === 'create')) {
+      this._initialSyncCompleted = true;
       this.emit('gameReady');
     } else {
       this.emit('gameNotFound');

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -82,37 +82,29 @@ export default class Game extends EventEmitter {
     if (this.socket) return;
     const socket = await getSocket();
     this.socket = socket;
-    const joinAck = await emitAsync(socket, 'join_game', this.gid);
-    if (joinAck && joinAck.error) {
-      if (isTerminalJoinError(joinAck.error)) {
-        // Server refused (banned/locked). Mark this connection terminal and
-        // bail before subscribing — otherwise attach() would still call
-        // sync_all_game_events and the client could load full game history
-        // for a game they're not allowed in.
-        this.joinRejected = joinAck.error;
-        this.emit('joinRejected', joinAck.error);
-        return;
-      }
-      // Transient (e.g. 'internal error') — log and continue. The socket's
-      // own reconnect handler will re-issue join_game when the connection
-      // re-establishes; treating these as terminal would lock the user out
-      // until a full refresh.
-      console.warn('join_game returned non-terminal error:', joinAck.error);
-    }
 
+    // Attach all long-lived listeners up-front, BEFORE the initial join.
+    // socket.io preserves listeners across disconnect/connect on the same
+    // Socket instance, so this also covers the bounce-during-initial-join
+    // case: if setSocketAuthToken rebuilds the handshake while our first
+    // join_game ack is in flight, the reconnect handler below still fires
+    // on the same socket and recovers (re-joins + re-syncs). Previously
+    // these listeners were registered AFTER the join await, so a bounce
+    // during the await would leave the new transport with no listeners
+    // and the page would sit blank waiting for the create event.
     socket.on('disconnect', () => {
       console.log('received disconnect from server');
     });
-
+    socket.on('game_event', (event) => {
+      event = castNullsToUndefined(event);
+      this.emitWSEvent(event);
+    });
     // Server broadcasts 'kicked' to the room when the owner kicks a player.
-    // Forward to listeners; the page checks identity and redirects if it
-    // matches the current user.
     socket.on('kicked', (msg) => {
       if (msg && msg.gid === this.gid) {
         this.emit('kicked', msg);
       }
     });
-
     // And 'unkicked' when a kick is reversed, so other tabs can drop the
     // dfac_id from their local kicked list without a full reload.
     socket.on('unkicked', (msg) => {
@@ -120,8 +112,10 @@ export default class Game extends EventEmitter {
         this.emit('unkicked', msg);
       }
     });
-
-    // handle future reconnects
+    // Reconnect handler — fires on every future 'connect' event on this
+    // socket instance (the initial connect already fired before getSocket
+    // resolved). Re-issues join_game, re-runs initial sync if it never
+    // completed, and flushes queued events.
     socket.on('connect', async () => {
       console.log('reconnecting...');
       const ack = await emitAsync(socket, 'join_game', this.gid);
@@ -135,18 +129,33 @@ export default class Game extends EventEmitter {
       }
       console.log('reconnected...');
       this.syncState = null;
-      // If the initial history sync never completed (e.g. socket bounced
-      // mid-sync because the auth token resolved late and setSocketAuthToken
-      // rebuilt the handshake), do it now. Without this, the client never
-      // receives the create event and the page sits on the connection-failed
-      // timeout. Safe to call on every reconnect — syncAllGameEvents is
-      // idempotent and the game_event listener is added separately.
       if (!this._initialSyncCompleted) {
         await this.syncAllGameEvents();
       }
       await this.flushOfflineQueue();
       this.emitReconnect();
     });
+
+    // Initial join. Use a timeout so a mid-flight socket bounce (its ack
+    // never arrives) doesn't hang attach() forever — the reconnect handler
+    // above will re-issue join_game on its own.
+    try {
+      const joinAck = await emitAsyncWithTimeout(socket, 10000, 'join_game', this.gid);
+      if (joinAck && joinAck.error) {
+        if (isTerminalJoinError(joinAck.error)) {
+          // Server refused (banned/locked). Mark this connection terminal so
+          // attach()'s caller skips flushOfflineQueue + the initial sync.
+          this.joinRejected = joinAck.error;
+          this.emit('joinRejected', joinAck.error);
+          return;
+        }
+        console.warn('join_game returned non-terminal error:', joinAck.error);
+      }
+    } catch (e) {
+      // Ack lost mid-flight (bounce, transient network) — fall through. The
+      // reconnect handler will recover.
+      console.warn('Initial join_game ack timed out; reconnect handler will retry:', e?.message);
+    }
   }
 
   // Called when the local user is the kick target — drop the live socket
@@ -260,14 +269,11 @@ export default class Game extends EventEmitter {
   }
 
   async subscribeToWebsocketEvents() {
-    if (!this.socket || !this.socket.connected) {
-      throw new Error('Not connected to websocket');
-    }
-
-    this.socket.on('game_event', (event) => {
-      event = castNullsToUndefined(event);
-      this.emitWSEvent(event);
-    });
+    // game_event listener is now attached up-front in connectToWebsocket,
+    // so this is just the initial history sync. We let the call no-op
+    // silently if we're disconnected — the reconnect handler in
+    // connectToWebsocket will redrive sync once the socket comes back.
+    if (!this.socket || !this.socket.connected) return;
     await this.syncAllGameEvents();
   }
 

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import * as uuid from 'uuid';
 import * as colors from '../lib/colors';
 import {emitAsync, emitAsyncWithTimeout} from '../sockets/emitAsync';
-import {getSocket} from '../sockets/getSocket';
+import {getSocket, resetSocket} from '../sockets/getSocket';
 // ============ Serialize / Deserialize Helpers ========== //
 
 // Recursively walks obj and converts `null` to `undefined`
@@ -115,11 +115,15 @@ export default class Game extends EventEmitter {
   // Called when the local user is the kick target — drop the live socket
   // so they stop receiving live updates/chat even though the server-side
   // ban also blocks outgoing events. Matches the UX of being booted.
+  // Also reset the module-level socket promise: getSocket() caches the
+  // socket globally, so without this, navigating to another game in the
+  // same SPA tab would reuse the now-disconnected socket and never sync.
   forceDisconnect() {
     if (this.socket) {
       this.socket.disconnect();
       this.socket = null;
     }
+    resetSocket();
   }
 
   emitEvent(event) {

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -74,9 +74,13 @@ export default class Game extends EventEmitter {
     this.socket = socket;
     const joinAck = await emitAsync(socket, 'join_game', this.gid);
     if (joinAck && joinAck.error) {
-      // Server refused — surface to the page so it can redirect / show
-      // an explanation instead of silently sitting on an empty grid.
+      // Server refused (banned/locked). Mark this connection terminal and
+      // bail before subscribing — otherwise attach() would still call
+      // sync_all_game_events and the client could load full game history
+      // for a game they're not allowed in.
+      this.joinRejected = joinAck.error;
       this.emit('joinRejected', joinAck.error);
+      return;
     }
 
     socket.on('disconnect', () => {
@@ -97,6 +101,7 @@ export default class Game extends EventEmitter {
       console.log('reconnecting...');
       const ack = await emitAsync(socket, 'join_game', this.gid);
       if (ack && ack.error) {
+        this.joinRejected = ack.error;
         this.emit('joinRejected', ack.error);
         return;
       }
@@ -105,6 +110,16 @@ export default class Game extends EventEmitter {
       await this.flushOfflineQueue();
       this.emitReconnect();
     });
+  }
+
+  // Called when the local user is the kick target — drop the live socket
+  // so they stop receiving live updates/chat even though the server-side
+  // ban also blocks outgoing events. Matches the UX of being booted.
+  forceDisconnect() {
+    if (this.socket) {
+      this.socket.disconnect();
+      this.socket = null;
+    }
   }
 
   emitEvent(event) {
@@ -232,6 +247,9 @@ export default class Game extends EventEmitter {
 
   async attach() {
     const websocketPromise = this.connectToWebsocket().then(async () => {
+      // join_game was rejected (banned/locked). Don't flush queued events
+      // (server would reject them anyway) and don't sync history.
+      if (this.joinRejected) return;
       await this.flushOfflineQueue();
       await this.subscribeToWebsocketEvents();
     });

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -72,16 +72,34 @@ export default class Game extends EventEmitter {
     if (this.socket) return;
     const socket = await getSocket();
     this.socket = socket;
-    await emitAsync(socket, 'join_game', this.gid);
+    const joinAck = await emitAsync(socket, 'join_game', this.gid);
+    if (joinAck && joinAck.error) {
+      // Server refused — surface to the page so it can redirect / show
+      // an explanation instead of silently sitting on an empty grid.
+      this.emit('joinRejected', joinAck.error);
+    }
 
     socket.on('disconnect', () => {
       console.log('received disconnect from server');
     });
 
+    // Server broadcasts 'kicked' to the room when the owner kicks a player.
+    // Forward to listeners; the page checks identity and redirects if it
+    // matches the current user.
+    socket.on('kicked', (msg) => {
+      if (msg && msg.gid === this.gid) {
+        this.emit('kicked', msg);
+      }
+    });
+
     // handle future reconnects
     socket.on('connect', async () => {
       console.log('reconnecting...');
-      await emitAsync(socket, 'join_game', this.gid);
+      const ack = await emitAsync(socket, 'join_game', this.gid);
+      if (ack && ack.error) {
+        this.emit('joinRejected', ack.error);
+        return;
+      }
       console.log('reconnected...');
       this.syncState = null;
       await this.flushOfflineQueue();

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -122,7 +122,7 @@ export default class Game extends EventEmitter {
       if (ack && ack.error) {
         if (isTerminalJoinError(ack.error)) {
           this.joinRejected = ack.error;
-          this.emit('joinRejected', ack.error);
+          this.emit('joinRejected', {reason: ack.error, gid: this.gid});
           return;
         }
         console.warn('join_game on reconnect returned non-terminal error:', ack.error);
@@ -146,7 +146,7 @@ export default class Game extends EventEmitter {
           // Server refused (banned/locked). Mark this connection terminal so
           // attach()'s caller skips flushOfflineQueue + the initial sync.
           this.joinRejected = joinAck.error;
-          this.emit('joinRejected', joinAck.error);
+          this.emit('joinRejected', {reason: joinAck.error, gid: this.gid});
           return;
         }
         console.warn('join_game returned non-terminal error:', joinAck.error);

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -94,6 +94,13 @@ export default class Game extends EventEmitter {
     // and the page would sit blank waiting for the create event.
     socket.on('disconnect', () => {
       console.log('received disconnect from server');
+      // Force the reconnect handler to re-issue join_game before we
+      // consider ourselves in the room again. Without resetting this, a
+      // mid-session disconnect would leave _joined true and the next
+      // pushEventToWebsocket would happily send game_event onto a socket
+      // that doesn't have a room membership yet — server rejects with
+      // 'not in game' and flushOfflineQueue silently drops the event.
+      this._joined = false;
     });
     socket.on('game_event', (event) => {
       event = castNullsToUndefined(event);
@@ -125,9 +132,16 @@ export default class Game extends EventEmitter {
           this.emit('joinRejected', {reason: ack.error, gid: this.gid});
           return;
         }
-        console.warn('join_game on reconnect returned non-terminal error:', ack.error);
+        // Non-terminal (e.g. 'internal error'). The socket isn't in the
+        // room — running flushOfflineQueue here would send game_event emits
+        // that the server rejects with 'not in game', and the flush treats
+        // a non-throwing ack as success and removes events from localStorage.
+        // Skip sync/flush entirely; the next reconnect will retry join_game.
+        console.warn('join_game on reconnect returned non-terminal error, skipping sync/flush:', ack.error);
+        return;
       }
       console.log('reconnected...');
+      this._joined = true;
       this.syncState = null;
       if (!this._initialSyncCompleted) {
         await this.syncAllGameEvents();
@@ -149,11 +163,18 @@ export default class Game extends EventEmitter {
           this.emit('joinRejected', {reason: joinAck.error, gid: this.gid});
           return;
         }
+        // Non-terminal (e.g. 'internal error'). Leave _joined false so
+        // attach() skips flush/sync — flushing on a socket that isn't in
+        // the room would get every event acked with 'not in game' and
+        // flushOfflineQueue would silently drop them from localStorage.
+        // The reconnect handler will retry join_game.
         console.warn('join_game returned non-terminal error:', joinAck.error);
+        return;
       }
+      this._joined = true;
     } catch (e) {
-      // Ack lost mid-flight (bounce, transient network) — fall through. The
-      // reconnect handler will recover.
+      // Ack lost mid-flight (bounce, transient network) — leave _joined
+      // false. The reconnect handler will retry and set it then.
       console.warn('Initial join_game ack timed out; reconnect handler will retry:', e?.message);
     }
   }
@@ -210,7 +231,12 @@ export default class Game extends EventEmitter {
     const queue = loadOfflineQueue(this.gid);
     if (queue.length === 0) {
       try {
-        await this.pushEventToWebsocket(event);
+        const ack = await this.pushEventToWebsocket(event);
+        // Server rejection (e.g. 'not in game') resolves the Promise — don't
+        // mistake it for success and lose the event. Fall through to queue.
+        if (ack && ack.error) {
+          throw new Error(`server rejected event: ${ack.error}`);
+        }
         this.setSyncState(null);
         return;
       } catch {
@@ -239,7 +265,15 @@ export default class Game extends EventEmitter {
 
         const event = queue[0];
         try {
-          await this.pushEventToWebsocket(event);
+          const ack = await this.pushEventToWebsocket(event);
+          // The server sends {error: ...} on rejection (e.g. 'not in game'
+          // from the room-membership gate, 'banned', 'unknown game'). Treat
+          // those as failures and keep the event in the queue — without
+          // this check the resolved Promise would be mistaken for success
+          // and the event would silently drop from localStorage.
+          if (ack && ack.error) {
+            throw new Error(`server rejected event: ${ack.error}`);
+          }
           // Re-load to avoid overwriting events added concurrently by addEvent
           const currentQueue = loadOfflineQueue(this.gid);
           if (currentQueue.length > 0 && currentQueue[0].id === event.id) {
@@ -303,6 +337,11 @@ export default class Game extends EventEmitter {
       // join_game was rejected (banned/locked). Don't flush queued events
       // (server would reject them anyway) and don't sync history.
       if (this.joinRejected) return;
+      // Non-terminal join failure (transient/timeout). Skip flush+sync —
+      // the server rejects game_event from sockets not in the room and
+      // flushOfflineQueue would treat each rejection as success, silently
+      // dropping queued events. The reconnect handler will retry.
+      if (!this._joined) return;
       await this.flushOfflineQueue();
       await this.subscribeToWebsocketEvents();
     });


### PR DESCRIPTION
## Summary

Adds the moderation tools requested in Discord: a game owner can now kick disruptive players and lock the game so new players can't join. Triggered by a report where someone joined a multiplayer puzzle and started typing slurs, and the creator had no recourse.

## What you get

- **Owner = creator.** The create event now carries \`params.creator: {userId, dfacId}\`. Games created before this feature have no creator and are ownerless (no kick available) — accepted limitation, documented in code.
- **Kick.** Owner clicks \`×\` next to a player in the chat presence list. Server inserts a row into \`game_bans\` (keyed on identity+type), broadcasts a \`kicked\` socket event, and the target's client renders a full-screen "you were removed" blocker.
- **Lock.** Owner toggles a lock from the chat header. Lock = a row in \`game_locks\`. With the game locked, \`join_game\` returns \`{error: 'locked'}\` for non-owners; the owner can always rejoin.
- **Server-enforced.** Both ban and lock are checked on every \`join_game\` and persisted \`game_event\`. Banned identities are silently rejected (including ephemeral cursor/ping events — kicked users shouldn't keep appearing in the live presence view).

## Files of note

| Layer | File |
| - | - |
| Schema | \`server/sql/create_game_bans.sql\`, \`create_game_locks.sql\`, \`alter_add_game_moderation.sql\` |
| Model | \`server/model/game_moderation.ts\` |
| API | \`server/api/game.ts\` (POST \`/kick\`, \`/lock\`, \`/unlock\`; GET \`/moderation\`) |
| Socket | \`server/SocketManager.ts\`, \`server/socket_instance.ts\` |
| Frontend | \`src/components/Chat/OwnerControls.tsx\`, \`Chat.js\`, \`src/pages/Game.js\` blocker, \`src/sockets/getSocket.ts\` |

## Deploy order

1. Apply \`server/sql/alter_add_game_moderation.sql\` on prod (additive — old code ignores the new tables).
2. Deploy.

## Test plan

- [x] \`pnpm test:server --ci\` — 261 pass (includes new \`game_moderation.test.ts\`, 16 cases)
- [x] \`pnpm test\` — 385 pass
- [x] \`pnpm tsc --noEmit\` server + frontend clean
- [x] \`pnpm eslint --max-warnings 0\`, \`pnpm stylelint\`, \`pnpm prettier --check\` clean
- [x] \`pnpm build\` succeeds
- [ ] Browser smoke: didn't run — local backend port was busy (likely your dev). Worth a manual pass before merge: create a game while signed in, open a second tab as a guest who joins via the share link, kick from the owner tab, verify guest gets the blocker. Then lock and verify a third tab can't join.

## Known follow-ups (out of scope)

- 5-min IP soft-block at kick time. Lock-game covers the main evasion case (incognito reopen → still can't join a locked game) so this can wait.
- Owner transfer if creator leaves permanently.
- Unban / lock-state UI for the owner to manage. Currently lock state is shown but ban list isn't queryable from the UI.
- Postgres-backed integration tests (#512) would catch socket-handler bugs better than the current mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)