### PR TITLE
Add zenMode to auth.ts

### DIFF
--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -607,6 +607,7 @@ const preferencesSchema = Joi.object({
   darkMode: Joi.string().valid('0', '1', '2'),
   colorAttribution: Joi.boolean(),
   sound: Joi.boolean(),
+  zenMode: Joi.boolean(),
 }).unknown(false);
 
 /**
@@ -630,6 +631,7 @@ const preferencesSchema = Joi.object({
  *               darkMode: {type: string, enum: ['0', '1', '2']}
  *               colorAttribution: {type: boolean}
  *               sound: {type: boolean}
+ *               zenMode: {type: boolean}
  *     responses:
  *       200:
  *         description: Preferences updated

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -7,6 +7,8 @@ export interface UserPreferences {
   showProgress?: boolean;
   darkMode?: string;
   colorAttribution?: boolean;
+  sound?: boolean;
+  zenMode?: boolean;
 }
 
 export interface AuthUser {


### PR DESCRIPTION
## Summary
Bugfix. Zen Mode wasn't persisting across sessions while logged-in. The auth schema was missing zenMode and thus rejected it silently. 

- Added `zenMode` to `preferencesSchema` in `server/api/auth.ts` (root cause)
- Added `sound` and `zenMode` to the `UserPreferences` TypeScript interface in `src/api/auth.ts`, which had been incomplete since both fields were added
- Updated the OpenAPI JSDoc comment on the preferences route to document `zenMode`
