### PR TITLE
fix(auth): require a real JWT secret in production

### DIFF
--- a/server/auth/jwt.ts
+++ b/server/auth/jwt.ts
@@ -1,6 +1,26 @@
 import jwt from 'jsonwebtoken';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'CHANGE_ME_IN_PRODUCTION';
+const DEV_FALLBACK_SECRET = 'CHANGE_ME_IN_PRODUCTION';
+
+// Resolve the signing secret at startup. In production a real secret is
+// mandatory: signing tokens with a publicly known default would let anyone
+// forge a valid token for any account. Outside production we allow a fallback
+// so local dev and tests run without extra setup.
+function resolveJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (process.env.NODE_ENV === 'production') {
+    if (!secret || secret === DEV_FALLBACK_SECRET) {
+      throw new Error('JWT_SECRET must be set to a strong, non-default value in production');
+    }
+    if (secret.length < 32) {
+      console.warn('[auth] JWT_SECRET is shorter than 32 characters; use a longer random value');
+    }
+    return secret;
+  }
+  return secret || DEV_FALLBACK_SECRET;
+}
+
+const JWT_SECRET = resolveJwtSecret();
 const ACCESS_TOKEN_TTL = '15m';
 
 export interface JwtPayload {


### PR DESCRIPTION
## Summary
`server/auth/jwt.ts` fell back to a hardcoded, publicly-known secret (`'CHANGE_ME_IN_PRODUCTION'`) when `JWT_SECRET` was unset. A deploy that forgot the env var would silently sign and verify tokens with that string — anyone could forge a valid access token for **any** `userId` and fully impersonate any account, with no startup warning.

This fixes the **critical** finding C1 from the codebase audit.

## Changes
- Resolve the signing secret at startup. In production, throw if `JWT_SECRET` is missing or still set to the default — fail fast at boot rather than run insecure.
- Warn (non-fatal) if the production secret is shorter than 32 chars, to avoid breaking existing deploys that use a shorter-but-real secret.
- Keep the dev/test fallback so local runs and CI (which run with `NODE_ENV` ≠ `production` and no secret) need no extra setup.

## Test plan
- [x] `pnpm tsc --noEmit -p server/tsconfig.json`
- [x] `pnpm eslint --max-warnings 0 server/auth/jwt.ts`
- [x] `pnpm test:server` auth/jwt suite (10 tests pass — unchanged because tests run under `NODE_ENV=test`)
- [ ] Verify staging boots with `JWT_SECRET` set; confirm a deploy **without** it fails fast

## Deploy note
Ensure `JWT_SECRET` is set in the production environment before merging/deploying — the server will now refuse to start without it.

https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ)_