### PR TITLE
Fix mobile clue bar clipping on Firefox Android

### DIFF
--- a/src/components/Player/css/mobileGridControls.css
+++ b/src/components/Player/css/mobileGridControls.css
@@ -33,7 +33,13 @@
   display: flex;
   font-size: 15px;
   flex: 1;
-  min-height: 20px;
+
+  /* Room for ~2 lines of clue text. Firefox on Android (153+) stopped
+     treating this bar's flex-stretched height as "definite", which collapsed
+     the descendants' percentage heights below and clipped 2-line clues to a
+     single scrollable line (#firefox-android clue-bar report). A concrete
+     min-height keeps the bar tall enough regardless. */
+  min-height: 48px;
   position: relative;
   overflow: hidden;
 }
@@ -47,7 +53,14 @@
   margin-left: 20px;
   display: inline-block;
   overflow-y: auto;
-  max-height: 100%;
+
+  /* Definite px cap (matches the bar's min-height) instead of `max-height:
+     100%`. A percentage max-height only resolves against an ancestor with a
+     definite height; the ancestors here are all sized by flex stretch, which
+     Firefox on Android stopped treating as definite, collapsing this scroll
+     box to one line. A px value resolves identically in every browser: up to
+     two lines show, longer clues scroll. */
+  max-height: 48px;
 }
 
 .mobile-grid-controls--clue-bar--text > span {
@@ -56,10 +69,11 @@
 
 .mobile-grid-controls--clue-bar--clues--container {
   position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
+
+  /* `inset: 0` sizes this box from its offsets rather than `height: 100%`, so
+     its height no longer depends on the flex-stretched bar height being
+     treated as definite (which Firefox on Android stopped doing). */
+  inset: 0;
   display: flex;
 }
 


### PR DESCRIPTION
## Problem

Firefox on Android (153+) users reported that clue text in the mobile clue bar became clipped and required scrolling — even ordinary two-line clues showed only a single scrollable line. It started without any app change on production and without a Firefox app-store update (matching an over-the-air rendering flag from Mozilla). Chrome on Android was unaffected.

## Root cause

The mobile clue bar relies on a percentage-height chain that only holds when its ancestors have a *definite* height:

- `.mobile-grid-controls--clue-bar--clues--container { height: 100% }` resolves against the clue bar, whose height comes only from flex stretch (the `<`/`>` arrow buttons make the row 48px tall).
- `.mobile-grid-controls--clue-bar--text { max-height: 100% }` resolves against the flex-stretched `.clue-bar--main`.

Firefox on Android stopped treating flex-stretched heights as "definite" for percentage resolution, so both percentages collapsed and the clue-text scroll box shrank to one line, clipping two-line clues. Chrome still resolves those percentages, which is why only Firefox regressed.

## Fix

Remove the dependency on percentages resolving through flex-stretched ancestors, in `src/components/Player/css/mobileGridControls.css`:

- Size the absolutely-positioned clues container from `inset: 0` instead of `height: 100%`, so its height comes from its offsets.
- Cap the clue text scroll box with a definite `max-height: 48px` instead of `max-height: 100%`; a px value resolves identically in every browser (up to two lines show, longer clues scroll).
- Raise the clue bar `min-height` to `48px` to guarantee room for two lines.

## Verification

- Reproduced the exact clue-bar DOM/CSS in a standalone page and measured computed heights in Chromium: the new rules produce the **identical** layout to the old ones (two lines fit, three-plus lines scroll) — no regression.
- `pnpm stylelint` and `pnpm prettier --check` pass; `MobileGridControls` tests (10) pass.
- Note: a real Firefox-on-Android device could not be tested in this environment, so the Firefox failure mode is addressed by construction (eliminating the fragile percentage chain) rather than reproduced directly. Worth a quick confirmation on a Pixel/Firefox before closing the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Up2RyzR15WvegwXWD1wECk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Up2RyzR15WvegwXWD1wECk)_