### PR TITLE
feat(profile): drive Complete overlay from solvedPids instead of history

### DIFF
--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -40,7 +40,7 @@ import {
 } from '../model/email_token';
 import {sendVerificationEmail, sendPasswordResetEmail} from '../model/mailer';
 import {pool} from '../model/pool';
-import {backfillSolvesForDfacId} from '../model/puzzle_solve';
+import {backfillSolvesForDfacId, invalidateSolvedPidsCacheForUser} from '../model/puzzle_solve';
 import {invalidateAuthPuzzleStatusCache} from '../model/user_games';
 
 const router = express.Router();
@@ -1210,6 +1210,7 @@ router.post('/link-identity', authLimiter, requireAuth, async (req, res) => {
   const backfilled = await backfillSolvesForDfacId(req.authUser!.userId, dfacId);
   if (backfilled > 0) {
     invalidateAuthPuzzleStatusCache(req.authUser!.userId);
+    invalidateSolvedPidsCacheForUser(req.authUser!.userId);
   }
   res.json({ok: true, backfilledSolves: backfilled});
 });

--- a/server/api/record_solve.ts
+++ b/server/api/record_solve.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import {RecordSolveRequest, RecordSolveResponse} from '../../src/shared/types';
 import {recordSolve} from '../model/puzzle';
 import {saveGameSnapshot} from '../model/game_snapshot';
-import {invalidateInProgressCacheForUser} from '../model/puzzle_solve';
+import {invalidateInProgressCacheForUser, invalidateSolvedPidsCacheForUser} from '../model/puzzle_solve';
 import {
   invalidateUserGamesCacheForUser,
   invalidateUserGamesCacheForUserId,
@@ -84,6 +84,7 @@ router.post<{pid: string}, RecordSolveResponse, RecordSolveRequest>('/:pid', asy
     if (userId && solveRecorded) {
       invalidateInProgressCacheForUser(userId);
       invalidateAuthPuzzleStatusCache(userId);
+      invalidateSolvedPidsCacheForUser(userId);
       invalidateUserGamesCacheForUserId(userId);
       const dfacIds = await getDfacIdsForUser(userId);
       for (const dfacId of dfacIds) invalidateUserGamesCacheForUser(dfacId);

--- a/server/api/user_stats.ts
+++ b/server/api/user_stats.ts
@@ -96,7 +96,11 @@ router.get('/:userId', async (req, res, next) => {
 
     let inProgress: Awaited<ReturnType<typeof getInProgressGames>> = [];
     let snapshotStatuses: Awaited<ReturnType<typeof getAuthenticatedPuzzleStatuses>> = {};
-    let solvedPids: Awaited<ReturnType<typeof getSolvedPidsForUser>> = [];
+    // solvedPids stays undefined on failure (rather than defaulting to []) so
+    // the client can distinguish "user has zero solves" from "we couldn't
+    // fetch your solved set". An empty array would be treated as authoritative
+    // and would clobber the cached Complete badges in localStorage.
+    let solvedPids: Awaited<ReturnType<typeof getSolvedPidsForUser>> | undefined;
     if (isOwner) {
       try {
         inProgress = await getInProgressGames(userId);
@@ -115,6 +119,7 @@ router.get('/:userId', async (req, res, next) => {
       } catch (err) {
         Sentry.captureException(err);
         console.error('getSolvedPidsForUser error:', err);
+        // intentionally leave undefined — see note above
       }
     }
 

--- a/server/api/user_stats.ts
+++ b/server/api/user_stats.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node';
 import express from 'express';
-import {getUserSolveStats, getInProgressGames} from '../model/puzzle_solve';
+import {getUserSolveStats, getInProgressGames, getSolvedPidsForUser} from '../model/puzzle_solve';
 import {getUserById} from '../model/user';
 import {getUserUploadedPuzzles} from '../model/puzzle';
 import {getAuthenticatedPuzzleStatuses} from '../model/user_games';
@@ -44,6 +44,7 @@ const router = express.Router();
  *                 history: {type: array, items: {type: object}}
  *                 uploads: {type: array, items: {type: object}}
  *                 inProgress: {type: array, items: {type: object}, description: Only present for the profile owner}
+ *                 solvedPids: {type: array, items: {type: string}, description: "Distinct pids the user has solved. Only present for the profile owner. Used by the puzzle list to overlay the Complete badge."}
  *       404: {description: User not found}
  */
 router.get('/:userId', async (req, res, next) => {
@@ -95,6 +96,7 @@ router.get('/:userId', async (req, res, next) => {
 
     let inProgress: Awaited<ReturnType<typeof getInProgressGames>> = [];
     let snapshotStatuses: Awaited<ReturnType<typeof getAuthenticatedPuzzleStatuses>> = {};
+    let solvedPids: Awaited<ReturnType<typeof getSolvedPidsForUser>> = [];
     if (isOwner) {
       try {
         inProgress = await getInProgressGames(userId);
@@ -107,6 +109,12 @@ router.get('/:userId', async (req, res, next) => {
       } catch (err) {
         Sentry.captureException(err);
         console.error('getAuthenticatedPuzzleStatuses error:', err);
+      }
+      try {
+        solvedPids = await getSolvedPidsForUser(userId);
+      } catch (err) {
+        Sentry.captureException(err);
+        console.error('getSolvedPidsForUser error:', err);
       }
     }
 
@@ -136,6 +144,7 @@ router.get('/:userId', async (req, res, next) => {
       uploads,
       inProgress,
       snapshotStatuses,
+      solvedPids,
     });
   } catch (e) {
     next(e);

--- a/server/api/user_stats.ts
+++ b/server/api/user_stats.ts
@@ -44,7 +44,7 @@ const router = express.Router();
  *                 history: {type: array, items: {type: object}}
  *                 uploads: {type: array, items: {type: object}}
  *                 inProgress: {type: array, items: {type: object}, description: Only present for the profile owner}
- *                 solvedPids: {type: array, items: {type: string}, description: "Distinct pids the user has solved. Only present for the profile owner. Used by the puzzle list to overlay the Complete badge."}
+ *                 solvedPids: {type: array, items: {type: string}, description: "Distinct pids the user has solved. Populated only for the profile owner (empty array otherwise). Used by the puzzle list to overlay the Complete badge."}
  *       404: {description: User not found}
  */
 router.get('/:userId', async (req, res, next) => {

--- a/server/model/puzzle_solve.ts
+++ b/server/model/puzzle_solve.ts
@@ -13,6 +13,19 @@ export function invalidateInProgressCacheForUser(userId: string): void {
   inProgressGamesCache.delete(userId);
 }
 
+// ---- In-memory TTL cache for a user's solved-pid set ----
+// Drives the homepage/search Complete badge overlay. Changes infrequently
+// (only on recordSolve + link-identity backfill), so caching is safe.
+const solvedPidsCache = new TTLCache<string[]>({ttlMs: 10 * 60_000, maxSize: 2_000});
+
+export function clearSolvedPidsCache(): void {
+  solvedPidsCache.clear();
+}
+
+export function invalidateSolvedPidsCacheForUser(userId: string): void {
+  solvedPidsCache.delete(userId);
+}
+
 export type UserSolveHistoryItem = {
   pid: string;
   gid: string;
@@ -40,6 +53,23 @@ export type DayOfWeekStats = {
   count: number;
   avgTime: number;
 };
+
+/**
+ * Distinct pids the user has at least one puzzle_solves row for.
+ *
+ * Used by the homepage/search puzzle list to overlay the Complete badge.
+ * Replaces overlaying from `history` (which has a row cap and was silently
+ * dropping the badge for users with many solves).
+ */
+export async function getSolvedPidsForUser(userId: string): Promise<string[]> {
+  return solvedPidsCache.getOrFetch(userId, async () => {
+    const result = await pool.query<{pid: string}>(
+      `SELECT DISTINCT pid FROM puzzle_solves WHERE user_id = $1`,
+      [userId]
+    );
+    return result.rows.map((r) => r.pid);
+  });
+}
 
 export async function getUserSolveStats(userId: string): Promise<{
   totalSolved: number;

--- a/src/api/user_stats.ts
+++ b/src/api/user_stats.ts
@@ -78,6 +78,9 @@ export interface UserStatsResponse {
   uploads?: UploadedPuzzle[];
   inProgress?: InProgressGame[];
   snapshotStatuses?: {[pid: string]: 'solved' | 'started'};
+  // Distinct pids the user has solved. Owner-only. Drives the Complete-badge
+  // overlay on the homepage/search puzzle list; cheaper than walking history.
+  solvedPids?: string[];
 }
 
 export async function getUserStats(

--- a/src/components/PuzzleList/NewPuzzleList.tsx
+++ b/src/components/PuzzleList/NewPuzzleList.tsx
@@ -69,9 +69,11 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
           (stats.inProgress || []).forEach((item) => {
             if (!statuses[item.pid]) statuses[item.pid] = 'started';
           });
-          // Overlay solved from puzzle_solves (highest priority)
-          (stats.history || []).forEach((item) => {
-            statuses[item.pid] = 'solved';
+          // Overlay solved from puzzle_solves (highest priority). solvedPids is
+          // the full distinct-pid set; history is capped and was silently
+          // dropping the Complete badge for users with many solves.
+          (stats.solvedPids || []).forEach((pid) => {
+            statuses[pid] = 'solved';
           });
           updateStatuses(statuses);
         })

--- a/src/components/PuzzleList/NewPuzzleList.tsx
+++ b/src/components/PuzzleList/NewPuzzleList.tsx
@@ -60,6 +60,12 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
       getUserStats(user.id, accessToken)
         .then((stats) => {
           if (stale || !stats) return;
+          // If the server couldn't produce solvedPids (transient failure), skip
+          // the status update entirely. Falling through with an empty solved
+          // set would persist authoritative-looking "no solves" data to
+          // localStorage and the user would lose their Complete badges until
+          // the next successful fetch.
+          if (stats.solvedPids === undefined) return;
           const statuses: PuzzleStatuses = {};
           // Apply snapshot-based statuses first (fallback from game_snapshots)
           if (stats.snapshotStatuses) {
@@ -72,7 +78,7 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
           // Overlay solved from puzzle_solves (highest priority). solvedPids is
           // the full distinct-pid set; history is capped and was silently
           // dropping the Complete badge for users with many solves.
-          (stats.solvedPids || []).forEach((pid) => {
+          stats.solvedPids.forEach((pid) => {
             statuses[pid] = 'solved';
           });
           updateStatuses(statuses);


### PR DESCRIPTION
## Summary

Proper fix for the issue patched by #549. The homepage/search puzzle list overlays the Complete badge using `stats.history` from `/user-stats/:userId`, but `history` is a recent-solve *detail* list with a row cap — heavy users silently lost the badge on anything past the cap. The interim fix raised the cap from 100 to 5000; this PR replaces the mechanism.

Adds a dedicated `solvedPids: string[]` field carrying only the distinct pid set (no JSONB joins, no row details). The PuzzleList overlay now uses `solvedPids`; `history` goes back to serving the profile-page Recent Solves table as originally intended.

## Implementation notes

- `getSolvedPidsForUser` is index-backed by `puzzle_solves_user_id_idx` and cached in a `TTLCache` (10 min TTL, 2k entries) following the same pattern as the existing `inProgressGames` and `authPuzzleStatus` caches.
- Cache is invalidated on the two write paths: [`recordSolve`](server/api/record_solve.ts) and [`backfillSolvesForDfacId`](server/api/auth.ts) (called by `/auth/link-identity`).
- Owner-only response field, same gating as `inProgress` and `snapshotStatuses` — public profile views don't expose a 2k-pid list.
- The `LIMIT 5000` on history from #549 is left in place. The profile page's Recent Solves table legitimately wants more than 100 for heavy users, and capping it back would visibly regress them.

## Test plan

- [x] `pnpm tsc --noEmit -p server/tsconfig.json` clean
- [x] `pnpm tsc --noEmit` (frontend) clean
- [x] `pnpm eslint --max-warnings 0` clean on changed files
- [x] `pnpm test:server --ci` — 287/287 passing
- [x] `pnpm vitest run` — 388/388 passing
- [x] `pnpm build` succeeds
- [ ] After deploy: heavy user (e.g. the 2,144-solve user from #549's report) reloads main/search page and confirms previously-solved puzzles still show the Complete badge — without relying on the bumped history cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)