### PR TITLE
Pin ws to >=8.20.1 to clear GHSA-58qx-3vcg-4xpx

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
       "postcss": ">=8.5.10",
       "ip-address": ">=10.1.1",
       "fast-uri": ">=3.1.1",
-      "brace-expansion@5": ">=5.0.6"
+      "brace-expansion@5": ">=5.0.6",
+      "ws@8": ">=8.20.1"
     },
     "onlyBuiltDependencies": [
       "bcrypt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ overrides:
   ip-address: '>=10.1.1'
   fast-uri: '>=3.1.1'
   brace-expansion@5: '>=5.0.6'
+  ws@8: '>=8.20.1'
 
 importers:
 
@@ -6241,8 +6242,8 @@ packages:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9719,7 +9720,7 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@5.5.0)
       engine.io-parser: 5.2.3
-      ws: 8.18.3
+      ws: 8.20.1
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -9739,7 +9740,7 @@ snapshots:
       cors: 2.8.6
       debug: 4.4.3(supports-color@5.5.0)
       engine.io-parser: 5.2.3
-      ws: 8.18.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12144,7 +12145,7 @@ snapshots:
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      ws: 8.18.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -13056,7 +13057,7 @@ snapshots:
     dependencies:
       signal-exit: 4.1.0
 
-  ws@8.18.3: {}
+  ws@8.20.1: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Another flapping CI failure on a fresh advisory — \`ws\` uninitialized memory disclosure ([GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx)). Pulled in transitively via:

\`\`\`
socket.io > engine.io > ws
\`\`\`

Vulnerable: \`>=8.0.0 <8.20.1\`. Patched: \`>=8.20.1\`. Same pin pattern as #535 — scoped to \`ws@8\` so it only bumps within the 8.x line.

This is blocking #536 (and any other open PR) from going green on CI.

## Test plan
- [x] \`pnpm audit --ignore-registry-errors\` → "No known vulnerabilities found"
- [ ] CI Security Audit goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)