### PR TITLE
chore(security): align qs override specifier with direct dep (^6.15.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "flatted": ">=3.4.2",
       "socket.io-parser": ">=4.2.6",
       "axios": ">=1.15.2",
-      "qs": ">=6.15.2",
+      "qs": "^6.15.2",
       "follow-redirects": ">=1.16.0",
       "postcss": ">=8.5.10",
       "ip-address": ">=10.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   flatted: '>=3.4.2'
   socket.io-parser: '>=4.2.6'
   axios: '>=1.15.2'
-  qs: '>=6.15.2'
+  qs: ^6.15.2
   follow-redirects: '>=1.16.0'
   postcss: '>=8.5.10'
   ip-address: '>=10.1.1'
@@ -98,7 +98,7 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
       qs:
-        specifier: '>=6.15.2'
+        specifier: ^6.15.2
         version: 6.15.2
       react:
         specifier: ^19.2.4


### PR DESCRIPTION
PR review (gemini medium): the lockfile recorded specifier '>=6.15.2' for the override while the direct dep was '^6.15.2'. pnpm's --frozen-lockfile is happy with overrides but the mismatched ranges are noise — keep both at '^6.15.2' for consistency.

pnpm audit still clean.