### PR TITLE
fix(link-preview): escape user content to close stored XSS

### DIFF
--- a/server/api/link_preview.ts
+++ b/server/api/link_preview.ts
@@ -8,6 +8,18 @@ import {getPuzzleInfo} from '../model/puzzle';
 
 const router = express.Router();
 
+// Escape values interpolated into the HTML/attribute contexts below. Puzzle
+// and game info fields (title/author/description) are user-controlled and
+// upload is unauthenticated, so raw interpolation is a stored-XSS sink.
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // TODO: revisit link preview implementation
 router.get('/', async (req, res) => {
   let url;
@@ -58,13 +70,13 @@ router.get('/', async (req, res) => {
   res.send(String.raw`
         <html prefix="og: https://ogp.me/ns/website#">
             <head>
-                <title>${titlePropContent}</title>
-                <meta property="og:title" content="${titlePropContent}" />
+                <title>${escapeHtml(titlePropContent)}</title>
+                <meta property="og:title" content="${escapeHtml(titlePropContent)}" />
                 <meta property="og:type" content="website" />
-                <meta property="og:url" content="${url.href}" />
-                <meta property="og:description" content="${info.description}" />
+                <meta property="og:url" content="${escapeHtml(url.href)}" />
+                <meta property="og:description" content="${escapeHtml(info.description)}" />
                 <meta property="og:site_name" content="downforacross.com" />
-                <link type="application/json+oembed" href=${oembedEndpointUrl} />
+                <link type="application/json+oembed" href="${escapeHtml(oembedEndpointUrl)}" />
                 <meta name="theme-color" content="#6aa9f4">
             </head>
         </html>


### PR DESCRIPTION
## Summary
`server/api/link_preview.ts` interpolated puzzle/game `title`, `author`, and `description` **raw** into the HTML it returns (`<title>${...}</title>`, `content="${info.description}"`, etc.). Because puzzle upload is unauthenticated, an attacker can upload a puzzle with a title like `"><script>…</script>` and it executes in any client served the link-preview page. This is the **critical** finding C2 from the audit.

## Changes
- Add an `escapeHtml()` helper and apply it to every interpolated value (`titlePropContent`, `info.description`, `url.href`, `oembedEndpointUrl`).
- Quote the previously-unquoted `oembed` `href` attribute so an escaped value can't break out of the attribute context.

## Notes / follow-ups (not in this PR)
- Length-limiting / sanitizing puzzle `info` on ingest and requiring auth for upload are separate audit items (H3 / M-tier).
- Re-enabling Helmet CSP (`server.ts:29`) is a related defense-in-depth item (L3).

## Test plan
- [x] `pnpm tsc --noEmit -p server/tsconfig.json`
- [x] `pnpm eslint --max-warnings 0 server/api/link_preview.ts`
- [ ] Manually upload a puzzle with `<script>`/`"`/`<` in title & description, hit the link-preview endpoint with a bot UA, confirm the markup is escaped and does not execute

https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ)_