### PR TITLE
Show copyable puzzle ID in game chat

### DIFF
--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -209,9 +209,10 @@ export default class Chat extends Component {
     link.classList.add('flashBlue');
   };
 
-  handleCopyPuzzleIdClick = () => {
+  handleCopyPuzzleIdClick = async () => {
     const pid = this.props.game?.pid;
-    if (!copyPuzzleId(pid)) return;
+    const ok = await copyPuzzleId(pid);
+    if (!ok) return;
     this.setState({copiedPuzzleId: true});
     clearTimeout(this.copyPuzzleIdTimeout);
     this.copyPuzzleIdTimeout = setTimeout(() => {
@@ -343,7 +344,7 @@ export default class Chat extends Component {
             className="chat--header--puzzle-id"
             onClick={this.handleCopyPuzzleIdClick}
             title={this.state.copiedPuzzleId ? 'Puzzle ID copied' : 'Copy puzzle ID'}
-            aria-label={`Copy puzzle ID ${pid}`}
+            aria-label={this.state.copiedPuzzleId ? 'Puzzle ID copied' : `Copy puzzle ID ${pid}`}
           >
             <span className="chat--header--puzzle-id-label">Puzzle ID</span>
             <span className="chat--header--puzzle-id-value">{pid}</span>

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -20,6 +20,7 @@ import ConfirmDialog from '../common/ConfirmDialog';
 import InfoDialog from '../common/InfoDialog';
 import AuthContext from '../../lib/AuthContext';
 import {kickPlayer, unkickPlayer} from '../../api/create_game';
+import {copyPuzzleId} from './puzzleId';
 
 const isEmojis = (str) => {
   const res = str.match(/[A-Za-z,.0-9!-]/g);
@@ -37,6 +38,7 @@ export default class Chat extends Component {
       kickTarget: null,
       unkickTarget: null,
       showLockInfo: false,
+      copiedPuzzleId: false,
     };
     this.chatBar = React.createRef();
     this.usernameInput = React.createRef();
@@ -135,6 +137,10 @@ export default class Chat extends Component {
     this.handleUpdateDisplayName(username);
   }
 
+  componentWillUnmount() {
+    clearTimeout(this.copyPuzzleIdTimeout);
+  }
+
   static get usernameKey() {
     return `username_${window.location.href}`;
   }
@@ -201,6 +207,16 @@ export default class Chat extends Component {
     // Force reflow to restart CSS animation
     void link.offsetWidth;
     link.classList.add('flashBlue');
+  };
+
+  handleCopyPuzzleIdClick = () => {
+    const pid = this.props.game?.pid;
+    if (!copyPuzzleId(pid)) return;
+    this.setState({copiedPuzzleId: true});
+    clearTimeout(this.copyPuzzleIdTimeout);
+    this.copyPuzzleIdTimeout = setTimeout(() => {
+      this.setState({copiedPuzzleId: false});
+    }, 1200);
   };
 
   handleShareScoreClick = () => {
@@ -320,6 +336,19 @@ export default class Chat extends Component {
             Battle
             {bid}
           </div>
+        )}
+        {pid && (
+          <button
+            type="button"
+            className="chat--header--puzzle-id"
+            onClick={this.handleCopyPuzzleIdClick}
+            title={this.state.copiedPuzzleId ? 'Puzzle ID copied' : 'Copy puzzle ID'}
+            aria-label={`Copy puzzle ID ${pid}`}
+          >
+            <span className="chat--header--puzzle-id-label">Puzzle ID</span>
+            <span className="chat--header--puzzle-id-value">{pid}</span>
+            {this.state.copiedPuzzleId && <span className="chat--header--puzzle-id-copied">Copied</span>}
+          </button>
         )}
         {pid && <PuzzleStatsLine pid={String(pid)} />}
         {pid && <RatingWidget pid={String(pid)} />}

--- a/src/components/Chat/__tests__/puzzleId.test.js
+++ b/src/components/Chat/__tests__/puzzleId.test.js
@@ -1,0 +1,20 @@
+import {describe, expect, it, vi} from 'vitest';
+import {copyPuzzleId} from '../puzzleId';
+
+describe('copyPuzzleId', () => {
+  it('writes the puzzle ID to the clipboard', () => {
+    const clipboard = {writeText: vi.fn()};
+
+    expect(copyPuzzleId('101663489-plig', clipboard)).toBe(true);
+
+    expect(clipboard.writeText).toHaveBeenCalledWith('101663489-plig');
+  });
+
+  it('does nothing when the puzzle ID is missing', () => {
+    const clipboard = {writeText: vi.fn()};
+
+    expect(copyPuzzleId('', clipboard)).toBe(false);
+
+    expect(clipboard.writeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Chat/__tests__/puzzleId.test.js
+++ b/src/components/Chat/__tests__/puzzleId.test.js
@@ -2,19 +2,25 @@ import {describe, expect, it, vi} from 'vitest';
 import {copyPuzzleId} from '../puzzleId';
 
 describe('copyPuzzleId', () => {
-  it('writes the puzzle ID to the clipboard', () => {
-    const clipboard = {writeText: vi.fn()};
+  it('writes the puzzle ID to the clipboard', async () => {
+    const clipboard = {writeText: vi.fn().mockResolvedValue(undefined)};
 
-    expect(copyPuzzleId('101663489-plig', clipboard)).toBe(true);
+    expect(await copyPuzzleId('101663489-plig', clipboard)).toBe(true);
 
     expect(clipboard.writeText).toHaveBeenCalledWith('101663489-plig');
   });
 
-  it('does nothing when the puzzle ID is missing', () => {
-    const clipboard = {writeText: vi.fn()};
+  it('does nothing when the puzzle ID is missing', async () => {
+    const clipboard = {writeText: vi.fn().mockResolvedValue(undefined)};
 
-    expect(copyPuzzleId('', clipboard)).toBe(false);
+    expect(await copyPuzzleId('', clipboard)).toBe(false);
 
     expect(clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it('returns false when clipboard write fails', async () => {
+    const clipboard = {writeText: vi.fn().mockRejectedValue(new Error('denied'))};
+
+    expect(await copyPuzzleId('101663489-plig', clipboard)).toBe(false);
   });
 });

--- a/src/components/Chat/css/index.css
+++ b/src/components/Chat/css/index.css
@@ -58,6 +58,51 @@
   font-style: italic;
 }
 
+.chat--header--puzzle-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  max-width: 100%;
+  margin-top: 6px;
+  padding: 2px 8px;
+  font: inherit;
+  font-size: 12px;
+  color: #555;
+  background: #f7f7f7;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+}
+
+.chat--header--puzzle-id:hover {
+  cursor: pointer;
+  background: #eee;
+}
+
+.chat--header--puzzle-id-label {
+  font-weight: 600;
+}
+
+.chat--header--puzzle-id-value {
+  overflow-wrap: anywhere;
+  font-family: monospace;
+}
+
+.chat--header--puzzle-id-copied {
+  color: var(--main-blue);
+  font-weight: 600;
+}
+
+.dark .chat--header--puzzle-id {
+  color: rgb(255 255 255 / 72%);
+  background: rgb(255 255 255 / 8%);
+  border-color: rgb(255 255 255 / 18%);
+}
+
+.dark .chat--header--puzzle-id:hover {
+  background: rgb(255 255 255 / 12%);
+}
+
 .chat--lock-chip {
   display: inline-flex;
   align-items: center;

--- a/src/components/Chat/puzzleId.js
+++ b/src/components/Chat/puzzleId.js
@@ -1,8 +1,12 @@
-export function copyPuzzleId(
+export async function copyPuzzleId(
   pid,
   clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
 ) {
   if (!pid || !clipboard?.writeText) return false;
-  clipboard.writeText(String(pid));
-  return true;
+  try {
+    await clipboard.writeText(String(pid));
+    return true;
+  } catch (_e) {
+    return false;
+  }
 }

--- a/src/components/Chat/puzzleId.js
+++ b/src/components/Chat/puzzleId.js
@@ -1,0 +1,8 @@
+export function copyPuzzleId(
+  pid,
+  clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
+) {
+  if (!pid || !clipboard?.writeText) return false;
+  clipboard.writeText(String(pid));
+  return true;
+}


### PR DESCRIPTION
## Summary

Adds a small copyable Puzzle ID chip to the game chat header so bug reports can include the underlying puzzle identifier without digging through the game URL or database.

## Changes

- Shows `Puzzle ID` below the puzzle title/author metadata when a `pid` is available.
- Copies the puzzle ID to the clipboard on click and briefly shows a `Copied` state.
- Adds a small helper and unit coverage for the clipboard behavior.

## Test plan

- `corepack pnpm exec vitest run src/components/Chat/__tests__/puzzleId.test.js --environment node`
- `corepack pnpm exec eslint --max-warnings=0 src/components/Chat/Chat.js src/components/Chat/puzzleId.js src/components/Chat/__tests__/puzzleId.test.js`
- `corepack pnpm exec stylelint "src/components/Chat/css/index.css"`
- `corepack pnpm exec prettier --check src/components/Chat/Chat.js src/components/Chat/css/index.css src/components/Chat/puzzleId.js src/components/Chat/__tests__/puzzleId.test.js`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`

Closes #540