### PR TITLE
fix(rating): handle expired-session 401 instead of capturing to Sentry

### DIFF
--- a/src/api/puzzle_rating.ts
+++ b/src/api/puzzle_rating.ts
@@ -15,6 +15,16 @@ export class RatingNotEligibleError extends Error {
   }
 }
 
+// Thrown when the request is rejected for an expired/invalid session (401).
+// This is an expected auth-expiry state, not a bug — callers should re-prompt
+// sign-in rather than reporting it to Sentry.
+export class RatingAuthError extends Error {
+  constructor() {
+    super('auth_required');
+    this.name = 'RatingAuthError';
+  }
+}
+
 function authHeaders(accessToken?: string | null): Record<string, string> {
   return accessToken ? {Authorization: `Bearer ${accessToken}`} : {};
 }
@@ -43,6 +53,9 @@ export async function submitPuzzleRating(
   if (resp.status === 403) {
     const body = await resp.json().catch(() => ({}));
     throw new RatingNotEligibleError(body.thresholdPercent ?? 25);
+  }
+  if (resp.status === 401) {
+    throw new RatingAuthError();
   }
   if (!resp.ok) {
     const text = await resp.text().catch(() => '');

--- a/src/components/Game/RatingCompletionModal.tsx
+++ b/src/components/Game/RatingCompletionModal.tsx
@@ -134,6 +134,12 @@ export default function RatingCompletionModal({
   // so Enter dismisses rather than accidentally submitting a 1-star rating.
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
+  // Clear the expired-session warning once a fresh token arrives (e.g. inline
+  // email/password re-login, which doesn't remount this component).
+  useEffect(() => {
+    setAuthError(false);
+  }, [accessToken]);
+
   useEffect(() => {
     const wasSolved = wasSolvedRef.current;
     wasSolvedRef.current = solved;

--- a/src/components/Game/RatingCompletionModal.tsx
+++ b/src/components/Game/RatingCompletionModal.tsx
@@ -4,7 +4,7 @@ import {MdStar, MdStarBorder} from 'react-icons/md';
 import * as Sentry from '@sentry/react';
 import AuthContext from '../../lib/AuthContext';
 import LoginModal from '../Auth/LoginModal';
-import {submitPuzzleRating, RatingNotEligibleError} from '../../api/puzzle_rating';
+import {submitPuzzleRating, RatingNotEligibleError, RatingAuthError} from '../../api/puzzle_rating';
 import {formatMilliseconds} from '../Toolbar/Clock';
 import './css/RatingCompletionModal.css';
 
@@ -122,6 +122,7 @@ export default function RatingCompletionModal({
   const [submitting, setSubmitting] = useState(false);
   const [submittedRating, setSubmittedRating] = useState<number | null>(null);
   const [eligibilityError, setEligibilityError] = useState<number | null>(null);
+  const [authError, setAuthError] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
   // Track previous solved state so we only open on a false→true transition.
   // Otherwise the modal would also pop on any mount where the puzzle is
@@ -170,6 +171,7 @@ export default function RatingCompletionModal({
       if (!accessToken) return;
       setSubmitting(true);
       setEligibilityError(null);
+      setAuthError(false);
       try {
         await submitPuzzleRating(pid, rating, accessToken);
         // Persist that the user has acted on this prompt so we don't pop it
@@ -182,6 +184,12 @@ export default function RatingCompletionModal({
       } catch (err) {
         if (err instanceof RatingNotEligibleError) {
           setEligibilityError(err.thresholdPercent);
+        } else if (err instanceof RatingAuthError) {
+          // Session expired — re-prompt sign-in instead of reporting noise.
+          // writeSignInIntent so the modal re-opens after an OAuth redirect.
+          if (pid) writeSignInIntent(pid);
+          setAuthError(true);
+          setShowLogin(true);
         } else {
           Sentry.captureException(err);
         }
@@ -250,6 +258,9 @@ export default function RatingCompletionModal({
                       You need to reach {eligibilityError}% completion before rating.
                     </p>
                   )}
+                  {authError && (
+                    <p className="rating-completion--hint">Your session expired. Sign in again to rate.</p>
+                  )}
                   {/* Save Replay: only shown for signed-in users who have a snapshot
                       saved but haven't retained the replay yet. Mirrors the toolbar
                       gating in src/components/Toolbar/index.js. */}
@@ -290,7 +301,7 @@ export default function RatingCompletionModal({
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
-      {!user && <LoginModal open={showLogin} onClose={handleCloseLogin} />}
+      {(!user || authError) && <LoginModal open={showLogin} onClose={handleCloseLogin} />}
     </>
   );
 }

--- a/src/components/Game/RatingWidget.tsx
+++ b/src/components/Game/RatingWidget.tsx
@@ -7,6 +7,7 @@ import {
   fetchPuzzleRating,
   submitPuzzleRating,
   RatingNotEligibleError,
+  RatingAuthError,
   PuzzleRatingAggregate,
 } from '../../api/puzzle_rating';
 import './css/RatingWidget.css';
@@ -85,6 +86,7 @@ export default function RatingWidget({pid}: RatingWidgetProps) {
   const [hover, setHover] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const [eligibilityError, setEligibilityError] = useState<number | null>(null);
+  const [authError, setAuthError] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
 
   useEffect(() => {
@@ -95,6 +97,7 @@ export default function RatingWidget({pid}: RatingWidgetProps) {
     // without a key in pages/Game.js so the same instance is reused.
     setAggregate(null);
     setEligibilityError(null);
+    setAuthError(false);
     setHover(0);
     setSubmitting(false);
     fetchPuzzleRating(pid, accessToken)
@@ -114,12 +117,17 @@ export default function RatingWidget({pid}: RatingWidgetProps) {
       if (!accessToken) return;
       setSubmitting(true);
       setEligibilityError(null);
+      setAuthError(false);
       try {
         const next = await submitPuzzleRating(pid, rating, accessToken);
         setAggregate(next);
       } catch (err) {
         if (err instanceof RatingNotEligibleError) {
           setEligibilityError(err.thresholdPercent);
+        } else if (err instanceof RatingAuthError) {
+          // Session expired — re-prompt sign-in instead of reporting noise.
+          setAuthError(true);
+          setShowLogin(true);
         } else {
           Sentry.captureException(err);
         }
@@ -156,7 +164,16 @@ export default function RatingWidget({pid}: RatingWidgetProps) {
       {eligibilityError != null && (
         <div className="rating-widget--hint">Reach {eligibilityError}% completion to rate this puzzle.</div>
       )}
-      {!user && <LoginModal open={showLogin} onClose={handleCloseLogin} />}
+      {authError && (
+        <div className="rating-widget--hint">
+          Your session expired —{' '}
+          <button type="button" className="rating-widget--cta" onClick={handleOpenLogin}>
+            sign in again
+          </button>{' '}
+          to rate.
+        </div>
+      )}
+      {(!user || authError) && <LoginModal open={showLogin} onClose={handleCloseLogin} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes Sentry issue **JAVASCRIPT-REACT-4V** — `Error: {"error":"Authentication required"}` (45 users, ongoing on the live build).

`submitPuzzleRating` threw a generic `Error` on a **401** (expired/invalid access token). Both rating callers gate only on `if (!accessToken) return`, so a *present-but-expired* token slips through, hits the 401, and is reported via `Sentry.captureException` — turning an expected auth-expiry state into a high-volume Sentry issue **while the user's rating silently fails**.

## Changes

- `src/api/puzzle_rating.ts`: add a typed `RatingAuthError` (mirrors the existing `RatingNotEligibleError` 403 pattern) and throw it on `401` from `submitPuzzleRating`.
- `src/components/Game/RatingWidget.tsx` & `RatingCompletionModal.tsx`: catch `RatingAuthError` and **re-prompt sign-in** (reusing the existing `LoginModal` flow) instead of `captureException`. The modal also writes the sign-in intent so it re-opens after a Google OAuth full-page redirect. A small hint tells the user their session expired.

Other error types still flow to `Sentry.captureException`, so genuine failures remain visible.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm eslint --max-warnings 0` on changed files — clean
- [x] `pnpm prettier --check` on changed files — clean
- [ ] Manual: with an expired session, click a star → login modal appears (no Sentry event); after re-auth, rating submits successfully
- [ ] Manual: confirm normal rating submit and the 403 "not eligible" path are unaffected

https://claude.ai/code/session_01R8z3i9cLnANWT1gYpZHg9z

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8z3i9cLnANWT1gYpZHg9z)_