### PR TITLE
Fix print styles for dark mode grid and clues (issue #572)

### DIFF
--- a/src/components/Grid/css/cell.css
+++ b/src/components/Grid/css/cell.css
@@ -21,7 +21,16 @@
    *    omit background fills unless print-color-adjust is set.
    *  - Dark mode printed dark fills (wasted ink) with white clue numbers and
    *    letters that vanished against the page, plus leftover highlight tints.
+   *
+   * print-color-adjust: exact is set globally on body in style.css, so dark
+   * mode otherwise prints its dark page background and fills. Reset the page
+   * to a light background here so only intended fills (block cells) render.
    */
+  body.dark {
+    background-color: white !important;
+    color: black !important;
+  }
+
   .cell {
     background-color: white !important;
     color: black !important;
@@ -34,6 +43,32 @@
   body.dark .cell.referenced,
   body.dark .cell.frozen.highlighted {
     background-color: white !important;
+  }
+
+  /* Referenced values are forced white in dark.css; restore dark text so they
+     are not white-on-white once the cell background is reset to white. */
+  body.dark .cell.referenced .cell--value {
+    color: black !important;
+  }
+
+  /* Shading is white-on-dark in dark.css; restore the light-mode dark shade so
+     shaded squares stay visible on white paper. */
+  body.dark .cell--shade {
+    background-color: rgb(0 0 0 / 30%) !important;
+  }
+
+  /* Dark-mode check/reveal colors are low-contrast on white; use the
+     light-mode high-contrast colors for print. */
+  body.dark .cell.good .cell--value {
+    color: blue !important;
+  }
+
+  body.dark .cell.bad .cell--value {
+    color: red !important;
+  }
+
+  body.dark .cell.revealed .cell--value {
+    color: green !important;
   }
 
   /* Block cells stay solid black; force the fill to actually render in print. */

--- a/src/components/Grid/css/cell.css
+++ b/src/components/Grid/css/cell.css
@@ -23,10 +23,13 @@
    *    letters that vanished against the page, plus leftover highlight tints.
    *
    * print-color-adjust: exact is set globally on body in style.css, so dark
-   * mode otherwise prints its dark page background and fills. Reset the page
-   * to a light background here so only intended fills (block cells) render.
+   * mode otherwise prints its dark page background and fills. The .dark class
+   * is applied to both document.body and .router-wrapper (src/index.js), so
+   * reset both carriers to a light background here — otherwise the wrapper's
+   * dark fill paints over the page around the grid and clues.
    */
-  body.dark {
+  body.dark,
+  .router-wrapper.dark {
     background-color: white !important;
     color: black !important;
   }

--- a/src/components/Grid/css/cell.css
+++ b/src/components/Grid/css/cell.css
@@ -15,8 +15,34 @@
 }
 
 @media print {
+  /*
+   * Print a clean, light-mode grid regardless of the active theme (issue #572).
+   *  - Block cells were printing blank: `.cell` was forced white, and browsers
+   *    omit background fills unless print-color-adjust is set.
+   *  - Dark mode printed dark fills (wasted ink) with white clue numbers and
+   *    letters that vanished against the page, plus leftover highlight tints.
+   */
   .cell {
     background-color: white !important;
+    color: black !important;
+    border-color: transparent !important;
+  }
+
+  /* dark.css applies these tints with !important, so out-specify them
+     (body carries the .dark class, which lets body.dark win on specificity). */
+  body.dark .cell.highlighted,
+  body.dark .cell.referenced,
+  body.dark .cell.frozen.highlighted {
+    background-color: white !important;
+  }
+
+  /* Block cells stay solid black; force the fill to actually render in print. */
+  .cell.black,
+  .cell.black.selected,
+  body.dark .cell.black {
+    background-color: var(--main-black) !important;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
   }
 }
 

--- a/src/components/Grid/css/cell.css
+++ b/src/components/Grid/css/cell.css
@@ -60,6 +60,13 @@
     background-color: rgb(0 0 0 / 30%) !important;
   }
 
+  /* The selected cell's wrapper carries its own translucent-black tint in dark
+     mode (dark.css), independent of the .cell background reset above; without
+     this it prints as light grey instead of white. */
+  body.dark .cell.selected .cell--wrapper {
+    background-color: transparent !important;
+  }
+
   /* Dark-mode check/reveal colors are low-contrast on white; use the
      light-mode high-contrast colors for print. */
   body.dark .cell.good .cell--value {

--- a/src/components/Player/css/clues.css
+++ b/src/components/Player/css/clues.css
@@ -69,6 +69,29 @@
   }
 }
 
+@media print {
+  /*
+   * Light-mode clue highlights are already scoped to @media screen above, but
+   * dark.css's clue-list rules leak into print: the selected clue keeps its
+   * dark highlight and the text prints light-on-white. Force a light-mode
+   * clue list for print (issue #572). body.dark out-specifies dark.css.
+   */
+  body.dark .clues--list--scroll {
+    background-color: transparent !important;
+  }
+
+  body.dark .clues--list--scroll--clue,
+  body.dark .clues--list--scroll--clue.complete {
+    color: black !important;
+  }
+
+  body.dark .clues--list--scroll--clue.selected,
+  body.dark .clues--list--scroll--clue.half-selected {
+    background-color: transparent !important;
+    border-left-color: transparent !important;
+  }
+}
+
 .clues--list--scroll--clue--number {
   margin-left: 5px;
   line-height: 1.2em;


### PR DESCRIPTION
## Summary
Fixes print output when dark mode is active by forcing a clean, light-mode appearance for printed pages, regardless of the active theme. Addresses issues where grid cells printed blank, dark fills wasted ink, and clue text became unreadable.

## Changes

**Grid cells (`src/components/Grid/css/cell.css`)**
- Force white background and black text for all cells in print mode
- Make borders transparent to avoid visual clutter
- Override dark mode highlight/reference tints by out-specifying with `body.dark` selector
- Preserve black cells with `print-color-adjust: exact` to ensure they render as solid black (not omitted by browsers)
- Added detailed comments explaining the print-specific issues being fixed

**Clue list (`src/components/Player/css/clues.css`)**
- Force light-mode styling for clue lists in print when dark mode is active
- Remove dark background fills and highlight colors that leak into print
- Ensure clue text prints as black on transparent/white background
- Out-specify dark mode rules using `body.dark` selector to maintain specificity hierarchy

## Implementation Details
Both changes use `!important` flags and `body.dark` selectors to override dark mode styles specifically for `@media print` blocks. This ensures the printed output is always clean and readable while preserving dark mode appearance on screen. The `print-color-adjust: exact` property on black cells ensures browsers don't omit the background fill during printing.

https://claude.ai/code/session_016VeLfLEXWYagSvjQKzaWwm