### PR TITLE
Surface 'Sign in to manage your game' CTA for guest owners

### DIFF
--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -311,7 +311,7 @@ export default class Chat extends Component {
         )}
         {pid && <PuzzleStatsLine pid={String(pid)} />}
         {pid && <RatingWidget pid={String(pid)} />}
-        {this.canModerate && this.props.gid && <OwnerControls gid={this.props.gid} />}
+        {this.isOwner && this.props.gid && <OwnerControls gid={this.props.gid} />}
         {this.renderFencingOptions()}
       </div>
     );

--- a/src/components/Chat/OwnerControls.tsx
+++ b/src/components/Chat/OwnerControls.tsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react';
 import AuthContext from '../../lib/AuthContext';
 import {fetchGameModeration, lockGame, unlockGame} from '../../api/create_game';
 import InfoDialog from '../common/InfoDialog';
+import LoginModal from '../Auth/LoginModal';
 import './css/OwnerControls.css';
 
 interface Props {
@@ -19,7 +20,10 @@ export default function OwnerControls({gid}: Props) {
   const [locked, setLocked] = useState<boolean | null>(null);
   const [busy, setBusy] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
+  const [showLogin, setShowLogin] = useState(false);
   const handleShowInfo = useCallback(() => setShowInfo(true), []);
+  const handleShowLogin = useCallback(() => setShowLogin(true), []);
+  const handleCloseLogin = useCallback(() => setShowLogin(false), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -47,17 +51,36 @@ export default function OwnerControls({gid}: Props) {
 
   if (locked === null) return null;
   const Icon = locked ? MdLock : MdLockOpen;
+  // Guest-owner state: keep the button in place so the layout doesn't
+  // shift after sign-in, but route the click to LoginModal and explain
+  // why it's disabled. The lock/kick endpoints reject dfac-only ownership
+  // anyway (creator.dfacId is forgeable from the create event), so this
+  // is just surfacing the actual requirement.
+  const signedOut = !accessToken;
+  let buttonTitle: string;
+  let buttonLabel: string;
+  if (signedOut) {
+    buttonTitle = 'Sign in to manage your game';
+    buttonLabel = 'Sign in to manage your game';
+  } else if (locked) {
+    buttonTitle = 'Unlock game (allow new players to join)';
+    buttonLabel = 'Locked';
+  } else {
+    buttonTitle = 'Lock game (block new players)';
+    buttonLabel = 'Lock game';
+  }
   return (
     <div className="owner-controls--lock-row">
       <button
         type="button"
         className="owner-controls--lock-btn"
-        onClick={handleToggle}
+        onClick={signedOut ? handleShowLogin : handleToggle}
         disabled={busy}
-        title={locked ? 'Unlock game (allow new players to join)' : 'Lock game (block new players)'}
+        aria-disabled={signedOut || undefined}
+        title={buttonTitle}
       >
         <Icon className="owner-controls--lock-icon" />
-        {locked ? 'Locked' : 'Lock game'}
+        {buttonLabel}
       </button>
       <button
         type="button"
@@ -79,6 +102,7 @@ export default function OwnerControls({gid}: Props) {
         </p>
         <p>You can unlock the game at any time.</p>
       </InfoDialog>
+      {signedOut && <LoginModal open={showLogin} onClose={handleCloseLogin} />}
     </div>
   );
 }

--- a/src/components/Chat/OwnerControls.tsx
+++ b/src/components/Chat/OwnerControls.tsx
@@ -49,14 +49,18 @@ export default function OwnerControls({gid}: Props) {
     }
   }, [accessToken, busy, gid, locked]);
 
-  if (locked === null) return null;
-  const Icon = locked ? MdLock : MdLockOpen;
   // Guest-owner state: keep the button in place so the layout doesn't
   // shift after sign-in, but route the click to LoginModal and explain
   // why it's disabled. The lock/kick endpoints reject dfac-only ownership
   // anyway (creator.dfacId is forgeable from the create event), so this
   // is just surfacing the actual requirement.
   const signedOut = !accessToken;
+  // Signed-in: wait for the moderation fetch so the icon/label reflects
+  // real lock state. Signed-out: render the CTA immediately — the lock
+  // state isn't actionable until they sign in anyway, so blocking on the
+  // fetch just delays the affordance.
+  if (locked === null && !signedOut) return null;
+  const Icon = locked === true ? MdLock : MdLockOpen;
   let buttonTitle: string;
   let buttonLabel: string;
   if (signedOut) {

--- a/src/components/Chat/css/OwnerControls.css
+++ b/src/components/Chat/css/OwnerControls.css
@@ -45,15 +45,31 @@
   cursor: not-allowed;
 }
 
-/* Guest-owner state: rendered as a real button (click opens LoginModal)
-   but visually muted so it reads as a CTA rather than an active control. */
+/* Guest-owner state: click opens LoginModal. Restyled as an outlined CTA
+   to match the sibling "Sign in to rate" button (.rating-widget--cta) —
+   the muted+italic look made it read as disabled instead of clickable. */
 .owner-controls--lock-btn[aria-disabled='true'] {
-  opacity: 0.65;
-  font-style: italic;
+  background: none;
+  border-color: #888;
+  color: #555;
 }
 
 .owner-controls--lock-btn[aria-disabled='true']:hover {
-  opacity: 0.85;
+  background: #f0f0f0;
+  border-color: #555;
+  color: #222;
+}
+
+.dark .owner-controls--lock-btn[aria-disabled='true'] {
+  background: none;
+  border-color: rgb(255 255 255 / 40%);
+  color: rgb(255 255 255 / 80%);
+}
+
+.dark .owner-controls--lock-btn[aria-disabled='true']:hover {
+  background: rgb(255 255 255 / 5%);
+  border-color: rgb(255 255 255 / 70%);
+  color: rgb(255 255 255 / 95%);
 }
 
 .owner-controls--lock-icon {

--- a/src/components/Chat/css/OwnerControls.css
+++ b/src/components/Chat/css/OwnerControls.css
@@ -45,6 +45,17 @@
   cursor: not-allowed;
 }
 
+/* Guest-owner state: rendered as a real button (click opens LoginModal)
+   but visually muted so it reads as a CTA rather than an active control. */
+.owner-controls--lock-btn[aria-disabled='true'] {
+  opacity: 0.65;
+  font-style: italic;
+}
+
+.owner-controls--lock-btn[aria-disabled='true']:hover {
+  opacity: 0.85;
+}
+
 .owner-controls--lock-icon {
   font-size: 14px;
 }


### PR DESCRIPTION
## Summary

Two follow-ups on top of #519 (already merged). Both UX polish.

- Guest creators of a game now see a CTA in place of the lock button — clicking it opens the existing `LoginModal`. After successful sign-in the button flips to the active `Lock game` state without a reload. Layout slot stays stable across the transition so nothing jumps.
- Signed-out lock button restyled to match the adjacent `Sign in to rate` button (outlined CTA, not muted/italic) so the two `Sign in to X` affordances read as the same kind of thing. Dark mode covered.

## Test plan

- [ ] Sign out, create a new game → see "Sign in to manage your game" button in chat panel header
- [ ] Click → LoginModal opens
- [ ] Sign in → button flips to "Lock game" (signed-in active state)
- [ ] Confirm visual match with "Sign in to rate" in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)