### PR TITLE
chore(sql): backport prod-only schema into canonical create scripts

### DIFF
--- a/server/sql/create_email_auth_tables.sql
+++ b/server/sql/create_email_auth_tables.sql
@@ -26,3 +26,11 @@ CREATE TABLE IF NOT EXISTS password_reset_tokens (
   created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
   used_at TIMESTAMP WITHOUT TIME ZONE
 );
+
+-- Partial indexes on user_id for fast lookup of unused tokens (verify/reset flows
+-- scan WHERE user_id = $1 AND used_at IS NULL).
+CREATE INDEX IF NOT EXISTS email_verification_tokens_user_id_idx
+  ON email_verification_tokens (user_id) WHERE used_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS password_reset_tokens_user_id_idx
+  ON password_reset_tokens (user_id) WHERE used_at IS NULL;

--- a/server/sql/create_fresh_db.sql
+++ b/server/sql/create_fresh_db.sql
@@ -20,6 +20,10 @@ GRANT ALL ON SCHEMA public TO dfacadmin;
 -- Extension needed for trigram index on puzzles
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
+-- pg_stat_statements is enabled on production (Render manages this at the
+-- cluster level). Local installs don't need it; it requires superuser and
+-- shared_preload_libraries='pg_stat_statements', so we skip it here.
+
 -- ============================================================
 -- 1. users (no dependencies)
 -- ============================================================

--- a/server/sql/create_game_events.sql
+++ b/server/sql/create_game_events.sql
@@ -13,7 +13,11 @@ CREATE TABLE public.game_events
     event_payload json
 )
 WITH (
-    OIDS = FALSE
+    OIDS = FALSE,
+    -- High-write table: tune autovacuum to run sooner and harder than defaults.
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_cost_limit = 1000,
+    autovacuum_vacuum_cost_delay = 10
 )
 TABLESPACE pg_default;
 

--- a/server/sql/create_puzzles.sql
+++ b/server/sql/create_puzzles.sql
@@ -54,3 +54,12 @@ CREATE INDEX puzzle_pid_numeric_desc
 
 CREATE UNIQUE INDEX IF NOT EXISTS puzzles_content_hash_public
     ON puzzles (content_hash) WHERE is_public = true AND content_hash IS NOT NULL;
+
+-- Sort index for the rating_desc puzzle list (rating_weighted is the
+-- Bayesian-shrunk score; NULL until the puzzle has any ratings).
+CREATE INDEX IF NOT EXISTS puzzles_rating_weighted_idx
+    ON public.puzzles (rating_weighted DESC NULLS LAST) WHERE rating_weighted IS NOT NULL;
+
+-- Lookup by uploader for "my uploads" / profile queries.
+CREATE INDEX IF NOT EXISTS puzzles_uploaded_by_idx
+    ON public.puzzles (uploaded_by) WHERE uploaded_by IS NOT NULL;


### PR DESCRIPTION
## Summary

- Backports four bits of schema that exist on prod but were never reflected in `server/sql/` — partial token indexes, two puzzle indexes, `game_events` autovacuum tuning, and a note about `pg_stat_statements` being platform-managed
- Caught during a schema audit comparing prod against a freshly-built DB from `create_fresh_db.sql` — the canonical script was producing a divergent schema for new developers and any future fresh-build target

No prod-side change in this PR. The remaining prod drift (missing CHECK constraints on `puzzles`, the `rame_events_rid_ts_idx` typo, the dead `schema_migrations` table) will be applied manually against prod separately.

## Test plan

- [ ] Rebuild a fresh local DB from `create_fresh_db.sql` and confirm the new indexes + autovacuum settings appear
- [ ] Diff the fresh local schema vs prod (via `server/sql/diff_schemas.sh`) — remaining diffs should only be the cosmetic column-order stuff and the prod-side drift slated for manual fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)