### PR TITLE
fix(deps): bump react-router to ^7.17.0 to resolve audit advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-dropzone": "^15.0.0",
     "react-helmet-async": "^2.0.5",
     "react-icons": "^5.6.0",
-    "react-router": "^7.13.2",
+    "react-router": "^7.17.0",
     "resend": "^6.12.3",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: ^5.6.0
         version: 5.6.0(react@19.2.4)
       react-router:
-        specifier: ^7.13.2
-        version: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^7.17.0
+        version: 7.17.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       resend:
         specifier: ^6.12.3
         version: 6.12.3
@@ -2682,6 +2682,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -5216,8 +5217,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-router@7.13.2:
-    resolution: {integrity: sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==}
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -11782,7 +11783,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-router@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.17.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       cookie: 1.1.1
       react: 19.2.4


### PR DESCRIPTION
Bumps `react-router` from `^7.13.2` to `^7.17.0` to clear 4 `pnpm audit` advisories present on `master` (which also fail the Security Audit job on open PRs like #570):

- **high** — turbo-stream RCE via `TYPE_ERROR` deserialization (GHSA-49rj-9fvp-4h2h)
- **high** — DoS via unbounded path expansion in `__manifest` (GHSA-8x6r-g9mw-2r78)
- **high** — DoS via reflected input in single-fetch (GHSA-rxv8-25v2-qmq8)
- **moderate** — open redirect via protocol-relative URL (GHSA-2j2x-hqr9-3h42)

Patched versions require `>=7.15.0`; bumped to the latest `7.17.0`.

Verified:
- `pnpm audit --ignore-registry-errors` → No known vulnerabilities found
- `pnpm tsc --noEmit` passes (minor bump is API-compatible)
- Lockfile regenerates clean

https://claude.ai/code/session_01Txn11Qk4XQAiDfQgmAxiLG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txn11Qk4XQAiDfQgmAxiLG)_