### PR TITLE
Reject puzzle uploads containing "[?]" placeholders

### DIFF
--- a/e2e/fixtures/suit-test-broken.ipuz
+++ b/e2e/fixtures/suit-test-broken.ipuz
@@ -1,0 +1,25 @@
+{
+  "version": "http://ipuz.org/v2",
+  "kind": ["http://ipuz.org/crossword#1"],
+  "dimensions": {"width": 3, "height": 3},
+  "title": "Suit Test (broken)",
+  "author": "tester",
+  "puzzle": [
+    [1, 2, 3],
+    [4, 0, 0],
+    [5, 0, 0]
+  ],
+  "solution": [
+    ["A", "B", "C"],
+    ["D", "E", "F"],
+    ["G", "H", "I"]
+  ],
+  "clues": {
+    "Across": [[1, "Top row"], [4, "Middle row"], [5, "Bottom row"]],
+    "Down": [
+      [1, "A[?] 9[?] 6[?] 4[?] 2[?], e.g."],
+      [2, "Middle col"],
+      [3, "Right col"]
+    ]
+  }
+}

--- a/e2e/fixtures/suit-test-clean.ipuz
+++ b/e2e/fixtures/suit-test-clean.ipuz
@@ -1,0 +1,21 @@
+{
+  "version": "http://ipuz.org/v2",
+  "kind": ["http://ipuz.org/crossword#1"],
+  "dimensions": {"width": 3, "height": 3},
+  "title": "Suit Test (clean)",
+  "author": "tester",
+  "puzzle": [
+    [1, 2, 3],
+    [4, 0, 0],
+    [5, 0, 0]
+  ],
+  "solution": [
+    ["A", "B", "C"],
+    ["D", "E", "F"],
+    ["G", "H", "I"]
+  ],
+  "clues": {
+    "Across": [[1, "Top row"], [4, "Middle row"], [5, "Bottom row"]],
+    "Down": [[1, "Left col"], [2, "Middle col"], [3, "Right col"]]
+  }
+}

--- a/e2e/tests/puzzle-upload.spec.ts
+++ b/e2e/tests/puzzle-upload.spec.ts
@@ -1,0 +1,95 @@
+import {test, expect} from '@playwright/test';
+import {readFileSync} from 'node:fs';
+import {join} from 'node:path';
+
+// Playwright loads .spec.ts files via its built-in TS loader, which emits
+// CommonJS. import.meta.url is unreliable in that mode, so resolve fixtures
+// off the project root (playwright is always invoked from there).
+const fixtureDir = join(process.cwd(), 'e2e', 'fixtures');
+
+// Each test POSTs to /api/puzzle and expects a 400 rejection from the
+// server-side validator (see server/model/puzzle.ts:findBrokenPlaceholderField).
+// Because the validator runs before any DB write, these tests are safe to
+// run against any environment — a rejection leaves no side effects.
+//
+// Note on local runs: with `pnpm start` (the default for `pnpm test:e2e`),
+// the Vite dev server proxies /api/* to the production backend. So locally
+// these tests effectively probe prod; once this PR is merged + deployed they
+// pass. For pre-merge local testing, run `pnpm devfrontend` alongside
+// `pnpm devbackend` and set BASE_URL=http://localhost:3020.
+
+// The PuzzleJson shape that POST /api/puzzle expects, with no [?] markers
+// anywhere — mirrors what iPUZtoJSON would output for the clean fixture.
+function buildCleanPuzzleJson() {
+  return {
+    info: {
+      type: 'Mini Puzzle',
+      title: 'Suit Test (clean)',
+      author: 'tester',
+      description: '',
+    },
+    grid: [
+      ['A', 'B', 'C'],
+      ['D', 'E', 'F'],
+      ['G', 'H', 'I'],
+    ],
+    clues: {
+      across: [null, 'Top row', null, null, 'Middle row', 'Bottom row'],
+      down: [null, 'Left col', 'Middle col', 'Right col'],
+    },
+    circles: [],
+    shades: [],
+  };
+}
+
+test.describe('POST /api/puzzle — broken-placeholder rejection', () => {
+  test('rejects a puzzle whose clue contains "[?]"', async ({request}) => {
+    const puzzle = buildCleanPuzzleJson();
+    puzzle.clues.down[1] = 'A[?] 9[?] 6[?] 4[?] 2[?], e.g.';
+
+    const resp = await request.post('/api/puzzle', {
+      data: {puzzle, isPublic: false},
+      failOnStatusCode: false,
+    });
+
+    expect(resp.status()).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toMatch(/clues\.down\[1\] contains "\[\?\]"/);
+  });
+
+  test('rejects a puzzle whose title contains "[?]"', async ({request}) => {
+    const puzzle = buildCleanPuzzleJson();
+    puzzle.info.title = 'Moral High Ground [?]';
+
+    const resp = await request.post('/api/puzzle', {
+      data: {puzzle, isPublic: false},
+      failOnStatusCode: false,
+    });
+
+    expect(resp.status()).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toMatch(/info\.title contains "\[\?\]"/);
+  });
+
+  test('the .ipuz fixture also rejects when converted to PuzzleJson shape', async ({request}) => {
+    // The fixture file is what a user might drag-and-drop into the upload UI.
+    // We replicate what iPUZtoJSON would produce for it (just the parts the
+    // validator scans) and confirm the same rejection path fires.
+    const ipuz = JSON.parse(readFileSync(join(fixtureDir, 'suit-test-broken.ipuz'), 'utf8'));
+    const downClueWithMarker = ipuz.clues.Down[0][1];
+    expect(downClueWithMarker).toContain('[?]'); // sanity: fixture is what we think
+
+    const puzzle = buildCleanPuzzleJson();
+    puzzle.info.title = ipuz.title;
+    puzzle.clues.down[1] = downClueWithMarker;
+
+    const resp = await request.post('/api/puzzle', {
+      data: {puzzle, isPublic: false},
+      failOnStatusCode: false,
+    });
+
+    expect(resp.status()).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toContain('[?]');
+  });
+});

--- a/e2e/tests/puzzle-upload.spec.ts
+++ b/e2e/tests/puzzle-upload.spec.ts
@@ -9,14 +9,20 @@ const fixtureDir = join(process.cwd(), 'e2e', 'fixtures');
 
 // Each test POSTs to /api/puzzle and expects a 400 rejection from the
 // server-side validator (see server/model/puzzle.ts:findBrokenPlaceholderField).
-// Because the validator runs before any DB write, these tests are safe to
-// run against any environment — a rejection leaves no side effects.
 //
-// Note on local runs: with `pnpm start` (the default for `pnpm test:e2e`),
-// the Vite dev server proxies /api/* to the production backend. So locally
-// these tests effectively probe prod; once this PR is merged + deployed they
-// pass. For pre-merge local testing, run `pnpm devfrontend` alongside
-// `pnpm devbackend` and set BASE_URL=http://localhost:3020.
+// IMPORTANT: only run when targeting an environment that has the validator
+// deployed. By default, `pnpm test:e2e` runs against http://localhost:3020
+// where Vite proxies /api/* to the *production* backend — if the validator
+// isn't deployed yet, the POST creates a real (private, anonymous) puzzle
+// row in prod. Gating to the testing env avoids that and matches how the
+// post-deploy workflow (`.github/workflows/deploy-tests.yml`) invokes us.
+const VALIDATED_BACKENDS = new Set([
+  'https://testing.crosswithfriends.com',
+  // Add 'http://localhost:3021' if you've wired up a local backend and want
+  // to run these tests against it directly.
+]);
+const baseURL = process.env.BASE_URL || '';
+const validatorDeployed = VALIDATED_BACKENDS.has(baseURL);
 
 // The PuzzleJson shape that POST /api/puzzle expects, with no [?] markers
 // anywhere — mirrors what iPUZtoJSON would output for the clean fixture.
@@ -43,6 +49,13 @@ function buildCleanPuzzleJson() {
 }
 
 test.describe('POST /api/puzzle — broken-placeholder rejection', () => {
+  test.skip(
+    !validatorDeployed,
+    `Skipped: set BASE_URL to a backend with the rejection deployed ` +
+      `(e.g. https://testing.crosswithfriends.com) to run these. By default they would hit prod via ` +
+      `the local Vite proxy and could create real rows.`
+  );
+
   test('rejects a puzzle whose clue contains "[?]"', async ({request}) => {
     const puzzle = buildCleanPuzzleJson();
     puzzle.clues.down[1] = 'A[?] 9[?] 6[?] 4[?] 2[?], e.g.';

--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -503,6 +503,43 @@ describe('addPuzzle', () => {
       'Image values must be data: URIs'
     );
   });
+
+  it('rejects puzzle whose clue contains the upstream "[?]" placeholder', async () => {
+    const puzzleWithBrokenClue = {
+      ...validPuzzle,
+      clues: {across: ['clue1', 'clue2'], down: ['ok', 'A[?] 9[?] 6[?] 4[?] 2[?], e.g.']},
+    };
+    await expect(addPuzzle(puzzleWithBrokenClue as any, false, 'broken-pid')).rejects.toThrow(
+      /clues\.down\[1\] contains "\[\?\]"/
+    );
+  });
+
+  it('rejects puzzle whose title contains the upstream "[?]" placeholder', async () => {
+    const puzzleWithBrokenTitle = {
+      ...validPuzzle,
+      info: {...validPuzzle.info, title: 'Moral High Ground [?]'},
+    };
+    await expect(addPuzzle(puzzleWithBrokenTitle as any, false, 'broken-title-pid')).rejects.toThrow(
+      /info\.title contains "\[\?\]"/
+    );
+  });
+
+  it('accepts a puzzle that mentions [?] outside the scanned fields (e.g. in grid)', async () => {
+    // The scan covers info text + clues only; grid solutions are not scanned
+    // because crossword cells are single letters and "[?]" couldn't be a
+    // real solution anyway. Confirm we don't false-positive on adjacent data.
+    pool.query.mockResolvedValue({rows: []});
+    const fineExceptForGrid = {
+      ...validPuzzle,
+      // A solution string with brackets/? — unlikely in practice, but
+      // documents the scope of the validator.
+      grid: [
+        ['A', '[?]'],
+        ['C', 'D'],
+      ],
+    };
+    await expect(addPuzzle(fineExceptForGrid as any, false, 'grid-pid')).resolves.not.toThrow();
+  });
 });
 
 describe('recordSolve', () => {

--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -485,6 +485,14 @@ describe('addPuzzle', () => {
     await expect(addPuzzle(invalidPuzzle as any)).rejects.toThrow();
   });
 
+  it('rejects an empty/incomplete puzzle object with an Invalid puzzle: error (becomes 400, not 500)', async () => {
+    // Without grid/info/clues as .required(), Joi accepted {} and addPuzzle
+    // reached computePuzzleHash, throwing a raw TypeError that bubbled up
+    // as a 500. The validator now rejects this shape so the API can return
+    // a proper 400.
+    await expect(addPuzzle({} as any, false, 'empty-pid')).rejects.toThrow(/^Invalid puzzle:/);
+  });
+
   it('accepts puzzle with data URI images', async () => {
     pool.query.mockResolvedValue({rows: []});
     const puzzleWithImages = {

--- a/server/__tests__/model/puzzle.test.ts
+++ b/server/__tests__/model/puzzle.test.ts
@@ -524,6 +524,19 @@ describe('addPuzzle', () => {
     );
   });
 
+  it('rejects puzzle whose titleOverride contains "[?]" (overrides display the override)', async () => {
+    // The puzzle list / chat header show titleOverride preferentially over
+    // title via COALESCE — a broken override would surface to users even
+    // if the underlying title was clean.
+    const puzzleWithBrokenOverride = {
+      ...validPuzzle,
+      info: {...validPuzzle.info, titleOverride: 'My version [?]'},
+    };
+    await expect(addPuzzle(puzzleWithBrokenOverride as any, false, 'broken-override-pid')).rejects.toThrow(
+      /info\.titleOverride contains "\[\?\]"/
+    );
+  });
+
   it('accepts a puzzle that mentions [?] outside the scanned fields (e.g. in grid)', async () => {
     // The scan covers info text + clues only; grid solutions are not scanned
     // because crossword cells are single letters and "[?]" couldn't be a

--- a/server/api/puzzle.ts
+++ b/server/api/puzzle.ts
@@ -36,7 +36,7 @@ const router = express.Router();
  *                 pid: {type: string}
  *                 duplicate: {type: string, description: PID of existing duplicate if found}
  */
-router.post<{}, AddPuzzleResponse, AddPuzzleRequest>('/', async (req, res) => {
+router.post<{}, AddPuzzleResponse | {error: string}, AddPuzzleRequest>('/', async (req, res, next) => {
   // Optional auth: extract userId if token is present
   let userId: string | null = null;
   const authHeader = req.headers.authorization;
@@ -45,11 +45,23 @@ router.post<{}, AddPuzzleResponse, AddPuzzleRequest>('/', async (req, res) => {
     if (payload) userId = payload.userId;
   }
 
-  const result = await addPuzzle(req.body.puzzle, req.body.isPublic, req.body.pid, userId);
-  res.json({
-    pid: result.pid,
-    duplicate: result.duplicate || undefined,
-  });
+  try {
+    const result = await addPuzzle(req.body.puzzle, req.body.isPublic, req.body.pid, userId);
+    res.json({
+      pid: result.pid,
+      duplicate: result.duplicate || undefined,
+    });
+  } catch (e) {
+    // addPuzzle's validatePuzzle throws Error('Invalid puzzle: ...') for
+    // structural / placeholder issues. Surface those as 400s so external
+    // uploaders get something actionable instead of a generic 500.
+    if (e instanceof Error && e.message.startsWith('Invalid puzzle')) {
+      console.warn(`[POST /api/puzzle] Rejected upload: ${e.message}`);
+      res.status(400).json({error: e.message});
+      return;
+    }
+    next(e);
+  }
 });
 
 /**

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -300,10 +300,53 @@ const puzzleValidator = Joi.object({
   contest: Joi.boolean().optional(),
 });
 
+// Some upstream .puz generators (esp. ones that did PDF→text extraction
+// of NYT/Vulture/Morning Brew puzzles) replace characters they couldn't
+// render — card suits, decorative emoji — with the literal three chars
+// "[?]". We've accumulated ~100 of these in prod from external bots
+// hitting this endpoint over the past year. Reject new uploads with
+// this marker so we don't keep collecting them, and give a clear
+// message pointing the uploader at the actual problem (their source).
+const BROKEN_PLACEHOLDER = '[?]';
+
+function findBrokenPlaceholderField(puzzle: any): string | null {
+  const info = puzzle?.info;
+  if (info && typeof info === 'object') {
+    for (const key of ['title', 'author', 'description', 'copyright', 'note']) {
+      const val = info[key];
+      if (typeof val === 'string' && val.includes(BROKEN_PLACEHOLDER)) {
+        return `info.${key}`;
+      }
+    }
+  }
+  const clues = puzzle?.clues;
+  if (clues && typeof clues === 'object') {
+    for (const direction of ['across', 'down'] as const) {
+      const arr = clues[direction];
+      if (!Array.isArray(arr)) continue;
+      for (let i = 0; i < arr.length; i += 1) {
+        const clue = arr[i];
+        if (typeof clue === 'string' && clue.includes(BROKEN_PLACEHOLDER)) {
+          return `clues.${direction}[${i}]`;
+        }
+      }
+    }
+  }
+  return null;
+}
+
 function validatePuzzle(puzzle: any) {
   const {error} = puzzleValidator.validate(puzzle);
   if (error) {
     throw new Error(error.message);
+  }
+  const brokenField = findBrokenPlaceholderField(puzzle);
+  if (brokenField) {
+    throw new Error(
+      `Invalid puzzle: ${brokenField} contains "[?]" placeholders, which usually means the source ` +
+        `pipeline stripped a card suit or decorative emoji. Try re-exporting from iPUZ, or fix the ` +
+        `source file before re-uploading.`
+    );
   }
 }
 

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -312,7 +312,20 @@ const BROKEN_PLACEHOLDER = '[?]';
 function findBrokenPlaceholderField(puzzle: any): string | null {
   const info = puzzle?.info;
   if (info && typeof info === 'object') {
-    for (const key of ['title', 'author', 'description', 'copyright', 'note']) {
+    // Includes titleOverride / authorOverride because the puzzle list and
+    // chat header display those preferentially over the underlying
+    // title / author (see COALESCE(..., 'title') queries elsewhere in this
+    // file). An upload that puts "[?]" into the override would otherwise
+    // bypass this scan and still surface the broken text to users.
+    for (const key of [
+      'title',
+      'author',
+      'description',
+      'copyright',
+      'note',
+      'titleOverride',
+      'authorOverride',
+    ]) {
       const val = info[key];
       if (typeof val === 'string' && val.includes(BROKEN_PLACEHOLDER)) {
         return `info.${key}`;
@@ -338,7 +351,9 @@ function findBrokenPlaceholderField(puzzle: any): string | null {
 function validatePuzzle(puzzle: any) {
   const {error} = puzzleValidator.validate(puzzle);
   if (error) {
-    throw new Error(error.message);
+    // Prefix so the API handler's `startsWith('Invalid puzzle')` check
+    // catches Joi failures too and surfaces them as 400 (not 500).
+    throw new Error(`Invalid puzzle: ${error.message}`);
   }
   const brokenField = findBrokenPlaceholderField(puzzle);
   if (brokenField) {

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -272,7 +272,11 @@ export async function listPuzzles(
 const string = () => Joi.string().allow(''); // https://github.com/sideway/joi/blob/master/API.md#string
 
 const puzzleValidator = Joi.object({
-  grid: Joi.array().items(Joi.array().items(string())),
+  // grid / info / clues are required: without them, addPuzzle reaches
+  // computePuzzleHash and crashes with a raw TypeError, which the API
+  // handler can't distinguish from an internal server error. Requiring
+  // them here lets the validation path emit a proper 400.
+  grid: Joi.array().items(Joi.array().items(string())).required(),
   info: Joi.object({
     type: string().optional(),
     title: string(),
@@ -281,7 +285,7 @@ const puzzleValidator = Joi.object({
     description: string().optional(),
     titleOverride: string().optional(),
     authorOverride: string().optional(),
-  }),
+  }).required(),
   circles: Joi.array().optional(),
   shades: Joi.array().optional(),
   images: Joi.object()
@@ -295,7 +299,7 @@ const puzzleValidator = Joi.object({
   clues: Joi.object({
     across: Joi.array(),
     down: Joi.array(),
-  }),
+  }).required(),
   private: Joi.boolean().optional(),
   contest: Joi.boolean().optional(),
 });


### PR DESCRIPTION
## Summary

Closes the upstream of the broken-clue bug ([Discord thread](#), pid \`100008328\` fixed by one-off SQL).

### Background

A scan of the prod \`puzzles\` table found ~99 puzzles whose clues / titles contain the literal three characters \`[?]\`:

\`\`\`sql
SELECT COUNT(*) FROM puzzles WHERE content::text LIKE '%[?]%';  -- 99
\`\`\`

These are the fingerprint of an upstream \`.puz\` generator (likely a PDF/HTML→\`.puz\` scraper for NYT, Vulture, Morning Brew, etc.) that substituted \`[?]\` for characters it couldn't render — typically card suits (\`♥ ♦ ♠ ♣\`) or decorative emoji.

Confirmed our converters aren't at fault:
- \`PUZtoJSON.js\` does the right thing (UTF-8 first, Windows-1252 fallback). Fresh manual \`.puz\` upload of the same affected puzzle produced clean output.
- The bytes already say \`[?]\` by the time they reach us — the upstream tool stripped the chars *before* writing the \`.puz\`.
- Metadata pattern: 98 of 99 affected puzzles are anonymous uploads, mostly from a bulk import on 2025-11-04 plus a trickle of ~3/month from auto-uploaded NYT/Vulture/Morning Brew titles since.

So the right defense is at our upload boundary.

### Change

- [server/model/puzzle.ts](server/model/puzzle.ts): \`validatePuzzle\` now scans \`info.{title, author, description, copyright, note}\` and \`clues.{across, down}[]\` for the literal \`[?]\` marker. If found, throws \`Invalid puzzle: <field> contains "[?]" placeholders, …\` with a hint pointing the uploader at the actual source-pipeline problem.
- [server/api/puzzle.ts](server/api/puzzle.ts): \`POST /api/puzzle\` catches the \`Invalid puzzle\` error and returns 400 with the message, so external uploaders get something actionable instead of a generic 500. Logs a warning so we have visibility into who/what is still sending the bad data.
- Three new tests cover broken-clue, broken-title, and a "grid contains the string but it's outside the scanned fields" bypass case.

### Out of scope

- **Backfilling the ~99 existing broken rows** — tracked in #541. This PR just stops new ones from coming in.

## Test plan
- [x] \`pnpm test:server --ci\` (282 pass, 3 new)
- [x] \`pnpm tsc --noEmit -p server/tsconfig.json\`
- [x] \`pnpm eslint --max-warnings 0 server/\`
- [x] \`pnpm prettier --check server/\`
- [ ] After deploy: hit \`POST /api/puzzle\` with a body whose clue contains \`[?]\` — should get 400 with the explainer message

🤖 Generated with [Claude Code](https://claude.com/claude-code)