### PR TITLE
Zen Mode

### DIFF
--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -314,6 +314,8 @@ export default class Chat extends Component {
     const displayAuthor = authorOverride || author;
     const desc = description?.startsWith('; ') ? description.substring(2) : description;
     const hasOverride = titleOverride || authorOverride;
+    // Zen mode: hide spoilers (median time, rating) until the puzzle is solved.
+    const showStats = !this.context?.preferences?.zenMode || !!game?.solved;
 
     return (
       <div className="chat--header">
@@ -351,8 +353,8 @@ export default class Chat extends Component {
             {this.state.copiedPuzzleId && <span className="chat--header--puzzle-id-copied">Copied</span>}
           </button>
         )}
-        {pid && <PuzzleStatsLine pid={String(pid)} />}
-        {pid && <RatingWidget pid={String(pid)} />}
+        {pid && showStats && <PuzzleStatsLine pid={String(pid)} />}
+        {pid && showStats && <RatingWidget pid={String(pid)} />}
         {!this.isOwner && this.props.locked && (
           <>
             <button

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import _ from 'lodash';
 import Linkify from 'linkify-react';
 import {Link} from 'react-router';
-import {MdClose, MdErrorOutline, MdHelpOutline, MdLock} from 'react-icons/md';
+import {MdClose, MdErrorOutline, MdHelpOutline, MdLock, MdVisibilityOff} from 'react-icons/md';
 import {FaClone, FaCrown} from 'react-icons/fa6';
 import * as Sentry from '@sentry/react';
 import Emoji from '../common/Emoji';
@@ -21,6 +21,7 @@ import InfoDialog from '../common/InfoDialog';
 import AuthContext from '../../lib/AuthContext';
 import {kickPlayer, unkickPlayer} from '../../api/create_game';
 import {copyPuzzleId} from './puzzleId';
+import {getUserStats} from '../../api/user_stats';
 
 const isEmojis = (str) => {
   const res = str.match(/[A-Za-z,.0-9!-]/g);
@@ -39,6 +40,7 @@ export default class Chat extends Component {
       unkickTarget: null,
       showLockInfo: false,
       copiedPuzzleId: false,
+      solvedPids: null,
     };
     this.chatBar = React.createRef();
     this.usernameInput = React.createRef();
@@ -135,6 +137,17 @@ export default class Chat extends Component {
     const username = this.props.initialUsername;
     this.setState({username});
     this.handleUpdateDisplayName(username);
+
+    // Zen mode hides spoilers per-puzzle, lifetime — not per-game-instance —
+    // so a fresh game on a puzzle you've already solved elsewhere shouldn't
+    // re-hide stats. Only authenticated users can have zen mode active (see
+    // showStats below), so only fetch for them.
+    const {isAuthenticated, user, accessToken} = this.context || {};
+    if (isAuthenticated && user?.id && accessToken) {
+      getUserStats(user.id, accessToken).then((stats) => {
+        if (stats?.solvedPids) this.setState({solvedPids: stats.solvedPids});
+      });
+    }
   }
 
   componentWillUnmount() {
@@ -315,7 +328,13 @@ export default class Chat extends Component {
     const desc = description?.startsWith('; ') ? description.substring(2) : description;
     const hasOverride = titleOverride || authorOverride;
     // Zen mode: hide spoilers (median time, rating) until the puzzle is solved.
-    const showStats = !this.context?.preferences?.zenMode || !!game?.solved;
+    // Account-only — a guest must not inherit a stale localStorage flag left
+    // over from a previous logged-in session. "Solved" is lifetime per-pid
+    // (have you ever solved this puzzle), not per-game-instance, so a fresh
+    // game on an already-solved puzzle doesn't re-hide stats.
+    const zenModeActive = !!this.context?.isAuthenticated && !!this.context?.preferences?.zenMode;
+    const alreadySolved = !!game?.solved || !!(pid && this.state.solvedPids?.includes(pid));
+    const showStats = !zenModeActive || alreadySolved;
 
     return (
       <div className="chat--header">
@@ -355,6 +374,15 @@ export default class Chat extends Component {
         )}
         {pid && showStats && <PuzzleStatsLine pid={String(pid)} />}
         {pid && showStats && <RatingWidget pid={String(pid)} />}
+        {pid && !showStats && (
+          <span
+            className="chat--zen-hidden-chip"
+            title="Rating and solve time are hidden until you finish this puzzle (Zen Mode)"
+          >
+            <MdVisibilityOff className="chat--zen-hidden-chip-icon" />
+            Hidden by Zen Mode
+          </span>
+        )}
         {!this.isOwner && this.props.locked && (
           <>
             <button

--- a/src/components/Chat/css/index.css
+++ b/src/components/Chat/css/index.css
@@ -128,6 +128,31 @@
   border-color: rgb(240 212 136 / 35%);
 }
 
+.chat--zen-hidden-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #5b3f99;
+  background: #f1ecfb;
+  border: 1px solid #8e6fc9;
+  border-radius: 12px;
+  width: fit-content;
+}
+
+.chat--zen-hidden-chip-icon {
+  font-size: 13px;
+}
+
+.dark .chat--zen-hidden-chip {
+  color: #b79df0;
+  background: rgb(183 157 240 / 12%);
+  border-color: rgb(183 157 240 / 35%);
+}
+
 .chat--username {
   padding: 5px;
   padding-top: 10px;

--- a/src/components/PuzzleList/Entry.tsx
+++ b/src/components/PuzzleList/Entry.tsx
@@ -1,6 +1,6 @@
 import {Component} from 'react';
 import _ from 'lodash';
-import {MdRadioButtonUnchecked, MdCheckCircle, MdStar, MdAccessTime} from 'react-icons/md';
+import {MdRadioButtonUnchecked, MdCheckCircle, MdStar, MdAccessTime, MdVisibilityOff} from 'react-icons/md';
 import {GiCrossedSwords} from 'react-icons/gi';
 import {Link} from 'react-router';
 import {formatMilliseconds} from '../Toolbar/Clock';
@@ -27,6 +27,7 @@ export interface EntryProps {
   fencing?: boolean;
   isPublic?: boolean;
   contest?: boolean;
+  zenMode?: boolean;
 }
 
 function ratingTitle(average: number | null | undefined, count: number | undefined): string {
@@ -78,6 +79,8 @@ export default class Entry extends Component<EntryProps> {
 
   render() {
     const {title, author, originalTitle, originalAuthor, pid, status, stats, fencing, isPublic} = this.props;
+    // Zen mode: hide spoilers (median time, rating) until this puzzle is solved.
+    const showStats = !this.props.zenMode || status === 'solved';
     const numSolvesOld = _.size(stats?.solves || []);
     const numSolves = numSolvesOld + (stats?.numSolves || 0);
     const displayName = _.compact([this.size, author.trim()]).join(' | ');
@@ -121,7 +124,7 @@ export default class Entry extends Component<EntryProps> {
                 Solved {numSolves} {numSolves === 1 ? 'time' : 'times'}
               </p>
               <div className="flex entry--detail-stats">
-                {stats?.medianSolveMs != null && (
+                {showStats && stats?.medianSolveMs != null && (
                   <span
                     className="entry--solve-time"
                     title={typicalSolveTitle(stats.medianSolveMs, stats.solveSampleCount)}
@@ -130,12 +133,26 @@ export default class Entry extends Component<EntryProps> {
                     {formatMilliseconds(stats.medianSolveMs)}
                   </span>
                 )}
-                <span className="entry--rating" title={ratingTitle(stats?.ratingAverage, stats?.ratingCount)}>
-                  <MdStar className="entry--rating-icon" />
-                  {stats?.ratingAverage != null
-                    ? `${stats.ratingAverage.toFixed(1)} (${stats.ratingCount ?? 0})`
-                    : 'Not yet rated'}
-                </span>
+                {showStats && (
+                  <span
+                    className="entry--rating"
+                    title={ratingTitle(stats?.ratingAverage, stats?.ratingCount)}
+                  >
+                    <MdStar className="entry--rating-icon" />
+                    {stats?.ratingAverage != null
+                      ? `${stats.ratingAverage.toFixed(1)} (${stats.ratingCount ?? 0})`
+                      : 'Not yet rated'}
+                  </span>
+                )}
+                {!showStats && (
+                  <span
+                    className="entry--zen-hidden"
+                    title="Rating and solve time are hidden until you finish this puzzle (Zen Mode)"
+                  >
+                    <MdVisibilityOff className="entry--zen-hidden-icon" />
+                    Hidden by Zen Mode
+                  </span>
+                )}
                 {this.props.contest && <span className="entry--contest">Contest</span>}
                 {isPublic === false && <span className="entry--unlisted">Unlisted</span>}
               </div>

--- a/src/components/PuzzleList/NewPuzzleList.tsx
+++ b/src/components/PuzzleList/NewPuzzleList.tsx
@@ -26,9 +26,10 @@ interface NewPuzzleListProps {
 }
 
 const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
-  const {accessToken, user} = useContext(AuthContext) as {
+  const {accessToken, user, preferences} = useContext(AuthContext) as {
     accessToken: string | null;
     user: {id: string} | null;
+    preferences: {zenMode?: boolean} | null;
   };
   const containerRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState<boolean>(false);
@@ -194,6 +195,7 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
         fencing: props.fencing,
         isPublic: puzzle.isPublic,
         contest: puzzle.content.contest,
+        zenMode: preferences?.zenMode,
       },
     }))
     .filter((data) => {
@@ -246,6 +248,7 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
             fencing={entryProps.fencing}
             isPublic={entryProps.isPublic}
             contest={entryProps.contest}
+            zenMode={entryProps.zenMode}
           />
         </div>
       ))}

--- a/src/components/PuzzleList/NewPuzzleList.tsx
+++ b/src/components/PuzzleList/NewPuzzleList.tsx
@@ -195,7 +195,9 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
         fencing: props.fencing,
         isPublic: puzzle.isPublic,
         contest: puzzle.content.contest,
-        zenMode: preferences?.zenMode,
+        // Zen mode is account-only — a guest must not inherit a stale
+        // localStorage flag left over from a previous logged-in session.
+        zenMode: !!user && preferences?.zenMode,
       },
     }))
     .filter((data) => {

--- a/src/dark.css
+++ b/src/dark.css
@@ -415,6 +415,11 @@
   border-color: #f0a050;
 }
 
+.dark .entry--zen-hidden {
+  color: #b79df0;
+  border-color: #b79df0;
+}
+
 .dark .entry--icon.fencing {
   fill: #8a9bb0;
 }

--- a/src/lib/AuthContext.js
+++ b/src/lib/AuthContext.js
@@ -14,6 +14,7 @@ const PREF_STORAGE_MAP = {
   darkMode: {key: 'dark_mode_preference', type: 'string', default: '0'},
   colorAttribution: {key: null, type: 'json', default: false},
   sound: {key: 'sound', type: 'json', default: true},
+  zenMode: {key: 'zen-mode', type: 'json', default: false},
 };
 
 function readLocalStoragePrefs() {

--- a/src/lib/redirect.js
+++ b/src/lib/redirect.js
@@ -1,8 +1,0 @@
-let redirected = false;
-
-export default (url, message) => {
-  if (redirected) return;
-  redirected = true;
-  if (message) alert(message);
-  window.location.replace(url);
-};

--- a/src/lib/withRouter.js
+++ b/src/lib/withRouter.js
@@ -1,11 +1,12 @@
-import {useParams, useLocation} from 'react-router';
+import {useParams, useLocation, useNavigate} from 'react-router';
 
 export default function withRouter(Component) {
   function WrappedComponent(props) {
     const params = useParams();
     const location = useLocation();
+    const navigate = useNavigate();
     // eslint-disable-next-line react/jsx-props-no-spreading
-    return <Component {...props} match={{params}} location={location} />;
+    return <Component {...props} match={{params}} location={location} navigate={navigate} />;
   }
   WrappedComponent.displayName = `withRouter(${Component.displayName || Component.name})`;
   return WrappedComponent;

--- a/src/pages/Account.js
+++ b/src/pages/Account.js
@@ -100,6 +100,11 @@ function GamePreferencesSection({preferences, savePreference, darkModePreference
     {key: 'showProgress', label: 'Show progress', value: preferences?.showProgress ?? true},
     {key: 'colorAttribution', label: 'Color Attribution', value: preferences?.colorAttribution ?? false},
     {key: 'sound', label: 'Sound on solve', value: preferences?.sound ?? true},
+    {
+      key: 'zenMode',
+      label: 'Zen mode (hide ratings & times until solved)',
+      value: preferences?.zenMode ?? false,
+    },
   ];
 
   return (

--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -11,7 +11,6 @@ import * as Sentry from '@sentry/react';
 import Nav from '../components/common/Nav';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 import actions from '../actions';
-import redirect from '../lib/redirect';
 import {createGame, dismissGame} from '../api/create_game';
 import {fetchPuzzleInfo, fetchPuzzleStats} from '../api/puzzle';
 import {fetchUserGames} from '../api/user_games';
@@ -160,7 +159,7 @@ class Play extends Component {
         href = `/beta/game/${gid}`;
       }
 
-      redirect(href, null);
+      this.props.navigate(href);
     }
   }
 
@@ -171,7 +170,7 @@ class Play extends Component {
       .getNextGid(async (gid) => {
         try {
           await createGame({gid, pid: this.pid, dfac_id: getLocalId()}, accessToken);
-          redirect(this.is_fencing ? `/fencing/${gid}` : `/beta/game/${gid}`);
+          this.props.navigate(this.is_fencing ? `/fencing/${gid}` : `/beta/game/${gid}`);
         } catch (e) {
           console.error('Failed to create game:', e);
           // createGame already reports to Sentry for unexpected errors.
@@ -192,7 +191,7 @@ class Play extends Component {
       .getNextGid(async (gid) => {
         try {
           await createGame({gid, pid: this.pid, dfac_id: getLocalId()}, accessToken);
-          redirect(`/fencing/${gid}`);
+          this.props.navigate(`/fencing/${gid}`);
         } catch (e) {
           console.error('Failed to create fencing game:', e);
           // Same as create() — createGame handles Sentry capture and 429 marking.

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -226,6 +226,22 @@
   white-space: nowrap;
 }
 
+.entry--zen-hidden {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #8e6fc9;
+  border: 1px solid #8e6fc9;
+  border-radius: 3px;
+  padding: 0 5px;
+  white-space: nowrap;
+}
+
+.entry--zen-hidden-icon {
+  font-size: 1em;
+  line-height: 1;
+}
+
 .entry--icon {
   position: static;
   z-index: auto;


### PR DESCRIPTION
## Reasoning
Seeing a puzzle's rating and median solve time before my own attempt often predisposes my attitudes towards that puzzle. For example, a high rating with a low median time can make me doubly sour on a puzzle if I'm not enjoying the solving experience and am already taking a long time. I find that it's easy to make assumptions about a puzzle's quality and difficulty based on those two statistics, which is unfair to an individual puzzle. 

Zen Mode lets users opt out of that, while still keeping solve-count visible.

## Description 
- Add a "Zen Mode" to the user settings, which hides ratings and median times (but not amount of solves) from the user unless they have solved the puzzle
- Clear indications on puzzle directory page and in game that Zen Mode is enabled
- Fully-optional; this will have no impact on people who prefer to play with ratings and times visible.

## Screenshots
**Image 1:**
<img width="799" height="296" alt="image" src="https://github.com/user-attachments/assets/073841a8-f0f8-4897-8b63-7f16fcec5f17" />

**Caption 1:** Zen Mode as seen in the puzzle directory (compare in-progress to incomplete and complete)

---

**Image 2:**
<img width="536" height="297" alt="image" src="https://github.com/user-attachments/assets/d363ad21-3055-45e2-b8ff-03129de51a24" />

**Caption 2:** Zen Mode as seen in the chat header when in game

---

**Image 3:**
<img width="500" height="485" alt="image" src="https://github.com/user-attachments/assets/9fa090ad-03b2-44db-bdef-876f022133f4" />

**Caption 3:** Display in `/account` page

## Notes
- Only available to users with accounts, since settings menu is only available when logged in
- Replaying an already completed puzzle will not reactivate Zen Mode's blocking of rating and median time in chat header


## Testing
- Firefox 151, PostgreSQL 18.3
- Tested for light + dark mode compatibility
- Tested mobile view (using Firefox mobile simulation mode)
- No automated tests added (manually checked only)