### PR TITLE
fix(deps): bump undici to ^7.28.0 to clear Dependabot advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "diff": "^5.2.0",
       "glob": "^13.0.6",
       "test-exclude>glob": "7",
-      "undici": ">=7.24.0",
+      "undici": "^7.28.0",
       "flatted": ">=3.4.2",
       "socket.io-parser": ">=4.2.6",
       "axios": ">=1.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   diff: ^5.2.0
   glob: ^13.0.6
   test-exclude>glob: '7'
-  undici: '>=7.24.0'
+  undici: ^7.28.0
   flatted: '>=3.4.2'
   socket.io-parser: '>=4.2.6'
   axios: '>=1.15.2'
@@ -5968,8 +5968,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.24.6:
-    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -8382,7 +8382,7 @@ snapshots:
   '@rollup/plugin-babel@5.3.1(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@2.80.0)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
       rollup: 2.80.0
     optionalDependencies:
@@ -10714,7 +10714,7 @@ snapshots:
 
   is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -11215,7 +11215,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.6
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -12787,7 +12787,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.24.6: {}
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Clears the remaining Dependabot advisories that were tripping the `pnpm audit` CI gate (the `Security Audit` job) and, transitively, blocking the `Build` job.

After #575 merged, a fresh batch of **`undici`** advisories was published — 7 in `pnpm audit` terms (3 high / 2 moderate / 2 low). Every one reaches the dependency tree **only transitively via `jsdom`**, which is a test-only dependency (the vitest `jsdom` environment); none of these are shipped to production.

## Change

Bumped the existing `undici` pnpm override from `>=7.24.0` to **`^7.28.0`**.

The caret upper bound is deliberate and load-bearing: an unbounded `>=7.28.0` resolves `jsdom`'s `undici` to **8.x**, whose internal module layout drops `lib/handler/wrap-handler.js`. `jsdom@28.1.0` deep-imports that file, so undici 8.x breaks the jsdom dispatcher and the entire vitest jsdom test environment fails to start (23 unhandled errors). Constraining to the **7.x line** (`^7.28.0`, latest `7.28.0`) lands the security patch while keeping jsdom working.

## Verification (local, full CI-equivalent)

- `pnpm audit` → **No known vulnerabilities found**
- `pnpm build` → succeeds
- Lockfile stable (`pnpm install --lockfile-only` produces no diff)
- Frontend tests: **388 passed**
- Server tests: **294 passed**

## Notes

- These advisories live entirely in dev/test tooling (`jsdom` → `undici`), not in production runtime code.
- The `Security Audit` job fails on *any* advisory regardless of severity. Newly-published CVEs in transitive dev deps will keep tripping it periodically; if desired, the gate could be relaxed to `--audit-level high` or `--prod` in a separate change — not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvF4aMhDkRs5GZoAVyT38o)_