### PR TITLE
Lay owner-controls out horizontally with wrap

### DIFF
--- a/src/components/Chat/css/OwnerControls.css
+++ b/src/components/Chat/css/OwnerControls.css
@@ -1,14 +1,15 @@
 .owner-controls {
   display: flex;
-  flex-direction: column;
-  gap: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 6px 0;
 }
 
 .owner-controls--lock-row {
   display: flex;
   align-items: center;
   gap: 4px;
-  margin: 4px 0;
 }
 
 .owner-controls--lock-btn {


### PR DESCRIPTION
## Summary

Follow-up to #534 testing on the testing env. The lock + three restrict-action buttons in the chat sidebar were stacked vertically (4 rows total), which ate a lot of the chat panel on mobile and pushed the chat input below the fold for game owners.

Flip [\`.owner-controls\`](src/components/Chat/css/OwnerControls.css) from \`flex-direction: column\` to a wrapping flex row so the buttons flow horizontally and wrap as needed:
- **Desktop** (wide chat): roughly one row
- **Mobile** (narrow chat): two rows

Drops the per-row vertical margin since the parent \`gap\` handles spacing in both axes now.

## Before / After
*Before:* 4 stacked rows (Lock game, Restrict Check, Restrict Reveal, Restrict Reset).
*After:* horizontal flow that wraps as needed.

## Test plan
- [ ] Verify owner view on mobile (chat input visible without scroll)
- [ ] Verify owner view on desktop (no layout regression)
- [ ] Verify dark mode still looks right
- [ ] Stylelint + Prettier pass (✅ lint-staged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)