### PR TITLE
perf(db): add missing indexes on hot read paths

### DIFF
--- a/server/sql/alter_add_perf_indexes.sql
+++ b/server/sql/alter_add_perf_indexes.sql
@@ -1,0 +1,34 @@
+-- alter_add_perf_indexes.sql
+-- Adds missing indexes on hot read paths. Safe and additive.
+--
+-- Usage:  psql -U dfacadmin -d <dbname> -f server/sql/alter_add_perf_indexes.sql
+--
+-- Run with CONCURRENTLY so these don't take a heavy lock on large/live tables.
+-- CONCURRENTLY cannot run inside a transaction block; psql runs each statement
+-- in its own autocommit transaction by default, so do NOT wrap this in BEGIN.
+
+-- firebase_history is keyed by (dfac_id, gid). Several hot queries join/filter
+-- on gid ALONE (LEFT JOIN ... ON fh.gid = ug.gid, and NOT EXISTS subqueries),
+-- which can't use the (dfac_id, gid) PK and fall back to a sequential scan of
+-- this large legacy table.
+-- Benefits: getInProgressGames, getUserGamesForPuzzle, puzzle-status queries.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_firebase_history_gid
+  ON firebase_history (gid);
+
+-- game_dismissals is keyed by (user_id, gid). The correlated NOT EXISTS
+-- subqueries match on gid (and user_id), so a (gid, user_id) index supports
+-- the gid-leading correlated form the PK can't.
+-- Benefits: getAuthenticatedPuzzleStatuses, getInProgressGames, getUserGamesForPuzzle.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS game_dismissals_gid_user_idx
+  ON game_dismissals (gid, user_id);
+
+-- wasParticipantOfGame() probes game_events for a gid filtered by the
+-- server-stamped verifiedUserId. gid is covered by game_events_gid_ts_idx, but
+-- without an index on the verifiedUserId expression every event row for that
+-- gid is scanned and filtered in memory. Partial (verifiedUserId IS NOT NULL)
+-- keeps the index small: only authenticated events carry the field.
+-- Benefits: wasParticipantOfGame (lock-bypass on reconnect, keep-replay and
+--           record_solve participation checks).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS game_events_gid_verified_user_idx
+  ON game_events (gid, ((event_payload->>'verifiedUserId')))
+  WHERE (event_payload->>'verifiedUserId') IS NOT NULL;

--- a/server/sql/alter_add_perf_indexes.sql
+++ b/server/sql/alter_add_perf_indexes.sql
@@ -29,6 +29,8 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS game_dismissals_gid_user_idx
 -- keeps the index small: only authenticated events carry the field.
 -- Benefits: wasParticipantOfGame (lock-bypass on reconnect, keep-replay and
 --           record_solve participation checks).
+-- Schema-qualified to match create_game_events.sql and avoid depending on
+-- search_path across environments.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS game_events_gid_verified_user_idx
-  ON game_events (gid, ((event_payload->>'verifiedUserId')))
+  ON public.game_events (gid, ((event_payload->>'verifiedUserId')))
   WHERE (event_payload->>'verifiedUserId') IS NOT NULL;

--- a/server/sql/create_firebase_history.sql
+++ b/server/sql/create_firebase_history.sql
@@ -14,5 +14,7 @@ CREATE TABLE IF NOT EXISTS firebase_history (
 CREATE INDEX IF NOT EXISTS idx_firebase_history_pid  ON firebase_history (pid);
 CREATE INDEX IF NOT EXISTS idx_firebase_history_dfac_pid ON firebase_history (dfac_id, pid);
 CREATE INDEX IF NOT EXISTS idx_firebase_history_dfac_solved ON firebase_history (dfac_id, solved);
+-- Hot queries join/filter on gid alone, which the (dfac_id, gid) PK can't serve.
+CREATE INDEX IF NOT EXISTS idx_firebase_history_gid ON firebase_history (gid);
 
 GRANT ALL ON firebase_history TO dfacadmin;

--- a/server/sql/create_game_dismissals.sql
+++ b/server/sql/create_game_dismissals.sql
@@ -4,3 +4,7 @@ CREATE TABLE IF NOT EXISTS game_dismissals (
   dismissed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (user_id, gid)
 );
+
+-- Supports the gid-leading correlated NOT EXISTS subqueries the (user_id, gid)
+-- PK can't serve.
+CREATE INDEX IF NOT EXISTS game_dismissals_gid_user_idx ON game_dismissals (gid, user_id);

--- a/server/sql/create_game_events.sql
+++ b/server/sql/create_game_events.sql
@@ -44,3 +44,9 @@ CREATE INDEX IF NOT EXISTS game_events_payload_id_idx
 
 CREATE INDEX IF NOT EXISTS game_events_gid_event_type_idx
     ON public.game_events (gid, event_type);
+
+-- Supports wasParticipantOfGame()'s verifiedUserId probe (gid + verifiedUserId).
+-- Partial: only authenticated events carry the field, keeping the index small.
+CREATE INDEX IF NOT EXISTS game_events_gid_verified_user_idx
+    ON public.game_events (gid, ((event_payload->>'verifiedUserId')))
+    WHERE (event_payload->>'verifiedUserId') IS NOT NULL;


### PR DESCRIPTION
## Summary
Adds three additive indexes for hot read paths that currently fall back to sequential scans or in-memory filtering (perf finding H6 + the related `verifiedUserId` index). No application code changes.

## Indexes
- **`firebase_history (gid)`** — the table is keyed by `(dfac_id, gid)`, but hot queries (`getInProgressGames`, `getUserGamesForPuzzle`, puzzle-status `NOT EXISTS`/`LEFT JOIN`) filter on `gid` **alone**, which the PK can't serve → seq scan of a large legacy table.
- **`game_dismissals (gid, user_id)`** — keyed by `(user_id, gid)`; supports the gid-leading correlated `NOT EXISTS` subqueries.
- **`game_events (gid, (event_payload->>'verifiedUserId'))` partial** — backs `wasParticipantOfGame`'s verifiedUserId probe (used by the lock-bypass on reconnect and the new keep-replay / record_solve participation checks). `gid` is already indexed, but the verifiedUserId filter was scanned in memory. Partial (`WHERE verifiedUserId IS NOT NULL`) keeps it small — only authenticated events carry the field.

## Applying
- **Fresh DBs**: added to `create_firebase_history.sql`, `create_game_dismissals.sql`, `create_game_events.sql` (all sourced by `create_fresh_db.sql`).
- **Existing DBs**: `server/sql/alter_add_perf_indexes.sql`, using `CREATE INDEX CONCURRENTLY` so it won't lock the live `game_events` / `firebase_history` tables. **This must be run manually** against each environment (the repo has no automatic migration runner).

## Test plan
- [x] Index DDL syntax reviewed (CONCURRENTLY outside a txn; partial expression index)
- [ ] Run the alter script against staging; `EXPLAIN ANALYZE` the target queries before/after to confirm index usage and no regressions

https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7m8gRAb7t8GBukVB3serJ)_