### PR TITLE
Drop aria-disabled from sign-in CTA (a11y)

### DIFF
--- a/src/components/Chat/OwnerControls.tsx
+++ b/src/components/Chat/OwnerControls.tsx
@@ -77,10 +77,9 @@ export default function OwnerControls({gid}: Props) {
     <div className="owner-controls--lock-row">
       <button
         type="button"
-        className="owner-controls--lock-btn"
+        className={`owner-controls--lock-btn${signedOut ? ' owner-controls--lock-btn-signin' : ''}`}
         onClick={signedOut ? handleShowLogin : handleToggle}
         disabled={busy}
-        aria-disabled={signedOut || undefined}
         title={buttonTitle}
       >
         <Icon className="owner-controls--lock-icon" />

--- a/src/components/Chat/css/OwnerControls.css
+++ b/src/components/Chat/css/OwnerControls.css
@@ -49,26 +49,31 @@
    to match the sibling "Sign in to rate" button (.rating-widget--cta) —
    the muted+italic look made it read as disabled instead of clickable.
    Plain class (not aria-disabled) since the button is fully interactive
-   and assistive tech should announce it as such. */
-.owner-controls--lock-btn-signin {
+   and assistive tech should announce it as such.
+
+   Compound selector (.owner-controls--lock-btn AND -signin) bumps these
+   above the later .dark .owner-controls--lock-btn block (defined further
+   down with the same specificity) — otherwise source order wins and the
+   outlined-CTA look reverts to the standard filled button in dark mode. */
+.owner-controls--lock-btn.owner-controls--lock-btn-signin {
   background: none;
   border-color: #888;
   color: #555;
 }
 
-.owner-controls--lock-btn-signin:hover {
+.owner-controls--lock-btn.owner-controls--lock-btn-signin:hover {
   background: #f0f0f0;
   border-color: #555;
   color: #222;
 }
 
-.dark .owner-controls--lock-btn-signin {
+.dark .owner-controls--lock-btn.owner-controls--lock-btn-signin {
   background: none;
   border-color: rgb(255 255 255 / 40%);
   color: rgb(255 255 255 / 80%);
 }
 
-.dark .owner-controls--lock-btn-signin:hover {
+.dark .owner-controls--lock-btn.owner-controls--lock-btn-signin:hover {
   background: rgb(255 255 255 / 5%);
   border-color: rgb(255 255 255 / 70%);
   color: rgb(255 255 255 / 95%);

--- a/src/components/Chat/css/OwnerControls.css
+++ b/src/components/Chat/css/OwnerControls.css
@@ -47,26 +47,28 @@
 
 /* Guest-owner state: click opens LoginModal. Restyled as an outlined CTA
    to match the sibling "Sign in to rate" button (.rating-widget--cta) —
-   the muted+italic look made it read as disabled instead of clickable. */
-.owner-controls--lock-btn[aria-disabled='true'] {
+   the muted+italic look made it read as disabled instead of clickable.
+   Plain class (not aria-disabled) since the button is fully interactive
+   and assistive tech should announce it as such. */
+.owner-controls--lock-btn-signin {
   background: none;
   border-color: #888;
   color: #555;
 }
 
-.owner-controls--lock-btn[aria-disabled='true']:hover {
+.owner-controls--lock-btn-signin:hover {
   background: #f0f0f0;
   border-color: #555;
   color: #222;
 }
 
-.dark .owner-controls--lock-btn[aria-disabled='true'] {
+.dark .owner-controls--lock-btn-signin {
   background: none;
   border-color: rgb(255 255 255 / 40%);
   color: rgb(255 255 255 / 80%);
 }
 
-.dark .owner-controls--lock-btn[aria-disabled='true']:hover {
+.dark .owner-controls--lock-btn-signin:hover {
   background: rgb(255 255 255 / 5%);
   border-color: rgb(255 255 255 / 70%);
   color: rgb(255 255 255 / 95%);


### PR DESCRIPTION
## Summary

Codex P2 from #524 that didn't make it into the merge — the follow-up commit landed on the branch after the merge was completed.

The signed-out lock button uses `aria-disabled="true"` as a CSS styling hook, but assistive tech announces such controls as unavailable. The button is fully interactive (opens `LoginModal`), so keyboard / screen-reader users would be told *Sign in to manage your game* isn't actionable and might never trigger it.

Switch to a plain modifier class (`.owner-controls--lock-btn-signin`) and key the CTA styling off that. Same visual result, correct semantics.

## Test plan

- [ ] Open a game while signed out → see "Sign in to manage your game" rendered as an outlined CTA
- [ ] Inspect element → no `aria-disabled` on the button, class includes `owner-controls--lock-btn-signin`
- [ ] Screen reader announces the button as a regular button, not as disabled
- [ ] Click still opens `LoginModal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)