### PR TITLE
feat(frontend): add top-level error boundary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -243,6 +243,26 @@ function DarkModeSync({darkModePreference, setDarkModePreference}) {
   return null;
 }
 
+function ErrorFallback({resetError}) {
+  const handleReload = React.useCallback(() => {
+    resetError();
+    window.location.reload();
+  }, [resetError]);
+  return (
+    <div style={{maxWidth: 480, margin: '15vh auto', padding: '0 24px', textAlign: 'center'}}>
+      <h2>Something went wrong</h2>
+      <p>The page hit an unexpected error. Reloading usually fixes it.</p>
+      <button
+        type="button"
+        onClick={handleReload}
+        style={{padding: '8px 16px', fontSize: 16, cursor: 'pointer'}}
+      >
+        Reload
+      </button>
+    </div>
+  );
+}
+
 const Root = () => {
   const urlDarkMode = window.location.search.indexOf('dark') !== -1;
   const savedDarkModePreference = (localStorage && localStorage.getItem(darkModeLocalStorageKey)) || '0';
@@ -286,34 +306,36 @@ const Root = () => {
             />
             <div className={clsx('router-wrapper', {mobile: isMobile(), dark: darkMode})}>
               <VerificationGate>
-                <React.Suspense fallback={null}>
-                  <Routes>
-                    <Route path="/auth/google/callback" element={<GoogleCallback />} />
-                    <Route path="/verify-email" element={<VerifyEmail />} />
-                    <Route path="/forgot-password" element={<ForgotPassword />} />
-                    <Route path="/reset-password" element={<ResetPassword />} />
-                    <Route path="/" element={<WrappedWelcome />} />
-                    <Route path="/fencing" element={<WrappedWelcome fencing />} />
-                    <Route path="/game/:gid" element={<Game />} />
-                    <Route path="/embed/game/:gid" element={<Game />} />
-                    <Route path="/room/:rid" element={<Room />} />
-                    <Route path="/embed/room/:rid" element={<Room />} />
-                    <Route path="/replay/:gid" element={<Replay />} />
-                    <Route path="/beta/replay/:gid" element={<Replay />} />
-                    <Route path="/beta" element={<WrappedWelcome />} />
-                    <Route path="/beta/game/:gid" element={<Game />} />
-                    <Route path="/beta/play/:pid" element={<Play />} />
-                    <Route path="/privacy" element={<Privacy />} />
-                    <Route path="/terms" element={<Terms />} />
-                    <Route path="/help" element={<Help />} />
-                    <Route path="/account" element={<Account />} />
-                    <Route path="/profile" element={<Profile />} />
-                    <Route path="/profile/:userId" element={<Profile />} />
-                    <Route path="/fencing/:gid" element={<Fencing />} />
-                    <Route path="/beta/fencing/:gid" element={<Fencing />} />
-                    <Route path="/discord" element={<DiscordRedirect />} />
-                  </Routes>
-                </React.Suspense>
+                <Sentry.ErrorBoundary fallback={ErrorFallback}>
+                  <React.Suspense fallback={null}>
+                    <Routes>
+                      <Route path="/auth/google/callback" element={<GoogleCallback />} />
+                      <Route path="/verify-email" element={<VerifyEmail />} />
+                      <Route path="/forgot-password" element={<ForgotPassword />} />
+                      <Route path="/reset-password" element={<ResetPassword />} />
+                      <Route path="/" element={<WrappedWelcome />} />
+                      <Route path="/fencing" element={<WrappedWelcome fencing />} />
+                      <Route path="/game/:gid" element={<Game />} />
+                      <Route path="/embed/game/:gid" element={<Game />} />
+                      <Route path="/room/:rid" element={<Room />} />
+                      <Route path="/embed/room/:rid" element={<Room />} />
+                      <Route path="/replay/:gid" element={<Replay />} />
+                      <Route path="/beta/replay/:gid" element={<Replay />} />
+                      <Route path="/beta" element={<WrappedWelcome />} />
+                      <Route path="/beta/game/:gid" element={<Game />} />
+                      <Route path="/beta/play/:pid" element={<Play />} />
+                      <Route path="/privacy" element={<Privacy />} />
+                      <Route path="/terms" element={<Terms />} />
+                      <Route path="/help" element={<Help />} />
+                      <Route path="/account" element={<Account />} />
+                      <Route path="/profile" element={<Profile />} />
+                      <Route path="/profile/:userId" element={<Profile />} />
+                      <Route path="/fencing/:gid" element={<Fencing />} />
+                      <Route path="/beta/fencing/:gid" element={<Fencing />} />
+                      <Route path="/discord" element={<DiscordRedirect />} />
+                    </Routes>
+                  </React.Suspense>
+                </Sentry.ErrorBoundary>
               </VerificationGate>
             </div>
           </GlobalContext>

--- a/src/index.js
+++ b/src/index.js
@@ -305,8 +305,8 @@ const Root = () => {
               setDarkModePreference={setDarkModePreference}
             />
             <div className={clsx('router-wrapper', {mobile: isMobile(), dark: darkMode})}>
-              <VerificationGate>
-                <Sentry.ErrorBoundary fallback={ErrorFallback}>
+              <Sentry.ErrorBoundary fallback={ErrorFallback}>
+                <VerificationGate>
                   <React.Suspense fallback={null}>
                     <Routes>
                       <Route path="/auth/google/callback" element={<GoogleCallback />} />
@@ -335,8 +335,8 @@ const Root = () => {
                       <Route path="/discord" element={<DiscordRedirect />} />
                     </Routes>
                   </React.Suspense>
-                </Sentry.ErrorBoundary>
-              </VerificationGate>
+                </VerificationGate>
+              </Sentry.ErrorBoundary>
             </div>
           </GlobalContext>
         </AuthProvider>


### PR DESCRIPTION
## Summary
The app had **no** React error boundary anywhere (`@sentry/react` was imported but `Sentry.ErrorBoundary` was never used). A render error in any page — or a chunk-load error that reaches React after the retry guard rethrows — unmounted the entire tree to a blank white screen, with no recovery path and no Sentry capture. This is the **critical** finding C3 from the audit.

## Changes
- Add an `ErrorFallback` component (centered message + Reload button).
- Wrap `<Routes>` (outside `Suspense`, so it also catches rethrown lazy/chunk errors) in `Sentry.ErrorBoundary`.

When `VITE_SENTRY_DSN` is unset, `Sentry.ErrorBoundary` still renders the fallback — it just doesn't report. So this works in dev and prod regardless of Sentry config.

## Test plan
- [x] `pnpm eslint --max-warnings 0 src/index.js`
- [x] `pnpm build`
- [ ] Temporarily throw in a page component, confirm the fallback renders (instead of a white screen) and Reload recovers
- [ ] Confirm normal navigation across routes is unaffected

https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ)_