### PR TITLE
Retry refresh instead of logging out on concurrent rotation race

### DIFF
--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -427,7 +427,7 @@ router.post('/refresh', async (req, res) => {
     // Lost a benign concurrent rotation race: a parallel /refresh already
     // issued a fresh cookie. Do NOT clear it — just ask the client to retry,
     // which will use the new cookie.
-    res.status(401).json({error: 'Refresh in progress, please retry'});
+    res.status(401).json({error: 'Refresh in progress, please retry', retry: true});
     return;
   }
   if (rotation.status !== 'rotated') {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -55,17 +55,32 @@ export async function login(email: string, password: string): Promise<AuthTokens
   return resp.json();
 }
 
-export async function refreshAccessToken(): Promise<{accessToken: string} | null> {
+async function attemptRefresh(): Promise<{accessToken: string} | null | 'retry'> {
   try {
     const resp = await fetch(`${SERVER_URL}/api/auth/refresh`, {
       method: 'POST',
       credentials: 'include',
     });
-    if (!resp.ok) return null;
-    return await resp.json();
+    if (resp.ok) return resp.json();
+    if (resp.status === 401) {
+      const body = await resp.json().catch(() => ({}));
+      // Lost a benign concurrent rotation race (e.g. two tabs refreshing at
+      // once) — the cookie is still valid via the call that won. Not a real
+      // logout, so the caller should retry rather than dropping the session.
+      if (body?.retry) return 'retry';
+    }
+    return null;
   } catch {
     return null;
   }
+}
+
+export async function refreshAccessToken(): Promise<{accessToken: string} | null> {
+  const first = await attemptRefresh();
+  if (first !== 'retry') return first;
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const second = await attemptRefresh();
+  return second === 'retry' ? null : second;
 }
 
 export async function logout(): Promise<void> {


### PR DESCRIPTION
## Summary
- When two requests refresh the access token at the same time, the loser previously got a 401 and the client treated that as "not authenticated" / logged the user out, even though the winning request had already rotated the cookie successfully.
- Server now flags this specific case (`retry: true`) instead of a plain 401, and the client retries once after a short delay before giving up.

## Screenshots
What it looks like on testing.

<img width="543" height="175" alt="image" src="https://github.com/user-attachments/assets/5cfde062-84d4-43da-b86c-78475fdb9295" />

## Notes
The summary section is the more accurate diagnosis, but this error was first noticed in local testing, wherein refreshing sometimes caused a locally stored user to log out, which was particularly frustrating when making UI changes.

