### PR TITLE
Replace Sentry captureMessage with structured logging for updateCell

### DIFF
--- a/src/lib/reducers/game.js
+++ b/src/lib/reducers/game.js
@@ -181,18 +181,17 @@ const reducers = {
     // before the create event has hydrated, dimension mismatch — skip the
     // update rather than throwing. The throw was caught upstream by `reduce`
     // and silently dropped the user's typed letter, which surfaced as #482.
-    // captureMessage (vs logger.warn) so this aggregates into a single
-    // Sentry Issue we can watch for rate / affected users / grid context.
+    // These are benign and already handled, but fire ~once per fresh game, so
+    // a captureMessage here drowned the Issues dashboard. Emit a structured
+    // log instead (Sentry Logs, not an Issue) so the rate / grid context stays
+    // queryable without the noise.
     if (!grid || !grid[r] || !grid[r][c]) {
-      Sentry.captureMessage('updateCell out of bounds', {
-        level: 'warning',
-        extra: {
-          r,
-          c,
-          gridRows: grid?.length,
-          gridCols: grid?.[0]?.length,
-          pid: game.pid,
-        },
+      Sentry.logger.warn('updateCell out of bounds', {
+        r,
+        c,
+        gridRows: grid?.length,
+        gridCols: grid?.[0]?.length,
+        pid: game.pid,
       });
       return game;
     }


### PR DESCRIPTION
## Summary
Changed error reporting for out-of-bounds `updateCell` calls from Sentry's `captureMessage` (which creates Issues) to `Sentry.logger.warn` (which emits structured logs). This reduces noise in the Issues dashboard while preserving queryable diagnostic data.

## Changes
- Replaced `Sentry.captureMessage('updateCell out of bounds', { level: 'warning', extra: {...} })` with `Sentry.logger.warn('updateCell out of bounds', {...})`
- Updated comment to explain that these benign errors fire ~once per fresh game and were drowning the Issues dashboard
- Structured log approach keeps rate and grid context queryable without creating separate Issues

## Details
The `updateCell` out-of-bounds condition is a known benign race condition that occurs when grid updates arrive before the create event has hydrated. Previously, each occurrence was captured as a Sentry Issue, creating noise. The new approach uses Sentry's structured logging (Sentry Logs, not Issues) to maintain observability while keeping the Issues dashboard clean.

https://claude.ai/code/session_014cakFG7umEBkoq1tNqrDje