### PR TITLE
fix(welcome): force re-render after navHeight measurement

### DIFF
--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -55,6 +55,10 @@ export default class Welcome extends Component {
     // the deref so we don't throw a null-pointer error on the homepage.
     if (this.nav.current) {
       this.navHeight = this.nav.current.getBoundingClientRect().height;
+      // First render uses navHeight=0 from the constructor, which collapses
+      // .welcome--nav to height: 0 on mobile and lets the search bar overlap
+      // the nav. Force a re-render now that we have the real measurement.
+      this.forceUpdate();
     }
   }
 


### PR DESCRIPTION
## Summary

- On mobile, the homepage search bar overlapped the top nav until the user tapped it, then snapped into place.
- Root cause: #555 initialized `this.navHeight = 0` in the constructor to silence React NaN warnings. That turned `navStyle.height = navHeight * (1 - motion)` from `NaN` (silently ignored by the browser) into a valid `height: 0`, collapsing `.welcome--nav` on the first render and letting the search bar render on top.
- `componentDidMount` measured the real `navHeight` but never triggered a re-render, so the layout only corrected itself the next time something else called `setState` — typically when the user tapped the search input (`handleSearchFocus`).
- Fix: call `this.forceUpdate()` after measuring `navHeight` so the corrected layout commits before the user interacts.

## Test plan

- [ ] Load `testing.crosswithfriends.com` homepage on mobile (or a narrow viewport) and confirm the search bar sits below the nav on first paint, with no overlap.
- [ ] Tap the search input — layout stays the same (no visible jump).
- [ ] Scroll the puzzle list and confirm the nav still collapses smoothly (motion-based shrink behavior still works).
- [ ] Desktop homepage still renders correctly (`!this.mobile` branch unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)