### PR TITLE
fix(play): implement optimistic UI and cache bypassing for game abandonment

### DIFF
--- a/server/api/game.ts
+++ b/server/api/game.ts
@@ -7,7 +7,11 @@ import {getPuzzleSolves, invalidateInProgressCacheForUser} from '../model/puzzle
 import {getPuzzleInfo} from '../model/puzzle';
 import {verifyAccessToken} from '../auth/jwt';
 import {dismissGameForUser, undismissGameForUser} from '../model/game_dismissal';
-import {invalidateUserGamesCacheForUser, invalidateAuthPuzzleStatusCache} from '../model/user_games';
+import {
+  invalidateUserGamesCacheForUser,
+  invalidateUserGamesCacheForUserId,
+  invalidateAuthPuzzleStatusCache,
+} from '../model/user_games';
 import {getDfacIdsForUser, getUserIdByDfacId} from '../model/user';
 import {
   addGameBan,
@@ -90,6 +94,9 @@ router.post<{}, CreateGameResponse | {error: string}, CreateGameRequest>(
       // Invalidate user games cache so the "Your Games" page reflects the new game immediately
       if (req.body.dfac_id) {
         invalidateUserGamesCacheForUser(req.body.dfac_id);
+      }
+      if (userId) {
+        invalidateUserGamesCacheForUserId(userId);
       }
       res.json({gid});
     } catch (e) {
@@ -198,6 +205,7 @@ router.post<{gid: string}>('/:gid/dismiss', async (req, res, next) => {
     // the homepage until the 10-min TTL expires.
     invalidateInProgressCacheForUser(payload.userId);
     invalidateAuthPuzzleStatusCache(payload.userId);
+    invalidateUserGamesCacheForUserId(payload.userId);
     const dfacIds = await getDfacIdsForUser(payload.userId);
     for (const dfacId of dfacIds) invalidateUserGamesCacheForUser(dfacId);
     res.sendStatus(204);
@@ -238,6 +246,7 @@ router.post<{gid: string}>('/:gid/undismiss', async (req, res, next) => {
     await undismissGameForUser(payload.userId, gid);
     invalidateInProgressCacheForUser(payload.userId);
     invalidateAuthPuzzleStatusCache(payload.userId);
+    invalidateUserGamesCacheForUserId(payload.userId);
     const dfacIds = await getDfacIdsForUser(payload.userId);
     for (const dfacId of dfacIds) invalidateUserGamesCacheForUser(dfacId);
     res.sendStatus(204);

--- a/server/api/record_solve.ts
+++ b/server/api/record_solve.ts
@@ -4,7 +4,11 @@ import {RecordSolveRequest, RecordSolveResponse} from '../../src/shared/types';
 import {recordSolve} from '../model/puzzle';
 import {saveGameSnapshot} from '../model/game_snapshot';
 import {invalidateInProgressCacheForUser} from '../model/puzzle_solve';
-import {invalidateUserGamesCacheForUser, invalidateAuthPuzzleStatusCache} from '../model/user_games';
+import {
+  invalidateUserGamesCacheForUser,
+  invalidateUserGamesCacheForUserId,
+  invalidateAuthPuzzleStatusCache,
+} from '../model/user_games';
 import {getDfacIdsForUser} from '../model/user';
 import {verifyAccessToken} from '../auth/jwt';
 
@@ -80,6 +84,7 @@ router.post<{pid: string}, RecordSolveResponse, RecordSolveRequest>('/:pid', asy
     if (userId && solveRecorded) {
       invalidateInProgressCacheForUser(userId);
       invalidateAuthPuzzleStatusCache(userId);
+      invalidateUserGamesCacheForUserId(userId);
       const dfacIds = await getDfacIdsForUser(userId);
       for (const dfacId of dfacIds) invalidateUserGamesCacheForUser(dfacId);
     }

--- a/server/model/user_games.ts
+++ b/server/model/user_games.ts
@@ -36,6 +36,15 @@ export function invalidateUserGamesCacheForUser(dfacId: string): void {
   });
 }
 
+/** Invalidate caches for a specific user ID. */
+export function invalidateUserGamesCacheForUserId(userId: string): void {
+  userGamesForPuzzleCache.deleteWhere((key) => {
+    const parts = key.split(':');
+    const userSegment = parts[2];
+    return userSegment === userId;
+  });
+}
+
 /** Invalidate authenticated puzzle status cache for a specific user. */
 export function invalidateAuthPuzzleStatusCache(userId: string): void {
   authPuzzleStatusCache.delete(userId);

--- a/src/api/user_games.ts
+++ b/src/api/user_games.ts
@@ -12,15 +12,22 @@ export type UserGame = {
 export async function fetchUserGames(
   pid: string | number,
   accessToken?: string | null,
-  dfacId?: string
+  dfacId?: string,
+  skipCache?: boolean
 ): Promise<UserGame[]> {
   const params = new URLSearchParams({pid: String(pid)});
   if (dfacId) params.set('dfac_id', dfacId);
+  if (skipCache) params.set('_t', String(Date.now()));
 
   const headers: Record<string, string> = {};
   if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
 
-  const resp = await fetch(`${SERVER_URL}/api/user-games?${params}`, {headers});
+  const fetchOptions: RequestInit = {headers};
+  if (skipCache) {
+    fetchOptions.cache = 'no-store';
+  }
+
+  const resp = await fetch(`${SERVER_URL}/api/user-games?${params}`, fetchOptions);
   if (!resp.ok) return [];
 
   const data = await resp.json();

--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -216,30 +216,36 @@ class Play extends Component {
     const {abandonGid} = this.state;
     if (!abandonGid) return;
     const accessToken = this.context?.accessToken;
+    const priorGames = this.state.games;
 
-    // Optimistically update UI
-    if (this.state.games) {
+    if (priorGames) {
       this.setState({
-        games: this.state.games.filter((g) => g.gid !== abandonGid),
+        games: priorGames.filter((g) => g.gid !== abandonGid),
       });
     }
 
-    if (accessToken) {
-      await dismissGame(abandonGid, accessToken);
-    } else {
-      try {
-        const guestDismissed = JSON.parse(localStorage.getItem('cwf:guest_dismissed_games') || '[]');
-        if (!guestDismissed.includes(abandonGid)) {
-          guestDismissed.push(abandonGid);
-          localStorage.setItem('cwf:guest_dismissed_games', JSON.stringify(guestDismissed));
+    try {
+      if (accessToken) {
+        await dismissGame(abandonGid, accessToken);
+      } else {
+        try {
+          const guestDismissed = JSON.parse(localStorage.getItem('cwf:guest_dismissed_games') || '[]');
+          if (!guestDismissed.includes(abandonGid)) {
+            guestDismissed.push(abandonGid);
+            localStorage.setItem('cwf:guest_dismissed_games', JSON.stringify(guestDismissed));
+          }
+        } catch (err) {
+          console.warn('Failed to store guest dismissed game:', err);
         }
-      } catch (err) {
-        console.warn('Failed to store guest dismissed game:', err);
       }
+      await this.loadGames(true);
+    } catch (err) {
+      console.warn('Failed to abandon game:', err);
+      Sentry.captureException(err, {extra: {phase: 'confirmAbandon', gid: abandonGid}});
+      if (priorGames) this.setState({games: priorGames});
+    } finally {
+      this.setState({abandonGid: null});
     }
-    // Re-fetch games from API (bypass browser cache to get latest list)
-    await this.loadGames(true);
-    this.setState({abandonGid: null});
   }
 
   renderMain() {

--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -76,11 +76,19 @@ class Play extends Component {
     });
   }
 
-  async loadGames() {
+  async loadGames(skipCache = false) {
     try {
       const accessToken = this.context?.accessToken;
       const dfacId = getLocalId();
-      const games = await fetchUserGames(this.pid, accessToken, dfacId);
+      let games = await fetchUserGames(this.pid, accessToken, dfacId, skipCache);
+      if (!accessToken) {
+        try {
+          const guestDismissed = JSON.parse(localStorage.getItem('cwf:guest_dismissed_games') || '[]');
+          games = games.filter((g) => !guestDismissed.includes(g.gid));
+        } catch (err) {
+          console.warn('Failed to parse guest dismissed games:', err);
+        }
+      }
       this.setState({games});
     } catch (e) {
       console.warn('Failed to load games:', e);
@@ -208,12 +216,29 @@ class Play extends Component {
     const {abandonGid} = this.state;
     if (!abandonGid) return;
     const accessToken = this.context?.accessToken;
+
+    // Optimistically update UI
+    if (this.state.games) {
+      this.setState({
+        games: this.state.games.filter((g) => g.gid !== abandonGid),
+      });
+    }
+
     if (accessToken) {
       await dismissGame(abandonGid, accessToken);
+    } else {
+      try {
+        const guestDismissed = JSON.parse(localStorage.getItem('cwf:guest_dismissed_games') || '[]');
+        if (!guestDismissed.includes(abandonGid)) {
+          guestDismissed.push(abandonGid);
+          localStorage.setItem('cwf:guest_dismissed_games', JSON.stringify(guestDismissed));
+        }
+      } catch (err) {
+        console.warn('Failed to store guest dismissed game:', err);
+      }
     }
-    // Re-fetch games from API (dismissed games are excluded server-side for auth'd users)
-    // For guests, the game will still appear since there's no server-side dismissal
-    await this.loadGames();
+    // Re-fetch games from API (bypass browser cache to get latest list)
+    await this.loadGames(true);
     this.setState({abandonGid: null});
   }
 


### PR DESCRIPTION
Implements optimistic UI filtering on the Play page when a game is abandoned, bypasses browser HTTP cache for the re-fetch query, and stores guest-dismissed games in localStorage so they persist for unregistered users.