### PR TITLE
Group puzzle size stats

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
       - ./server/sql:/sql
       - ./docker/init-db.sh:/docker-entrypoint-initdb.d/01-init-db.sh
     healthcheck:

--- a/server/__tests__/model/puzzle_solve.test.ts
+++ b/server/__tests__/model/puzzle_solve.test.ts
@@ -80,8 +80,8 @@ describe('getUserSolveStats', () => {
     // Combined stats+day CTE query (size rows then day rows via UNION ALL)
     pool.query.mockResolvedValueOnce({
       rows: [
-        {stat_type: 'size', key: '15x15', count: 5, avg_time: 300},
-        {stat_type: 'day', key: 'Mon', count: 3, avg_time: 120},
+        {stat_type: 'size', solve_mode: 'all', key: 'Standard', count: 5, avg_time: 300},
+        {stat_type: 'day', solve_mode: 'all', key: 'Mon', count: 3, avg_time: 120},
       ],
     });
     // History query
@@ -94,6 +94,12 @@ describe('getUserSolveStats', () => {
     expect(result).toHaveProperty('bySize');
     expect(result).toHaveProperty('byDay');
     expect(result).toHaveProperty('history');
+    expect(result.bySize).toEqual([
+      {size: 'Large', count: 0, avgTime: null},
+      {size: 'Standard', count: 5, avgTime: 300},
+      {size: 'Midi', count: 0, avgTime: null},
+      {size: 'Mini', count: 0, avgTime: null},
+    ]);
     expect(result.byDay).toEqual([{day: 'Mon', count: 3, avgTime: 120}]);
   });
 
@@ -101,15 +107,47 @@ describe('getUserSolveStats', () => {
     // Combined stats CTE returns both size rows
     pool.query.mockResolvedValueOnce({
       rows: [
-        {stat_type: 'size', key: '5x5', count: 3, avg_time: 60},
-        {stat_type: 'size', key: '15x15', count: 7, avg_time: 300},
+        {stat_type: 'size', solve_mode: 'all', key: 'Mini', count: 3, avg_time: 60},
+        {stat_type: 'size', solve_mode: 'all', key: 'Standard', count: 7, avg_time: 300},
       ],
     });
     pool.query.mockResolvedValueOnce({rows: []}); // history
 
     const result = await getUserSolveStats('user-1');
     expect(result.totalSolved).toBe(10);
-    expect(result.bySize).toHaveLength(2);
+    expect(result.bySize).toEqual([
+      {size: 'Large', count: 0, avgTime: null},
+      {size: 'Standard', count: 7, avgTime: 300},
+      {size: 'Midi', count: 0, avgTime: null},
+      {size: 'Mini', count: 3, avgTime: 60},
+    ]);
+  });
+
+  it('returns four size buckets in fixed order for each mode', async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [
+        {stat_type: 'size', solve_mode: 'solo', key: 'Midi', count: 2, avg_time: 180},
+        {stat_type: 'size', solve_mode: 'coop', key: 'Large', count: 4, avg_time: 900},
+        {stat_type: 'size', solve_mode: 'all', key: 'Large', count: 4, avg_time: 900},
+        {stat_type: 'size', solve_mode: 'all', key: 'Midi', count: 2, avg_time: 180},
+      ],
+    });
+    pool.query.mockResolvedValueOnce({rows: []});
+
+    const result = await getUserSolveStats('user-1');
+
+    expect(result.bySizeSolo).toEqual([
+      {size: 'Large', count: 0, avgTime: null},
+      {size: 'Standard', count: 0, avgTime: null},
+      {size: 'Midi', count: 2, avgTime: 180},
+      {size: 'Mini', count: 0, avgTime: null},
+    ]);
+    expect(result.bySizeCoop).toEqual([
+      {size: 'Large', count: 4, avgTime: 900},
+      {size: 'Standard', count: 0, avgTime: null},
+      {size: 'Midi', count: 0, avgTime: null},
+      {size: 'Mini', count: 0, avgTime: null},
+    ]);
   });
 
   it('defaults title to "Untitled" and playerCount to 1', async () => {

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -70,14 +70,41 @@ export async function getPuzzle(pid: string): Promise<PuzzleJson | null> {
   return row ? row.content : null;
 }
 
-const GRID_MAX_DIM = `GREATEST(jsonb_array_length(content->'grid'), jsonb_array_length(content->'grid'->0))`;
-const TITLE_HAS_MINI = `(content->'info'->>'title') ~* '\\mmini\\M'`;
-const TITLE_HAS_MIDI = `(content->'info'->>'title') ~* '\\mmidi\\M'`;
+export const PUZZLE_SIZE_BUCKET_ORDER = ['Large', 'Standard', 'Midi', 'Mini'] as const;
+
+export function getPuzzleGridMaxDimSql(contentExpr: string): string {
+  return `GREATEST(jsonb_array_length(${contentExpr}->'grid'), jsonb_array_length(${contentExpr}->'grid'->0))`;
+}
+
+export function getPuzzleTitleHasMiniSql(contentExpr: string): string {
+  return `(${contentExpr}->'info'->>'title') ~* '\\mmini\\M'`;
+}
+
+export function getPuzzleTitleHasMidiSql(contentExpr: string): string {
+  return `(${contentExpr}->'info'->>'title') ~* '\\mmidi\\M'`;
+}
+
+export function getPuzzleSizeBucketSql(contentExpr: string): string {
+  const gridMaxDim = getPuzzleGridMaxDimSql(contentExpr);
+  const titleHasMini = getPuzzleTitleHasMiniSql(contentExpr);
+  const titleHasMidi = getPuzzleTitleHasMidiSql(contentExpr);
+
+  return `CASE
+    WHEN ${titleHasMidi} OR (${gridMaxDim} BETWEEN 9 AND 12 AND NOT ${titleHasMini}) THEN 'Midi'
+    WHEN (${titleHasMini} AND NOT ${titleHasMidi}) OR (${gridMaxDim} <= 8 AND NOT ${titleHasMidi}) THEN 'Mini'
+    WHEN ${gridMaxDim} BETWEEN 13 AND 16 AND NOT ${titleHasMini} AND NOT ${titleHasMidi} THEN 'Standard'
+    ELSE 'Large'
+  END`;
+}
 
 const buildSizeFilterClause = (sizeFilter: ListPuzzleRequestFilters['sizeFilter']): string => {
   const allSelected = sizeFilter.Mini && sizeFilter.Midi && sizeFilter.Standard && sizeFilter.Large;
   const noneSelected = !sizeFilter.Mini && !sizeFilter.Midi && !sizeFilter.Standard && !sizeFilter.Large;
   if (allSelected || noneSelected) return '';
+
+  const gridMaxDim = getPuzzleGridMaxDimSql('content');
+  const titleHasMini = getPuzzleTitleHasMiniSql('content');
+  const titleHasMidi = getPuzzleTitleHasMidiSql('content');
 
   // Size classification: title takes priority over grid size
   // Mini: title contains "mini" (not "midi"), OR grid ≤8 without "midi" in title
@@ -87,16 +114,16 @@ const buildSizeFilterClause = (sizeFilter: ListPuzzleRequestFilters['sizeFilter'
   const conditions: string[] = [];
   if (sizeFilter.Mini) {
     conditions.push(
-      `(${TITLE_HAS_MINI} AND NOT ${TITLE_HAS_MIDI}) OR (${GRID_MAX_DIM} <= 8 AND NOT ${TITLE_HAS_MIDI})`
+      `(${titleHasMini} AND NOT ${titleHasMidi}) OR (${gridMaxDim} <= 8 AND NOT ${titleHasMidi})`
     );
   }
   if (sizeFilter.Midi) {
-    conditions.push(`${TITLE_HAS_MIDI} OR (${GRID_MAX_DIM} BETWEEN 9 AND 12 AND NOT ${TITLE_HAS_MINI})`);
+    conditions.push(`${titleHasMidi} OR (${gridMaxDim} BETWEEN 9 AND 12 AND NOT ${titleHasMini})`);
   }
   if (sizeFilter.Standard)
-    conditions.push(`${GRID_MAX_DIM} BETWEEN 13 AND 16 AND NOT ${TITLE_HAS_MINI} AND NOT ${TITLE_HAS_MIDI}`);
+    conditions.push(`${gridMaxDim} BETWEEN 13 AND 16 AND NOT ${titleHasMini} AND NOT ${titleHasMidi}`);
   if (sizeFilter.Large)
-    conditions.push(`${GRID_MAX_DIM} >= 17 AND NOT ${TITLE_HAS_MINI} AND NOT ${TITLE_HAS_MIDI}`);
+    conditions.push(`${gridMaxDim} >= 17 AND NOT ${titleHasMini} AND NOT ${titleHasMidi}`);
 
   return `AND (${conditions.join(' OR ')})`;
 };

--- a/server/model/puzzle_solve.ts
+++ b/server/model/puzzle_solve.ts
@@ -1,6 +1,7 @@
 import {pool} from './pool';
 import {dayOfWeekExtract} from './sql_helpers';
 import {TTLCache} from './ttl_cache';
+import {getPuzzleSizeBucketSql, PUZZLE_SIZE_BUCKET_ORDER} from './puzzle';
 
 // ---- In-memory TTL cache for in-progress games ----
 const inProgressGamesCache = new TTLCache<InProgressGameItem[]>({ttlMs: 5 * 60_000, maxSize: 2_000});
@@ -45,7 +46,7 @@ export type UserSolveHistoryItem = {
 export type SizeStats = {
   size: string;
   count: number;
-  avgTime: number;
+  avgTime: number | null;
 };
 
 export type DayOfWeekStats = {
@@ -83,6 +84,8 @@ export async function getUserSolveStats(userId: string): Promise<{
   byDayCoop: DayOfWeekStats[];
   history: UserSolveHistoryItem[];
 }> {
+  const puzzleSizeBucketSql = getPuzzleSizeBucketSql('p.content');
+
   // Run size+day stats query and history query in parallel.
   // Both use lightweight JSONB extraction (no full content fetch).
   const [combinedStatsResult, historyResult] = await Promise.all([
@@ -94,10 +97,7 @@ export async function getUserSolveStats(userId: string): Promise<{
           ps.pid,
           ps.time_taken_to_solve AS best_time,
           CASE WHEN COALESCE(ps.player_count, 1) = 1 THEN 'solo' ELSE 'coop' END AS solve_mode,
-          GREATEST(jsonb_array_length(p.content->'grid'), jsonb_array_length(p.content->'grid'->0))::text
-            || 'x' ||
-          LEAST(jsonb_array_length(p.content->'grid'), jsonb_array_length(p.content->'grid'->0))::text
-            AS size,
+          ${puzzleSizeBucketSql} AS size,
           ${dayOfWeekExtract('p')} AS dow
         FROM puzzle_solves ps
         JOIN puzzles p ON ps.pid = p.pid
@@ -156,15 +156,22 @@ export async function getUserSolveStats(userId: string): Promise<{
   for (const r of combinedStatsResult.rows) {
     const bucket = statsByMode[r.solve_mode] || statsByMode.all;
     if (r.stat_type === 'size') {
-      bucket.bySize.push({size: r.key, count: r.count, avgTime: r.avg_time});
+      bucket.bySize.push({
+        size: r.key,
+        count: r.count,
+        avgTime: r.avg_time === null ? null : Number(r.avg_time),
+      });
       bucket.total += r.count;
     } else {
       bucket.byDay.push({day: r.key, count: r.count, avgTime: r.avg_time});
     }
   }
-  // Sort bySize by count descending for each mode
+
   for (const mode of Object.values(statsByMode)) {
-    mode.bySize.sort((a, b) => b.count - a.count);
+    const bySizeMap = new Map(mode.bySize.map((stat) => [stat.size, stat]));
+    mode.bySize = PUZZLE_SIZE_BUCKET_ORDER.map(
+      (size) => bySizeMap.get(size) || {size, count: 0, avgTime: null}
+    );
   }
 
   // For collaborative solves, batch co-solver + count into a single query

--- a/src/api/user_stats.ts
+++ b/src/api/user_stats.ts
@@ -24,7 +24,7 @@ export interface SolveHistoryItem {
 export interface SizeStats {
   size: string;
   count: number;
-  avgTime: number;
+  avgTime: number | null;
 }
 
 export interface DayOfWeekStats {

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -182,7 +182,7 @@ function StatsCards({stats}) {
           ))}
         </div>
       )}
-      <div className="profile--stats-grid">
+      <div className="profile--stats-grid profile--stats-grid--sizes">
         <div className="profile--stat-card">
           <div className="profile--stat-card--value">{total}</div>
           <div className="profile--stat-card--label">Puzzles Solved</div>

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -191,7 +191,7 @@ function StatsCards({stats}) {
           <div key={s.size} className="profile--stat-card">
             <div className="profile--stat-card--value">{s.count}</div>
             <div className="profile--stat-card--label">{s.size}</div>
-            <div className="profile--stat-card--sub">avg {formatTime(s.avgTime)}</div>
+            {s.avgTime !== null && <div className="profile--stat-card--sub">avg {formatTime(s.avgTime)}</div>}
           </div>
         ))}
       </div>

--- a/src/pages/css/profile.css
+++ b/src/pages/css/profile.css
@@ -11,6 +11,7 @@
   max-width: 700px;
   margin: 0 auto;
   padding: 20px;
+  container-type: inline-size;
 }
 
 .profile--header {
@@ -63,6 +64,31 @@
   gap: 12px;
   margin-bottom: 24px;
   flex-wrap: wrap;
+}
+
+.profile--stats-grid--sizes {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.profile--stats-grid--sizes .profile--stat-card {
+  min-width: 0;
+}
+
+@container (width <= 635px) {
+  .profile--stats-grid--sizes {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .profile--stats-grid--sizes .profile--stat-card:first-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@container (width <= 571px) {
+  .profile--stats-grid--sizes {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .profile--stat-card {
@@ -254,7 +280,7 @@
   display: none;
 }
 
-@media (width <= 480px) {
+@media (width <= 760px) {
   .profile--actions {
     white-space: nowrap;
     font-size: 12px;


### PR DESCRIPTION
Resolves #560 

This PR groups profile complete stats by the Large/Standard/Midi/Mini classification. It uses the same grid size classifier as the filter feature uses.

The main benefit is for mobile users, who no longer have to scroll past possibly dozens of tiles for nearly identical grid sizes (9x9, 7x7, 8x7, 10x9, 10x10, etc.) There is a secondary benefit to the app experience, since players can now see their average solve times with more meaningful groupings than grid size.

On the implementation side, there are now 3 breakpoints. If the screen is wide enough, it will comfortably show all 5 stats in one line (the 5th stat is your overall solve count.) As the screen shrinks, it first moves to a layout with the overall solve count on its own line, followed by the 4 size groupings on their own line. Finally, at the smallest screen widths (mobile) it will break the 4 size groupings up into a 2x2 grid.

<img width="425" height="500" alt="image" src="https://github.com/user-attachments/assets/3ef4db88-f9d6-45f5-9263-244f64a523a1" />
<img width="580" height="391" alt="image" src="https://github.com/user-attachments/assets/e4e16161-f268-4c60-a65c-afb0d3fce576" />
<img width="745" height="295" alt="image" src="https://github.com/user-attachments/assets/8c594185-0860-4c5b-9533-1e49b326a3f1" />
