### PR TITLE
Add emoji font fallbacks to global font stack

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3,6 +3,10 @@ html {
   width: 100%;
 }
 
+/* Append platform emoji fonts to the fallback chain so emoji codepoints in
+   clue text (e.g. ⬛⬛⬛ for the "Come Full Circle" Sunday NYT, #526) route
+   to the right system font. Without these, Firefox in particular fails to
+   reach the OS emoji font on its own and renders tofu / .notdef glyphs. */
 html,
 body,
 input,
@@ -13,14 +17,18 @@ input,
   flex: 1;
   min-height: 0;
   margin: 0;
-  font-family: 'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, sans-serif;
+  font-family:
+    'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
   -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
 }
 
 button {
   margin: 0;
-  font-family: 'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, sans-serif;
+  font-family:
+    'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
 }
 
 @media only screen and (width <= 768px) {

--- a/src/style.css
+++ b/src/style.css
@@ -3,10 +3,6 @@ html {
   width: 100%;
 }
 
-/* Append platform emoji fonts to the fallback chain so emoji codepoints in
-   clue text (e.g. ⬛⬛⬛ for the "Come Full Circle" Sunday NYT, #526) route
-   to the right system font. Without these, Firefox in particular fails to
-   reach the OS emoji font on its own and renders tofu / .notdef glyphs. */
 html,
 body,
 input,
@@ -17,18 +13,14 @@ input,
   flex: 1;
   min-height: 0;
   margin: 0;
-  font-family:
-    'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
+  font-family: var(--app-font-family);
   -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
 }
 
 button {
   margin: 0;
-  font-family:
-    'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
+  font-family: var(--app-font-family);
 }
 
 @media only screen and (width <= 768px) {
@@ -52,6 +44,15 @@ button {
   --main-green-1: rgb(31 255 61 / 30%);
   --main-green-2: rgb(31 255 61 / 100%);
   --pencil-color: #888; /* must be 3 or 6 digit hex */
+
+  /* Append platform emoji fonts to the fallback chain so emoji codepoints
+     in clue text (e.g. ⬛⬛⬛ for the "Come Full Circle" Sunday NYT, #526)
+     route to the right system font. Without these, Firefox in particular
+     fails to reach the OS emoji font on its own and renders tofu /
+     .notdef glyphs. */
+  --app-font-family:
+    'avenir next', avenir, nunito, 'helvetica neue', helvetica, arial, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
 }
 
 #unlisted-row {


### PR DESCRIPTION
## Summary

Fixes #526.

The global font stack was text-only (`'avenir next', avenir, Nunito, 'helvetica neue', Helvetica, arial, sans-serif`). Browsers don't always reach their built-in emoji fallback when the cascade explicitly terminates in `sans-serif` — Firefox is the notable offender — so emoji codepoints in clue text (the *Come Full Circle* Sunday NYT has 65D as three `⬛⬛⬛` U+2B1B emoji) render as tofu / `.notdef` glyphs for some users.

Confirmed reports:
- Firefox 150.0.3 / Win10 — `#[?]#[?]#[?]`
- Safari / macOS — three tofu squares
- iOS Safari — `#[?]#[?]#[?]` (original report)

Mine and many others render fine because our font matching does reach the system emoji font without prompting. Adding the standard platform emoji fonts as explicit fallbacks ensures Firefox + everyone else lands in the right place.

## Approach

Append the four standard platform emoji fonts (`Apple Color Emoji`, `Segoe UI Emoji`, `Segoe UI Symbol`, `Noto Color Emoji`) to the font-family chain on the two places it's declared (`.router-wrapper` group and `button`). Browser per-character font matching keeps using avenir/etc. for regular text and only routes emoji codepoints to the emoji fonts.

No bundle size impact — these all ship with their respective OSes, just naming them.

Doesn't help systems whose OS emoji font is itself missing the codepoint (very old iOS), but that's a webfont-shipping conversation if it ever comes up again.

## Test plan

- [ ] Open puzzle 100007942 *Come Full Circle* in Firefox on Windows — 65D should render as ⬛⬛⬛ glyphs, not tofu
- [ ] Same in Safari macOS
- [ ] Same in iOS Safari
- [ ] No regression in regular clue rendering on the systems that already worked

🤖 Generated with [Claude Code](https://claude.com/claude-code)