### PR TITLE
Stop stringifying full socket event payloads in logAllEvents (fixes OOM)

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -8,7 +8,6 @@ import cookieParser from 'cookie-parser';
 import path from 'path';
 import http from 'http';
 import {Server} from 'socket.io';
-import _ from 'lodash';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import SocketManager from './SocketManager';
@@ -99,12 +98,17 @@ app.use((err: any, req: express.Request, res: express.Response, _next: express.N
 // ================== Logging ================
 
 function logAllEvents(log: typeof console.log) {
-  io.on('*', (event: any, ...args: any) => {
-    try {
-      log(`[${event}]`, _.truncate(JSON.stringify(args), {length: 100}));
-    } catch (_e) {
-      log(`[${event}]`, args);
-    }
+  // Log the event name only. The previous version called
+  // JSON.stringify(args) before truncating to 100 chars — but the
+  // intermediate full string was 50+ KB for events like `create`
+  // (whole grid + clues + solution embedded), and under load those
+  // intermediate strings piled up in the heap and forced V8 to flatten
+  // cons-strings on stdout writes. Net result was steady heap growth and
+  // periodic OOM crashes once the heap hit max-old-space-size. We don't
+  // actually need the payload here — just knowing which events fire is
+  // enough for the diagnostic this logging exists for.
+  io.on('*', (event: any) => {
+    log(`[${event}]`);
   });
 }
 


### PR DESCRIPTION
## Summary

Diagnoses and fixes the prod OOM crashes that started May 16. Prod has `--max-old-space-size=400` (a 400 MB V8 heap on a 2 GB container), and the heap was being eaten by intermediate JSON strings from the wildcard event logger.

### Symptom

Two crash modes observed:
- Slow heap accumulation over ~9 hours, OOM at the 400 MB ceiling. Mark-Compact reclaims `414.0 → 413.1 MB` — live references, not garbage.
- Occasional fresh-boot crashes ~26 seconds in.

Stack trace ends in `String::SlowFlatten` + `String::Utf8Length` (both internals of `console.log` writing a giant string to stdout).

### Root cause

[server.ts:101](server/server.ts#L101) `logAllEvents` was:

```ts
io.on('*', (event, ...args) => {
  log(`[${event}]`, _.truncate(JSON.stringify(args), {length: 100}));
});
```

`JSON.stringify(args)` runs *before* the truncate. For events like `create` (which embed the entire grid + clues + solution payload), that intermediate string is 50+ KB. Under load (Sunday NYT 21×21 puzzles, many concurrent joins/syncs) the intermediate strings stack up faster than V8 reclaims them.

The May 16 crash onset matches the Sunday May 10 NYT (*Come Full Circle*, 21×21) reaching peak weekly traffic — more concurrent `create` events with bigger payloads = faster cons-string churn = faster ceiling hit.

### Fix

Replace with just the event name. The previous version truncated to 100 chars anyway — the payload contents were never useful in the log line. Drops a lodash import that's no longer needed.

After this, the wildcard handler does no allocation beyond a template literal.

### Recommended Render env change (separate from this PR)

`NODE_OPTIONS=--max-old-space-size=400` should be raised on the 2 GB plan. Conventional sweet spot is `--max-old-space-size=1536` — leaves ~500 MB for ts-node + native code + buffers. This isn't strictly needed for the immediate fix (the leak source is gone), but the current cap is unreasonably tight and a second issue would hit it just as fast.

## Test plan

- [ ] Deploy and confirm `[event_name]` lines still appear in Render logs (no payloads)
- [ ] Monitor heap memory over ~24 hours — should plateau, not climb
- [ ] No regression in normal gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)