### PR TITLE
Rework card display so more information can be seen on mobile

### DIFF
--- a/src/components/PuzzleList/Entry.tsx
+++ b/src/components/PuzzleList/Entry.tsx
@@ -80,7 +80,11 @@ export default class Entry extends Component<EntryProps> {
     const {title, author, originalTitle, originalAuthor, pid, status, stats, fencing, isPublic} = this.props;
     const numSolvesOld = _.size(stats?.solves || []);
     const numSolves = numSolvesOld + (stats?.numSolves || 0);
-    const displayName = _.compact([author.trim(), this.size]).join(' | ');
+    const displayName = _.compact([this.size, author.trim()]).join(' | ');
+    const originalDisplay =
+      originalTitle || originalAuthor
+        ? `Originally: ${originalTitle || title}${originalAuthor ? ` by ${originalAuthor}` : ''}`
+        : null;
     return (
       <Link
         to={`/beta/play/${pid}${fencing ? '?fencing=1' : ''}`}
@@ -89,15 +93,17 @@ export default class Entry extends Component<EntryProps> {
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- interactive via parent Link */}
         <div className="flex--column entry" onClick={handleClick} onMouseLeave={handleMouseLeave}>
           <div className="flex entry--top--left">
-            <div style={{minWidth: 0}}>
-              <p
-                style={{textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden'}}
-                title={displayName}
-              >
-                {displayName}
+            <div className="flex--column entry--title-block">
+              <p className="entry--title" title={title}>
+                {title}
               </p>
+              {originalDisplay && (
+                <p className="entry--original" title={originalDisplay}>
+                  {originalDisplay}
+                </p>
+              )}
             </div>
-            <div className="flex">
+            <div className="flex entry--status-icons">
               {status === 'started' && !this.props.contest && (
                 <MdRadioButtonUnchecked className="entry--icon" />
               )}
@@ -106,44 +112,33 @@ export default class Entry extends Component<EntryProps> {
               {fencing && <GiCrossedSwords className="entry--icon fencing" />}
             </div>
           </div>
-          <div className="flex entry--main">
-            <div style={{minWidth: 0}}>
-              <p style={{textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden'}} title={title}>
-                {title}
-              </p>
-              {(originalTitle || originalAuthor) && (
-                <p
-                  className="entry--original"
-                  title={`Originally: ${originalTitle || title}${originalAuthor ? ` by ${originalAuthor}` : ''}`}
-                >
-                  Originally: {originalTitle || title}
-                  {originalAuthor ? ` by ${originalAuthor}` : ''}
-                </p>
-              )}
-            </div>
-          </div>
-          <div className="flex entry--details">
-            <p>
-              Solved {numSolves} {numSolves === 1 ? 'time' : 'times'}
+          <div className="flex--column entry--main">
+            <p className="entry--meta-line" title={displayName}>
+              {displayName}
             </p>
-            <div className="flex">
-              {stats?.medianSolveMs != null && (
-                <span
-                  className="entry--solve-time"
-                  title={typicalSolveTitle(stats.medianSolveMs, stats.solveSampleCount)}
-                >
-                  <MdAccessTime className="entry--solve-time-icon" />
-                  {formatMilliseconds(stats.medianSolveMs)}
+            <div className="flex entry--details">
+              <p>
+                Solved {numSolves} {numSolves === 1 ? 'time' : 'times'}
+              </p>
+              <div className="flex entry--detail-stats">
+                {stats?.medianSolveMs != null && (
+                  <span
+                    className="entry--solve-time"
+                    title={typicalSolveTitle(stats.medianSolveMs, stats.solveSampleCount)}
+                  >
+                    <MdAccessTime className="entry--solve-time-icon" />
+                    {formatMilliseconds(stats.medianSolveMs)}
+                  </span>
+                )}
+                <span className="entry--rating" title={ratingTitle(stats?.ratingAverage, stats?.ratingCount)}>
+                  <MdStar className="entry--rating-icon" />
+                  {stats?.ratingAverage != null
+                    ? `${stats.ratingAverage.toFixed(1)} (${stats.ratingCount ?? 0})`
+                    : 'Not yet rated'}
                 </span>
-              )}
-              <span className="entry--rating" title={ratingTitle(stats?.ratingAverage, stats?.ratingCount)}>
-                <MdStar className="entry--rating-icon" />
-                {stats?.ratingAverage != null
-                  ? `${stats.ratingAverage.toFixed(1)} (${stats.ratingCount ?? 0})`
-                  : 'Not yet rated'}
-              </span>
-              {this.props.contest && <span className="entry--contest">Contest</span>}
-              {isPublic === false && <span className="entry--unlisted">Unlisted</span>}
+                {this.props.contest && <span className="entry--contest">Contest</span>}
+                {isPublic === false && <span className="entry--unlisted">Unlisted</span>}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/PuzzleList/__tests__/Entry.test.tsx
+++ b/src/components/PuzzleList/__tests__/Entry.test.tsx
@@ -145,14 +145,14 @@ describe('Entry size classification', () => {
 });
 
 describe('Entry display', () => {
-  it('formats displayName as author | size', () => {
+  it('formats displayName as size | author', () => {
     const entry = makeEntry({
       author: 'John Doe',
       title: 'Untitled',
       info: {type: 'Daily Puzzle'},
     });
-    const displayName = [entry.props.author.trim(), entry.size].filter(Boolean).join(' | ');
-    expect(displayName).toBe('John Doe | Standard');
+    const displayName = [entry.size, entry.props.author.trim()].filter(Boolean).join(' | ');
+    expect(displayName).toBe('Standard | John Doe');
   });
 
   it('handles empty author gracefully', () => {
@@ -161,7 +161,7 @@ describe('Entry display', () => {
       title: 'Untitled',
       info: {type: 'Mini Puzzle'},
     });
-    const displayName = [entry.props.author.trim(), entry.size].filter(Boolean).join(' | ');
+    const displayName = [entry.size, entry.props.author.trim()].filter(Boolean).join(' | ');
     expect(displayName).toBe('Mini');
   });
 

--- a/src/dark.css
+++ b/src/dark.css
@@ -421,8 +421,13 @@
 
 .dark .entry--meta-line,
 .dark .entry--details > p,
-.dark .entry--rating {
+.dark .entry--rating,
+.dark .entry--unlisted {
   color: rgb(255 255 255 / 60%);
+}
+
+.dark .entry--unlisted {
+  border-color: rgb(255 255 255 / 30%);
 }
 
 .dark .entry--original {

--- a/src/dark.css
+++ b/src/dark.css
@@ -207,14 +207,14 @@
   border-bottom-color: var(--dark-blue-1);
 }
 
-.dark .entry--top--left {
-  color: var(--dark-primary-text);
-}
-
 .dark .entry {
   color: var(--dark-primary-text);
   background-color: var(--dark-background-1);
   border-color: rgb(255 255 255 / 30%);
+}
+
+.dark .entry--title {
+  color: var(--dark-primary-text);
 }
 
 .dark .file-uploader--wrapper.v2 {
@@ -415,16 +415,18 @@
   border-color: #f0a050;
 }
 
-.dark .entry--original {
-  color: rgb(255 255 255 / 35%);
-}
-
 .dark .entry--icon.fencing {
   fill: #8a9bb0;
 }
 
+.dark .entry--meta-line,
+.dark .entry--details > p,
 .dark .entry--rating {
   color: rgb(255 255 255 / 60%);
+}
+
+.dark .entry--original {
+  color: rgb(255 255 255 / 40%);
 }
 
 .dark .entry--solve-time,

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -111,15 +111,17 @@
 
 .entry {
   cursor: pointer;
-  white-space: nowrap;
   position: relative;
   border: 1px solid silver;
   border-radius: 12px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  padding: 25px;
+  gap: 14px;
+  padding: 20px;
   font-size: 15px;
+  line-height: 1.4;
+  color: var(--main-gray-1);
+  font-variant-numeric: tabular-nums;
   width: 330px;
 }
 
@@ -128,95 +130,128 @@
 }
 
 .entry--top--left {
-  font-size: 15px;
-  font-weight: 400;
-  color: rgb(0 0 0 / 70%);
   justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
 }
 
+.entry--title-block,
 .entry--main {
-  padding-top: 10px;
+  gap: 6px;
+  min-width: 0;
+}
+
+.entry--title,
+.entry--meta-line,
+.entry--details > p,
+.entry--solve-time,
+.entry--rating,
+.entry--contest,
+.entry--unlisted,
+.entry--original {
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+  margin: 0;
+}
+
+.entry--title {
+  color: rgb(0 0 0 / 87%);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.entry--meta-line,
+.entry--details > p,
+.entry--solve-time,
+.entry--rating,
+.entry--contest,
+.entry--unlisted {
+  font-size: 11px;
+  color: var(--main-gray-1);
 }
 
 .entry--original {
   font-size: 11px;
   color: rgb(0 0 0 / 45%);
-  font-style: italic;
-  margin: 2px 0 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.entry--main {
+  justify-content: flex-end;
 }
 
 .entry--details {
-  padding-top: 10px;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
 }
 
-.entry--details > p {
-  font-size: 0.75em;
+.entry--detail-stats {
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.entry--status-icons {
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
 }
 
 .entry--unlisted {
-  font-size: 10px;
-  font-weight: 600;
-  color: #888;
   border: 1px solid #aaa;
   border-radius: 3px;
-  padding: 1px 5px;
-  margin-right: 4px;
+  padding: 0 5px;
   white-space: nowrap;
 }
 
 .entry--contest {
-  font-size: 10px;
-  font-weight: 600;
   color: #e67e22;
   border: 1px solid #e67e22;
   border-radius: 3px;
-  padding: 1px 5px;
-  margin-right: 4px;
+  padding: 0 5px;
   white-space: nowrap;
 }
 
 .entry--icon {
-  position: relative;
-  z-index: 1;
-  bottom: 15px;
-  left: 15px;
+  position: static;
+  z-index: auto;
+  font-size: 1.1em;
+  line-height: 1;
+  align-self: center;
 }
 
 .entry--rating {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
-  font-size: 10px;
-  font-weight: 600;
-  color: #888;
+  gap: 4px;
   white-space: nowrap;
-  margin-right: 4px;
 }
 
 .entry--rating-icon {
   color: #f5a623;
-  font-size: 12px;
+  font-size: 1em;
+  line-height: 1;
 }
 
 .entry--solve-time {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
-  font-size: 10px;
-  font-weight: 600;
-  color: #888;
+  gap: 4px;
   white-space: nowrap;
-  margin-right: 6px;
 }
 
 .entry--solve-time-icon {
   color: #888;
-  font-size: 12px;
+  font-size: 1em;
+  line-height: 1;
 }
 
 .welcome--sort-select {

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -178,6 +178,10 @@
 .entry--original {
   font-size: 11px;
   color: rgb(0 0 0 / 45%);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
   white-space: normal;
   overflow-wrap: anywhere;
 }

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -159,6 +159,7 @@
   color: rgb(0 0 0 / 87%);
   display: -webkit-box;
   -webkit-box-orient: vertical;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
   overflow: hidden;
   white-space: normal;
@@ -180,6 +181,7 @@
   color: rgb(0 0 0 / 45%);
   display: -webkit-box;
   -webkit-box-orient: vertical;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
   overflow: hidden;
   white-space: normal;


### PR DESCRIPTION
There are some UX issues when selecting a puzzle on mobile. The 'gimmick' clue often placed in the title will be hidden by an ellipsis. The size of the puzzle will be hidden by a long byline.

And then there are a couple of general UX problems. It's difficult to scan titles across many cards because the byline has the prominent position and a competing font size. Dark mode makes it even harder to differentiate byline and title.

This PR makes the following adjustments:

- Move the title to the top of the card
- Wrap the title to 2 lines before ellipsizing (also applies to the optional 'original' title line)
- Reduce the author & size font size to match the other metadata line
- Swap size to the front of the line, so that it's easy to see even when there is a long author line
- Standardize font color used for metadata lines and maintain contrast across light/dark mode

Before & After shots:

<img width="333" height="466" alt="image" src="https://github.com/user-attachments/assets/a89bc82e-8685-437a-9f3d-80c1e40feff3" />

<img width="333" height="483" alt="image" src="https://github.com/user-attachments/assets/799b29ac-1592-49f2-9e3a-4a675dec2c8c" />
