### PR TITLE
Return user to their game after Google sign-in

### DIFF
--- a/src/components/Auth/GoogleCallback.js
+++ b/src/components/Auth/GoogleCallback.js
@@ -28,18 +28,17 @@ export default function GoogleCallback() {
     (async () => {
       try {
         const user = await getMe(token);
-        if (user) {
-          await handleLoginSuccess({accessToken: token, user});
-        } else {
+        if (!user) {
           setError('Failed to retrieve user info');
+          return;
         }
-      } catch (_e) {
-        setError('Authentication failed');
-      } finally {
+        await handleLoginSuccess({accessToken: token, user});
         // Return the user to wherever they kicked off the OAuth flow from
         // (set in LoginModal.handleGoogleLogin). Falls back to '/' if it
         // wasn't set or got mangled. Only same-origin relative paths are
         // accepted so this can't be hijacked into an open-redirect.
+        // Navigation only fires on success — leaving it in `finally`
+        // unmounted the page mid-error and the user never saw why.
         let returnTo = '/';
         try {
           const stored = sessionStorage.getItem('post_login_return_to');
@@ -51,6 +50,8 @@ export default function GoogleCallback() {
           // sessionStorage unavailable
         }
         navigate(returnTo, {replace: true});
+      } catch (_e) {
+        setError('Authentication failed');
       }
     })();
   }, [location.search, handleLoginSuccess, navigate]);

--- a/src/components/Auth/GoogleCallback.js
+++ b/src/components/Auth/GoogleCallback.js
@@ -36,7 +36,21 @@ export default function GoogleCallback() {
       } catch (_e) {
         setError('Authentication failed');
       } finally {
-        navigate('/', {replace: true});
+        // Return the user to wherever they kicked off the OAuth flow from
+        // (set in LoginModal.handleGoogleLogin). Falls back to '/' if it
+        // wasn't set or got mangled. Only same-origin relative paths are
+        // accepted so this can't be hijacked into an open-redirect.
+        let returnTo = '/';
+        try {
+          const stored = sessionStorage.getItem('post_login_return_to');
+          sessionStorage.removeItem('post_login_return_to');
+          if (stored && stored.startsWith('/') && !stored.startsWith('//')) {
+            returnTo = stored;
+          }
+        } catch {
+          // sessionStorage unavailable
+        }
+        navigate(returnTo, {replace: true});
       }
     })();
   }, [location.search, handleLoginSuccess, navigate]);

--- a/src/components/Auth/LoginModal.js
+++ b/src/components/Auth/LoginModal.js
@@ -70,7 +70,9 @@ export default function LoginModal({open, onClose}) {
     // after the OAuth roundtrip. Without this, every Google sign-in ends
     // up at the homepage — bad UX when signing in mid-game.
     try {
-      const here = window.location.pathname + window.location.search;
+      // Include hash too so routers that use it (or in-page anchor state)
+      // survive the round-trip — pathname + search alone would strip it.
+      const here = window.location.pathname + window.location.search + window.location.hash;
       sessionStorage.setItem('post_login_return_to', here);
     } catch {
       // sessionStorage unavailable — fall back to default homepage redirect

--- a/src/components/Auth/LoginModal.js
+++ b/src/components/Auth/LoginModal.js
@@ -66,6 +66,15 @@ export default function LoginModal({open, onClose}) {
   );
 
   const handleGoogleLogin = useCallback(() => {
+    // Stash the current path so GoogleCallback can return the user here
+    // after the OAuth roundtrip. Without this, every Google sign-in ends
+    // up at the homepage — bad UX when signing in mid-game.
+    try {
+      const here = window.location.pathname + window.location.search;
+      sessionStorage.setItem('post_login_return_to', here);
+    } catch {
+      // sessionStorage unavailable — fall back to default homepage redirect
+    }
     window.location.href = getGoogleAuthUrl();
   }, []);
 


### PR DESCRIPTION
## Summary

`GoogleCallback` was unconditionally `navigate('/')` after a successful OAuth roundtrip, so anyone clicking *Sign in with Google* from inside a game landed on the homepage and had to navigate back. Now `LoginModal` stashes the current path in `sessionStorage` just before redirecting to Google, and `GoogleCallback` reads it back to navigate there instead.

Email/password sign-in already kept the user in place (the modal just closes) — only the Google flow was broken because it leaves the SPA.

Same-origin check on the stored value (must start with `/` and not `//`) keeps the obvious open-redirect path closed.

## Test plan

- [ ] Open a game while signed out, click `Sign in to manage your game`, choose `Sign in with Google` → after OAuth, end up back on the same game (not homepage)
- [ ] Same flow with `Sign in to rate` from the rating widget on a puzzle/game page
- [ ] Sign in with email/password from the same spot → still closes modal in-place, no redirect
- [ ] Open a game, manually navigate to `/auth/google/callback?token=fake` (no stashed path) → falls back to homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)