### PR TITLE
fix(game-snapshot): require participation to retain a replay

### DIFF
--- a/server/api/game_snapshot.ts
+++ b/server/api/game_snapshot.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import {getGameSnapshot, setReplayRetained} from '../model/game_snapshot';
 import {getPuzzle} from '../model/puzzle';
+import {wasParticipantOfGame} from '../model/game_moderation';
+import {getDfacIdsForUser} from '../model/user';
 import {verifyAccessToken} from '../auth/jwt';
 import {pool} from '../model/pool';
 
@@ -114,7 +116,28 @@ router.post('/:gid/keep-replay', async (req, res, next) => {
       return;
     }
 
-    const updated = await setReplayRetained(req.params.gid, true);
+    // Only a participant of the game may retain its replay. Without this any
+    // authenticated user could flip replay_retained on an arbitrary gid by
+    // enumerating game ids. Check the verified user id first, then fall back
+    // to any of the user's linked legacy dfac ids (games they played as a
+    // guest before logging in).
+    const {gid} = req.params;
+    let participated = await wasParticipantOfGame(gid, {userId: payload.userId});
+    if (!participated) {
+      const dfacIds = await getDfacIdsForUser(payload.userId);
+      for (const dfacId of dfacIds) {
+        if (await wasParticipantOfGame(gid, {dfacId})) {
+          participated = true;
+          break;
+        }
+      }
+    }
+    if (!participated) {
+      res.status(403).json({error: 'Not a participant of this game'});
+      return;
+    }
+
+    const updated = await setReplayRetained(gid, true);
     if (!updated) {
       res.status(404).json({error: 'No snapshot found for this game'});
       return;


### PR DESCRIPTION
## Summary
`POST /game-snapshot/:gid/keep-replay` authenticated the caller but never checked they actually played the game. Any logged-in user could flip `replay_retained` on an arbitrary `gid` by enumerating ids — the **High** IDOR finding H2 from the audit.

## Changes
- Before mutating, verify the caller participated in the game via the existing `wasParticipantOfGame` helper:
  - first by `verifiedUserId` (server-stamped on authenticated events),
  - then falling back to any of the user's linked legacy `dfac_id`s (games played as a guest before logging in).
- Return `403` if not a participant.

This reuses the same participation primitive the socket lock-bypass already relies on, so behavior is consistent with existing moderation logic.

## Test plan
- [x] `pnpm tsc --noEmit -p server/tsconfig.json`
- [x] `pnpm eslint --max-warnings 0 server/api/game_snapshot.ts`
- [x] `pnpm test:server model/game_snapshot` (8 pass)
- [ ] Manual: as user A (played game G) → keep-replay on G succeeds; as user B (never played G) → 403

https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ)_