### PR TITLE
fix(profile): raise getUserSolveStats history LIMIT 100 -> 5000

### DIFF
--- a/server/model/puzzle_solve.ts
+++ b/server/model/puzzle_solve.ts
@@ -91,7 +91,11 @@ export async function getUserSolveStats(userId: string): Promise<{
       FROM all_solves WHERE dow IS NOT NULL GROUP BY dow`,
       [userId]
     ),
-    // Recent solve history — only extract needed JSONB fields
+    // Solve history — extracts needed JSONB fields. Limit is intentionally
+    // generous (rather than just "recent N"): the frontend uses this list
+    // to overlay 'solved' status on the puzzle list, so a low cap silently
+    // drops Complete flags for heavy users. Proper fix is a separate
+    // lightweight solvedPids endpoint; this LIMIT is the interim.
     pool.query(
       `SELECT
          ps.pid, ps.gid, ps.time_taken_to_solve, ps.solved_time, ps.player_count,
@@ -108,7 +112,7 @@ export async function getUserSolveStats(userId: string): Promise<{
        JOIN puzzles p ON ps.pid = p.pid
        WHERE ps.user_id = $1
        ORDER BY ps.solved_time DESC
-       LIMIT 100`,
+       LIMIT 5000`,
       [userId]
     ),
   ]);


### PR DESCRIPTION
## Summary

- Frontend [PuzzleList overlay](src/components/PuzzleList/NewPuzzleList.tsx#L73-L75) uses `stats.history` from `/user-stats/:userId` to mark puzzles as Complete on the main/search page. The query in [server/model/puzzle_solve.ts](server/model/puzzle_solve.ts#L94-L113) was capped at `LIMIT 100`, so any solve older than a user's 100th-most-recent silently never got the Complete flag.
- Reported by user with 2,144 lifetime solves; missing puzzles ranked ~#500–#633 in their history.
- This is a one-line interim bump to 5000. The proper fix is a dedicated lightweight `solvedPids: string[]` field on the user-stats response so the status overlay stops piggybacking on the "Recent solves" detail list — to be done as a follow-up.

## Test plan

- [x] `pnpm tsc --noEmit -p server/tsconfig.json` clean
- [x] `pnpm eslint --max-warnings 0 server/model/puzzle_solve.ts` clean
- [x] `pnpm test:server --ci -- --testPathPatterns puzzle_solve` — 11/11 passing (no test referenced the LIMIT value)
- [ ] After deploy, affected user reloads main/search page and confirms previously-solved puzzles now show the Complete badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)