### PR TITLE
Fix game clock skew from device clock differences

### DIFF
--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -148,7 +148,12 @@ class SocketManager {
             }
           }
           socket.join(`game-${gid}`);
-          if (typeof ack === 'function') ack();
+          // serverTime seeds the client's server/local clock offset before any
+          // live event arrives, so a page refresh mid-solve renders the clock
+          // against server time instead of a possibly-skewed device clock.
+          // Callers only inspect `error`, so the added field is backwards
+          // compatible with older clients.
+          if (typeof ack === 'function') ack({serverTime: Date.now()});
         } catch (err) {
           console.error(`[Socket] join_game error for gid=${gid}:`, err);
           Sentry.captureException(err);
@@ -286,10 +291,16 @@ class SocketManager {
               }
             }
           }
-          // Replace non-numeric timestamps with real server time
-          if (typeof event.timestamp !== 'number') {
-            event.timestamp = Date.now();
-          }
+          // Stamp every event with server time, overwriting whatever the
+          // client sent. The game clock is accumulated from the diff between
+          // consecutive event timestamps (see tick() in lib/reducers/game),
+          // and the client re-sorts history by timestamp, so mixing wall
+          // clocks from different devices charged each player's clock skew to
+          // the timer: a peer whose device was 30s off made the clock jump
+          // ~30s the moment their event interleaved with yours (usually the
+          // first letter typed). One clock for all events removes both the
+          // skew and the out-of-order re-sorting that surfaced it.
+          event.timestamp = Date.now();
           // Stamp verified user identity if authenticated, otherwise clear it
           // to prevent unauthenticated users from spoofing verifiedUserId
           if (socket.data.authUser) {

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -214,6 +214,12 @@ class SocketManager {
       });
 
       socket.on('game_event', async (message, ack) => {
+        // Captured before any validation, because the checks below await and so
+        // interleave with the next packet from the same socket: whichever
+        // handler clears its awaits first would otherwise claim the earlier
+        // stamp, and two rapid edits to one cell could persist in reverse
+        // order. Reading the clock here makes the stamp reflect arrival order.
+        const receivedAt = Date.now();
         try {
           const event = message?.event;
           if (!event || typeof event.type !== 'string') {
@@ -300,7 +306,7 @@ class SocketManager {
           // ~30s the moment their event interleaved with yours (usually the
           // first letter typed). One clock for all events removes both the
           // skew and the out-of-order re-sorting that surfaced it.
-          event.timestamp = Date.now();
+          event.timestamp = receivedAt;
           // Stamp verified user identity if authenticated, otherwise clear it
           // to prevent unauthenticated users from spoofing verifiedUserId
           if (socket.data.authUser) {

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -37,8 +37,28 @@ const RESTRICTABLE_EVENT_TYPES: Record<string, RestrictableAction> = Object.assi
 class SocketManager {
   io: Server;
 
+  // Last stamp handed out by nextEventStamp, so stamps stay strictly increasing.
+  lastEventStamp = 0;
+
   constructor(io: Server) {
     this.io = io;
+  }
+
+  // Server time, but never the same millisecond twice. Equal timestamps have no
+  // tie-breaker in either the client's history sort or the `ORDER BY ts ASC`
+  // replay query, so two edits to one cell landing in the same millisecond could
+  // still settle on the stale value. Strictly increasing stamps make the
+  // ordering guarantee this file relies on — history order follows arrival
+  // order — hold by construction rather than by luck of the clock.
+  nextEventStamp(): number {
+    const now = Date.now();
+    const stamp = now > this.lastEventStamp ? now : this.lastEventStamp + 1;
+    // Under a sustained burst past 1000 events/sec the +1s would outrun real
+    // time. Cap the drift at a second and fall back to colliding stamps beyond
+    // that: clients derive their server/local clock offset from these, so the
+    // stamp staying close to real time matters more than the tie-break.
+    this.lastEventStamp = stamp > now + 1000 ? now : stamp;
+    return this.lastEventStamp;
   }
 
   async addGameEvent(gid: string, event: GameEvent) {
@@ -214,12 +234,12 @@ class SocketManager {
       });
 
       socket.on('game_event', async (message, ack) => {
-        // Captured before any validation, because the checks below await and so
+        // Claimed before any validation, because the checks below await and so
         // interleave with the next packet from the same socket: whichever
         // handler clears its awaits first would otherwise claim the earlier
         // stamp, and two rapid edits to one cell could persist in reverse
-        // order. Reading the clock here makes the stamp reflect arrival order.
-        const receivedAt = Date.now();
+        // order. Taking the stamp here makes it reflect arrival order.
+        const receivedAt = this.nextEventStamp();
         try {
           const event = message?.event;
           if (!event || typeof event.type !== 'string') {

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -50,14 +50,17 @@ class SocketManager {
   // still settle on the stale value. Strictly increasing stamps make the
   // ordering guarantee this file relies on — history order follows arrival
   // order — hold by construction rather than by luck of the clock.
+  //
+  // Deliberately unbounded: past 1000 events/sec in aggregate the +1 outruns
+  // real time and the sequence drifts ahead. Capping that drift would mean
+  // moving the sequence backward, which is far worse than drift — later events
+  // would sort before the preceding second of history and could leave stale
+  // cell values. Drift costs display precision only, needs a sustained rate
+  // this app doesn't see (normal solving is a few events/sec per player), and
+  // decays as soon as the rate drops. If it ever became real, the fix is an
+  // ordering key separate from the timestamp, not a backward reset.
   nextEventStamp(): number {
-    const now = Date.now();
-    const stamp = now > this.lastEventStamp ? now : this.lastEventStamp + 1;
-    // Under a sustained burst past 1000 events/sec the +1s would outrun real
-    // time. Cap the drift at a second and fall back to colliding stamps beyond
-    // that: clients derive their server/local clock offset from these, so the
-    // stamp staying close to real time matters more than the tie-break.
-    this.lastEventStamp = stamp > now + 1000 ? now : stamp;
+    this.lastEventStamp = Math.max(Date.now(), this.lastEventStamp + 1);
     return this.lastEventStamp;
   }
 

--- a/server/SocketManager.ts
+++ b/server/SocketManager.ts
@@ -44,23 +44,27 @@ class SocketManager {
     this.io = io;
   }
 
-  // Server time, but never the same millisecond twice. Equal timestamps have no
-  // tie-breaker in either the client's history sort or the `ORDER BY ts ASC`
-  // replay query, so two edits to one cell landing in the same millisecond could
-  // still settle on the stale value. Strictly increasing stamps make the
-  // ordering guarantee this file relies on — history order follows arrival
-  // order — hold by construction rather than by luck of the clock.
+  // Server time, clamped so it never moves backward. An NTP step back would
+  // otherwise emit stamps that sort into the middle of existing history.
   //
-  // Deliberately unbounded: past 1000 events/sec in aggregate the +1 outruns
-  // real time and the sequence drifts ahead. Capping that drift would mean
-  // moving the sequence backward, which is far worse than drift — later events
-  // would sort before the preceding second of history and could leave stale
-  // cell values. Drift costs display precision only, needs a sustained rate
-  // this app doesn't see (normal solving is a few events/sec per player), and
-  // decays as soon as the rate drops. If it ever became real, the fix is an
-  // ordering key separate from the timestamp, not a backward reset.
+  // This deliberately does NOT invent sub-millisecond ticks to break ties.
+  // A `+1` per collision makes stamps strictly increasing, but past 1000
+  // events/sec in aggregate it outruns the clock, and the drift *grows* while
+  // that lasts. tick() in lib/reducers/game charges the difference between
+  // consecutive stamps to the timer, so growing drift is charged as solve time
+  // — and since this counter is per process, shared by every game, a burst in
+  // one game would inflate the clock in all of them, up to MAX_CLOCK_INCREMENT
+  // per event. That is the same phantom time this whole change exists to
+  // remove, so the timestamp stays a clock reading and nothing else.
+  //
+  // The cost is that two events can still share a millisecond, which leaves
+  // their relative order to the broadcast and to `ORDER BY ts ASC`. That needs
+  // two edits to one cell inside the same millisecond to matter, and it costs
+  // one stale letter that the next edit corrects. If it ever needs fixing, the
+  // fix is a sequence key stored alongside the timestamp — ordering and clock
+  // reading kept separate — not a counter smuggled into the clock.
   nextEventStamp(): number {
-    this.lastEventStamp = Math.max(Date.now(), this.lastEventStamp + 1);
+    this.lastEventStamp = Math.max(Date.now(), this.lastEventStamp);
     return this.lastEventStamp;
   }
 
@@ -121,6 +125,10 @@ class SocketManager {
 
       // ======== Game Events ========= //
       socket.on('join_game', async (gid, ack) => {
+        // Both ends of our time on the server, so the client can estimate the
+        // clock offset without having to guess how much of the round trip was
+        // network and how much was the moderation lookups below. See the ack.
+        const serverReceivedAt = Date.now();
         try {
           if (typeof gid !== 'string' || !gid) {
             if (typeof ack === 'function') ack({error: 'invalid gid'});
@@ -171,12 +179,17 @@ class SocketManager {
             }
           }
           socket.join(`game-${gid}`);
-          // serverTime seeds the client's server/local clock offset before any
-          // live event arrives, so a page refresh mid-solve renders the clock
-          // against server time instead of a possibly-skewed device clock.
-          // Callers only inspect `error`, so the added field is backwards
-          // compatible with older clients.
-          if (typeof ack === 'function') ack({serverTime: Date.now()});
+          // Seeds the client's server/local clock offset before any live event
+          // arrives, so a page refresh mid-solve renders the clock against
+          // server time instead of a possibly-skewed device clock.
+          //
+          // Both timestamps are sent because the gap between them is server
+          // processing time, not network travel: the checks above can miss the
+          // moderation cache and hit the database. Given the client's own send
+          // and receive times, the pair lets it cancel that processing out
+          // instead of mistaking it for flight time. Callers only inspect
+          // `error`, so the added fields are backwards compatible.
+          if (typeof ack === 'function') ack({serverTime: Date.now(), serverReceivedAt});
         } catch (err) {
           console.error(`[Socket] join_game error for gid=${gid}:`, err);
           Sentry.captureException(err);

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -245,64 +245,37 @@ describe('SocketManager', () => {
       expect(second.timestamp - first.timestamp).toBeLessThan(50);
     });
 
-    // Equal stamps have no tie-breaker in the client's timestamp sort or in the
-    // `ORDER BY ts ASC` replay query, so same-millisecond events could still
-    // settle on the stale value.
-    it('never hands out the same stamp twice', async () => {
-      const {io, socketHandlers} = createMockIo();
-      const sm = new SocketManager(io);
-      sm.listen();
-
-      // Freeze the clock so every packet lands in the same millisecond.
-      const frozen = 1700000000000;
-      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(frozen);
-      try {
-        const events = [
-          {type: 'updateCursor', timestamp: 1, params: {}},
-          {type: 'updateCursor', timestamp: 2, params: {}},
-          {type: 'updateCursor', timestamp: 3, params: {}},
-        ];
-        for (const event of events) {
-          await socketHandlers['game_event']({gid: 'g1', event}, jest.fn());
-        }
-
-        expect(events.map((e) => e.timestamp)).toEqual([frozen, frozen + 1, frozen + 2]);
-      } finally {
-        nowSpy.mockRestore();
-      }
-    });
-
-    // Drift is the accepted cost of monotonicity. Bounding it would mean moving
-    // the sequence backward, which reorders whole seconds of history — much
-    // worse than the ties the sequence exists to break.
-    it('never moves the sequence backward, even past the drift a burst causes', () => {
+    // tick() charges the gap between consecutive stamps to the game clock, and
+    // this counter is shared by every game, so a stamp that runs ahead of real
+    // time turns into phantom solve time everywhere.
+    it('never runs the stamp ahead of real time, however long the burst', () => {
       const {io} = createMockIo();
       const sm = new SocketManager(io);
 
       const frozen = 1700000000000;
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(frozen);
       try {
-        const stamps = [];
-        for (let i = 0; i < 3000; i += 1) stamps.push(sm.nextEventStamp());
-        for (let i = 1; i < stamps.length; i += 1) {
-          expect(stamps[i]).toBeGreaterThan(stamps[i - 1]);
+        for (let i = 0; i < 3000; i += 1) {
+          expect(sm.nextEventStamp()).toBe(frozen);
         }
       } finally {
         nowSpy.mockRestore();
       }
     });
 
-    it('catches back up to real time once the burst subsides', () => {
+    it('does not move backward when the server clock steps back', () => {
       const {io} = createMockIo();
       const sm = new SocketManager(io);
 
-      const frozen = 1700000000000;
-      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(frozen);
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1700000005000);
       try {
-        for (let i = 0; i < 3000; i += 1) sm.nextEventStamp();
-        // Real time moves past the drifted sequence; stamps track it again.
-        nowSpy.mockReturnValue(frozen + 10_000);
-        expect(sm.nextEventStamp()).toBe(frozen + 10_000);
+        expect(sm.nextEventStamp()).toBe(1700000005000);
+        // NTP correction moves the clock back two seconds.
+        nowSpy.mockReturnValue(1700000003000);
+        expect(sm.nextEventStamp()).toBe(1700000005000);
+        // And it tracks real time again once the clock passes the clamp.
+        nowSpy.mockReturnValue(1700000006000);
+        expect(sm.nextEventStamp()).toBe(1700000006000);
       } finally {
         nowSpy.mockRestore();
       }
@@ -739,6 +712,10 @@ describe('SocketManager', () => {
       expect(payload.error).toBeUndefined();
       expect(payload.serverTime).toBeGreaterThanOrEqual(before);
       expect(payload.serverTime).toBeLessThanOrEqual(after);
+      // Both ends of the server's own processing, so the client can cancel it
+      // out rather than charging it to network flight time.
+      expect(payload.serverReceivedAt).toBeGreaterThanOrEqual(before);
+      expect(payload.serverReceivedAt).toBeLessThanOrEqual(payload.serverTime);
     });
   });
 

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -272,17 +272,37 @@ describe('SocketManager', () => {
       }
     });
 
-    it('does not let the tie-breaker drift far ahead of real time', () => {
+    // Drift is the accepted cost of monotonicity. Bounding it would mean moving
+    // the sequence backward, which reorders whole seconds of history — much
+    // worse than the ties the sequence exists to break.
+    it('never moves the sequence backward, even past the drift a burst causes', () => {
       const {io} = createMockIo();
       const sm = new SocketManager(io);
 
       const frozen = 1700000000000;
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(frozen);
       try {
-        // A burst long enough to outrun the clock falls back to real time
-        // rather than stamping ever further into the future.
-        for (let i = 0; i < 1500; i += 1) sm.nextEventStamp();
-        expect(sm.nextEventStamp()).toBeLessThanOrEqual(frozen + 1000);
+        const stamps = [];
+        for (let i = 0; i < 3000; i += 1) stamps.push(sm.nextEventStamp());
+        for (let i = 1; i < stamps.length; i += 1) {
+          expect(stamps[i]).toBeGreaterThan(stamps[i - 1]);
+        }
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('catches back up to real time once the burst subsides', () => {
+      const {io} = createMockIo();
+      const sm = new SocketManager(io);
+
+      const frozen = 1700000000000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(frozen);
+      try {
+        for (let i = 0; i < 3000; i += 1) sm.nextEventStamp();
+        // Real time moves past the drifted sequence; stamps track it again.
+        nowSpy.mockReturnValue(frozen + 10_000);
+        expect(sm.nextEventStamp()).toBe(frozen + 10_000);
       } finally {
         nowSpy.mockRestore();
       }

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -245,6 +245,49 @@ describe('SocketManager', () => {
       expect(second.timestamp - first.timestamp).toBeLessThan(50);
     });
 
+    // Equal stamps have no tie-breaker in the client's timestamp sort or in the
+    // `ORDER BY ts ASC` replay query, so same-millisecond events could still
+    // settle on the stale value.
+    it('never hands out the same stamp twice', async () => {
+      const {io, socketHandlers} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+
+      // Freeze the clock so every packet lands in the same millisecond.
+      const frozen = 1700000000000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(frozen);
+      try {
+        const events = [
+          {type: 'updateCursor', timestamp: 1, params: {}},
+          {type: 'updateCursor', timestamp: 2, params: {}},
+          {type: 'updateCursor', timestamp: 3, params: {}},
+        ];
+        for (const event of events) {
+          await socketHandlers['game_event']({gid: 'g1', event}, jest.fn());
+        }
+
+        expect(events.map((e) => e.timestamp)).toEqual([frozen, frozen + 1, frozen + 2]);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('does not let the tie-breaker drift far ahead of real time', () => {
+      const {io} = createMockIo();
+      const sm = new SocketManager(io);
+
+      const frozen = 1700000000000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(frozen);
+      try {
+        // A burst long enough to outrun the clock falls back to real time
+        // rather than stamping ever further into the future.
+        for (let i = 0; i < 1500; i += 1) sm.nextEventStamp();
+        expect(sm.nextEventStamp()).toBeLessThanOrEqual(frozen + 1000);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
     it('stamps verifiedUserId when socket is authenticated', async () => {
       (verifyAccessToken as jest.Mock).mockReturnValue({userId: 'user-42'});
       const {io, socketHandlers, mockSocket} = createMockIo();

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -215,6 +215,36 @@ describe('SocketManager', () => {
       expect(new Date(insert![1][2] as string).getTime()).toBe(event.timestamp);
     });
 
+    // The validation above the stamp awaits, so handlers for consecutive
+    // packets from one socket interleave. Stamping after those awaits let
+    // whichever handler cleared them first claim the earlier timestamp, which
+    // would persist two rapid edits to the same cell in reverse order.
+    it('stamps by arrival order even when validation awaits interleave', async () => {
+      const {io, socketHandlers} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+
+      // Make the first event's gameExists lookup slow and the rest immediate.
+      let queries = 0;
+      pool.query.mockImplementation(async () => {
+        queries += 1;
+        if (queries === 1) await new Promise((resolve) => setTimeout(resolve, 50));
+        return {rowCount: 1, rows: [{}]};
+      });
+
+      const first = {type: 'updateCell', timestamp: 1, params: {id: 'p1', cell: {r: 0, c: 0}, value: 'A'}};
+      const second = {type: 'updateCell', timestamp: 2, params: {id: 'p1', cell: {r: 0, c: 0}, value: 'B'}};
+      await Promise.all([
+        socketHandlers['game_event']({gid: 'g1', event: first}, jest.fn()),
+        socketHandlers['game_event']({gid: 'g1', event: second}, jest.fn()),
+      ]);
+
+      // Arrival order is first → second, so its stamps must not invert.
+      expect(second.timestamp).toBeGreaterThanOrEqual(first.timestamp);
+      // And neither carries the 50ms the slow lookup spent waiting.
+      expect(second.timestamp - first.timestamp).toBeLessThan(50);
+    });
+
     it('stamps verifiedUserId when socket is authenticated', async () => {
       (verifyAccessToken as jest.Mock).mockReturnValue({userId: 'user-42'});
       const {io, socketHandlers, mockSocket} = createMockIo();

--- a/server/__tests__/SocketManager.test.ts
+++ b/server/__tests__/SocketManager.test.ts
@@ -169,17 +169,50 @@ describe('SocketManager', () => {
       expect(ack).toHaveBeenCalled();
     });
 
-    it('preserves valid numeric timestamps', async () => {
+    // The game clock is accumulated from diffs between consecutive event
+    // timestamps, so client-supplied ones let a player's device clock skew be
+    // charged to the timer (the ~30s jump on the first letter typed).
+    it('overwrites client-supplied timestamps with server time', async () => {
       const {io, socketHandlers} = createMockIo();
       const sm = new SocketManager(io);
       sm.listen();
 
+      const now = Date.now();
       const ack = jest.fn();
-      const event = {type: 'updateCursor', timestamp: 1700000000000, params: {}};
+      // A device whose clock is 30s fast.
+      const event = {type: 'updateCursor', timestamp: now + 30_000, params: {}};
       await socketHandlers['game_event']({gid: 'g1', event}, ack);
 
-      expect(event.timestamp).toBe(1700000000000);
+      expect(event.timestamp).toBeGreaterThanOrEqual(now);
+      expect(event.timestamp).toBeLessThan(now + 30_000);
       expect(ack).toHaveBeenCalled();
+    });
+
+    it('persists and broadcasts the server timestamp, not the client one', async () => {
+      const {io, socketHandlers, emitFn} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+
+      // gameExists: create event found
+      pool.query.mockResolvedValueOnce({rowCount: 1, rows: [{}]});
+
+      const now = Date.now();
+      const ack = jest.fn();
+      const event = {type: 'updateCell', timestamp: 1700000000000, params: {id: 'p1'}};
+      await socketHandlers['game_event']({gid: 'g1', event}, ack);
+
+      expect(event.timestamp).toBeGreaterThanOrEqual(now);
+      // Broadcast payload carries the server timestamp...
+      expect(emitFn).toHaveBeenCalledWith(
+        'game_event',
+        expect.objectContaining({timestamp: event.timestamp})
+      );
+      // ...and so does the persisted row's ts column.
+      const insert = pool.query.mock.calls.find((call: unknown[]) =>
+        String(call[0]).includes('INSERT INTO game_events')
+      );
+      expect(insert).toBeDefined();
+      expect(new Date(insert![1][2] as string).getTime()).toBe(event.timestamp);
     });
 
     it('stamps verifiedUserId when socket is authenticated', async () => {
@@ -593,6 +626,26 @@ describe('SocketManager', () => {
       await socketHandlers['leave_game']('', ack);
 
       expect(ack).toHaveBeenCalledWith({error: 'invalid gid'});
+    });
+
+    // The client seeds its server/local clock offset from this, so the game
+    // clock renders against server time on a refresh mid-solve — before any
+    // live event has arrived to sample the offset from.
+    it('acks join_game with the current server time', async () => {
+      const {io, socketHandlers, mockSocket} = createMockIo();
+      const sm = new SocketManager(io);
+      sm.listen();
+
+      const before = Date.now();
+      const ack = jest.fn();
+      await socketHandlers['join_game']('g1', ack);
+      const after = Date.now();
+
+      expect(mockSocket.join).toHaveBeenCalledWith('game-g1');
+      const [payload] = ack.mock.calls[0];
+      expect(payload.error).toBeUndefined();
+      expect(payload.serverTime).toBeGreaterThanOrEqual(before);
+      expect(payload.serverTime).toBeLessThanOrEqual(after);
     });
   });
 

--- a/src/components/Toolbar/Clock.js
+++ b/src/components/Toolbar/Clock.js
@@ -1,7 +1,7 @@
 import './css/clock.css';
 import {Component} from 'react';
 import {FaFlagCheckered, FaPause, FaStopwatch} from 'react-icons/fa6';
-import {MAX_CLOCK_INCREMENT} from '../../lib/timing';
+import {MAX_CLOCK_INCREMENT, serverNow} from '../../lib/timing';
 
 export const formatMilliseconds = (ms) => {
   function pad2(num) {
@@ -48,7 +48,9 @@ export default class Clock extends Component {
     const {pausedTime} = this.props;
     const start = this.props.startTime;
     const stop = this.props.stopTime;
-    const now = Date.now();
+    // startTime is clock.lastUpdated — a server timestamp — so compare it
+    // against server time, not this device's possibly-skewed clock.
+    const now = serverNow();
 
     let clock = 0; // start with pausedTime
     if (pausedTime) {
@@ -75,7 +77,7 @@ export default class Clock extends Component {
   get isCapped() {
     if (!this.props.v2) return false;
     const start = this.props.startTime;
-    const now = Date.now();
+    const now = serverNow();
     return now > start + MAX_CLOCK_INCREMENT;
   }
 

--- a/src/components/Toolbar/__tests__/Clock.test.js
+++ b/src/components/Toolbar/__tests__/Clock.test.js
@@ -1,0 +1,76 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import Clock, {formatMilliseconds} from '../Clock';
+import {recordServerTimestamp, resetServerTimeOffset} from '../../../lib/timing';
+
+// Clock's displayed value is pure arithmetic over props, so drive updateClock()
+// directly instead of pulling in a DOM renderer.
+function displayedClock(props) {
+  const clock = new Clock();
+  clock.props = props;
+  let state = null;
+  clock.setState = (next) => {
+    state = next;
+  };
+  clock.updateClock();
+  return state.clock;
+}
+
+describe('formatMilliseconds', () => {
+  it('formats under an hour as mm:ss', () => {
+    expect(formatMilliseconds(0)).toBe('00:00');
+    expect(formatMilliseconds(30_000)).toBe('00:30');
+    expect(formatMilliseconds(90_000)).toBe('01:30');
+  });
+
+  it('formats over an hour as h:mm:ss', () => {
+    expect(formatMilliseconds(3_690_000)).toBe('1:01:30');
+  });
+});
+
+describe('Clock display', () => {
+  beforeEach(() => {
+    resetServerTimeOffset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetServerTimeOffset();
+  });
+
+  it('shows only the banked time while paused', () => {
+    const now = Date.now();
+    expect(displayedClock({startTime: now - 60_000, pausedTime: 12_000, isPaused: true})).toBe('00:12');
+  });
+
+  it('adds the time elapsed since the last event while running', () => {
+    const now = Date.now();
+    expect(displayedClock({startTime: now - 5_000, pausedTime: 12_000, isPaused: false})).toBe('00:17');
+  });
+
+  it('shows the frozen solve time once stopped', () => {
+    const now = Date.now();
+    expect(
+      displayedClock({startTime: now - 60_000, stopTime: now - 30_000, pausedTime: 0, isPaused: false})
+    ).toBe('00:30');
+  });
+
+  // startTime is clock.lastUpdated, a server-stamped event timestamp. Measuring
+  // the live portion with a raw local Date.now() showed the device's own clock
+  // skew as solve time — the reported "timer jumps to ~30s on the first letter".
+  it('does not count a fast local clock as solve time', () => {
+    const local = Date.now();
+    // A live event tells us the server is 30s behind this device's clock.
+    recordServerTimestamp(local - 30_000);
+    // That same event is what set lastUpdated, so no time has really elapsed.
+    expect(displayedClock({startTime: local - 30_000, pausedTime: 0, isPaused: false})).toBe('00:00');
+  });
+
+  it('does not stall the timer when the local clock is slow', () => {
+    const local = Date.now();
+    // Server is 30s ahead of this device.
+    recordServerTimestamp(local + 30_000);
+    // Event stamped 5s (server time) ago.
+    expect(displayedClock({startTime: local + 25_000, pausedTime: 0, isPaused: false})).toBe('00:05');
+  });
+});

--- a/src/lib/__tests__/timing.test.js
+++ b/src/lib/__tests__/timing.test.js
@@ -1,0 +1,60 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {getServerTimeOffset, recordServerTimestamp, resetServerTimeOffset, serverNow} from '../timing';
+
+describe('server time offset', () => {
+  beforeEach(() => {
+    resetServerTimeOffset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetServerTimeOffset();
+  });
+
+  it('defaults to no offset', () => {
+    expect(getServerTimeOffset()).toBe(0);
+    expect(serverNow()).toBeCloseTo(Date.now(), -2);
+  });
+
+  it('measures how far this device is behind the server', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    // Server-stamped event lands while our clock reads 30s earlier.
+    recordServerTimestamp(local + 30_000);
+
+    expect(getServerTimeOffset()).toBe(30_000);
+    expect(serverNow()).toBe(local + 30_000);
+  });
+
+  it('measures how far this device is ahead of the server', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    recordServerTimestamp(local - 30_000);
+
+    expect(getServerTimeOffset()).toBe(-30_000);
+    expect(serverNow()).toBe(local - 30_000);
+  });
+
+  it('tracks the most recent sample', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    recordServerTimestamp(local + 5_000);
+    recordServerTimestamp(local + 1_000);
+
+    expect(getServerTimeOffset()).toBe(1_000);
+  });
+
+  it('ignores samples that are not finite numbers', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    recordServerTimestamp(local + 7_000);
+
+    recordServerTimestamp(undefined);
+    recordServerTimestamp(null);
+    recordServerTimestamp('1700000000000');
+    recordServerTimestamp(NaN);
+    recordServerTimestamp(Infinity);
+
+    expect(getServerTimeOffset()).toBe(7_000);
+  });
+});

--- a/src/lib/__tests__/timing.test.js
+++ b/src/lib/__tests__/timing.test.js
@@ -1,5 +1,11 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {getServerTimeOffset, recordServerTimestamp, resetServerTimeOffset, serverNow} from '../timing';
+import {
+  getServerTimeOffset,
+  recordServerTimeFromRoundTrip,
+  recordServerTimestamp,
+  resetServerTimeOffset,
+  serverNow,
+} from '../timing';
 
 describe('server time offset', () => {
   beforeEach(() => {
@@ -26,118 +32,11 @@ describe('server time offset', () => {
     expect(serverNow()).toBe(local + 30_000);
   });
 
-  it('measures how far this device is ahead of the server', () => {
-    vi.useFakeTimers();
-    const local = Date.now();
-    recordServerTimestamp(local - 30_000);
-
-    expect(getServerTimeOffset()).toBe(-30_000);
-    expect(serverNow()).toBe(local - 30_000);
-  });
-
-  // Every sample is biased low by however long the event was in flight, so the
-  // largest recent sample is the best estimate. Preferring the newest let one
-  // late callback rewind serverNow() and stall the displayed clock.
-  it('keeps the best sample rather than the newest one', () => {
-    vi.useFakeTimers();
-    const local = Date.now();
-    recordServerTimestamp(local + 5_000);
-    // A delayed callback: same true offset, but 4s of queueing lands in the
-    // local term and makes the sample look smaller.
-    recordServerTimestamp(local + 1_000);
-
-    expect(getServerTimeOffset()).toBe(5_000);
-  });
-
-  it('adopts a better sample immediately', () => {
-    vi.useFakeTimers();
-    const local = Date.now();
-    recordServerTimestamp(local + 1_000);
-    recordServerTimestamp(local + 5_000);
-
-    expect(getServerTimeOffset()).toBe(5_000);
-  });
-
-  it('does not let a late event rewind server time', () => {
-    vi.useFakeTimers();
-    const local = Date.now();
-    recordServerTimestamp(local + 30_000);
-    const before = serverNow();
-
-    // Tab suspended: this event's callback runs two minutes after it was
-    // stamped, which would read as the device being 2min ahead of the server.
-    recordServerTimestamp(local + 30_000 - 120_000);
-
-    expect(serverNow()).toBe(before);
-  });
-
-  it('adapts to a genuine clock change once two samples agree', () => {
-    vi.useFakeTimers();
-    const local = Date.now();
-    recordServerTimestamp(local + 30_000);
-    expect(getServerTimeOffset()).toBe(30_000);
-
-    // Past the window, two agreeing lower samples are believed — the device
-    // clock really did move, rather than one event arriving late.
-    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
-    recordServerTimestamp(Date.now() + 2_000);
-    expect(getServerTimeOffset()).toBe(30_000); // one lower sample proves nothing
-    recordServerTimestamp(Date.now() + 2_000);
-
-    expect(getServerTimeOffset()).toBe(2_000);
-  });
-
-  // A long suspension makes the estimate stale AND the queued sample delayed at
-  // the same time, so an expiry branch that trusted a lone sample would rewind
-  // the clock exactly when it is most likely to be wrong.
-  it('does not trust a lone delayed sample after a long suspension', () => {
-    vi.useFakeTimers();
-    const local = Date.now();
-    recordServerTimestamp(local + 30_000);
-    const before = serverNow();
-
-    // Tab suspended for ten minutes; on resume a queued event's callback runs
-    // with a stamp from before the suspension.
-    vi.advanceTimersByTime(10 * 60 * 1000);
-    recordServerTimestamp(Date.now() + 30_000 - 10 * 60 * 1000);
-
-    expect(getServerTimeOffset()).toBe(30_000);
-    expect(serverNow()).toBe(before + 10 * 60 * 1000);
-  });
-
-  it('recovers immediately from the join ack after a suspension', () => {
-    vi.useFakeTimers();
-    const local = Date.now();
-    recordServerTimestamp(local + 30_000);
-
-    vi.advanceTimersByTime(10 * 60 * 1000);
-    // Stale delayed sample first, then the reconnect's fresh ack.
-    recordServerTimestamp(Date.now() + 30_000 - 10 * 60 * 1000);
-    recordServerTimestamp(Date.now() + 45_000);
-
-    expect(getServerTimeOffset()).toBe(45_000);
-  });
-
-  it('disagreeing low samples never accumulate into an adoption', () => {
-    vi.useFakeTimers();
-    const local = Date.now();
-    recordServerTimestamp(local + 30_000);
-
-    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
-    // Independent delays of differing magnitude — no two agree.
-    recordServerTimestamp(Date.now() + 30_000 - 8_000);
-    recordServerTimestamp(Date.now() + 30_000 - 20_000);
-    recordServerTimestamp(Date.now() + 30_000 - 3_000);
-
-    expect(getServerTimeOffset()).toBe(30_000);
-  });
-
   it('ignores samples that are not finite numbers', () => {
     vi.useFakeTimers();
     const local = Date.now();
     recordServerTimestamp(local + 7_000);
     // A non-sample must not be treated as "no offset yet" and reset anything.
-
     recordServerTimestamp(undefined);
     recordServerTimestamp(null);
     recordServerTimestamp('1700000000000');
@@ -145,5 +44,126 @@ describe('server time offset', () => {
     recordServerTimestamp(Infinity);
 
     expect(getServerTimeOffset()).toBe(7_000);
+  });
+
+  describe('one-way samples from broadcast events', () => {
+    // A sample is `serverStamp - Date.now()`, so in-flight delay lands in the
+    // local term and biases it low. A higher sample can't be explained by delay.
+    it('adopts a better sample immediately', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      recordServerTimestamp(local + 1_000);
+      recordServerTimestamp(local + 5_000);
+
+      expect(getServerTimeOffset()).toBe(5_000);
+    });
+
+    it('never lowers the estimate, however many low samples arrive', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      recordServerTimestamp(local + 30_000);
+
+      recordServerTimestamp(local + 30_000 - 4_000);
+      recordServerTimestamp(local + 30_000 - 4_000);
+      recordServerTimestamp(local + 30_000 - 4_000);
+      recordServerTimestamp(local + 30_000 - 90_000);
+
+      expect(getServerTimeOffset()).toBe(30_000);
+    });
+
+    it('does not let a late event rewind server time', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      recordServerTimestamp(local + 30_000);
+      const before = serverNow();
+
+      // Tab suspended: this event's callback runs two minutes after it was
+      // stamped, which would read as the device being 2min ahead of the server.
+      recordServerTimestamp(local + 30_000 - 120_000);
+
+      expect(serverNow()).toBe(before);
+    });
+
+    // A suspended tab resumes by draining a batch of queued events whose delays
+    // are near-identical, so agreement between them proves nothing about
+    // freshness — an earlier version of this module was fooled by exactly this.
+    it('is not fooled by a batch of queued events agreeing with each other', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      recordServerTimestamp(local + 30_000);
+
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      // Two events stamped 200ms apart, both delivered on resume.
+      const suspension = 10 * 60 * 1000;
+      recordServerTimestamp(Date.now() + 30_000 - suspension);
+      recordServerTimestamp(Date.now() + 30_000 - suspension + 200);
+
+      expect(getServerTimeOffset()).toBe(30_000);
+    });
+  });
+
+  describe('round-trip samples from the join ack', () => {
+    it('corrects the offset downward, which broadcasts cannot', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      recordServerTimestamp(local + 30_000);
+      expect(getServerTimeOffset()).toBe(30_000);
+
+      // The device clock really did move: a timed round trip proves the server
+      // is only 2s ahead now.
+      recordServerTimeFromRoundTrip(Date.now() + 2_000, 0);
+
+      expect(getServerTimeOffset()).toBe(2_000);
+    });
+
+    // The stamp was taken somewhere between our send and our receive, so
+    // assuming the midpoint leaves ±rtt/2 of error rather than a systematic lag.
+    it('credits half the round trip to the flight out', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      recordServerTimeFromRoundTrip(local + 1_000, 400);
+
+      expect(getServerTimeOffset()).toBe(1_200);
+    });
+
+    it('recovers immediately after a suspension', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      recordServerTimestamp(local + 30_000);
+
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      // Stale delayed broadcast first, then the reconnect's timed ack.
+      recordServerTimestamp(Date.now() + 30_000 - 10 * 60 * 1000);
+      recordServerTimeFromRoundTrip(Date.now() + 45_000, 100);
+
+      expect(getServerTimeOffset()).toBe(45_050);
+    });
+
+    it('falls back to raise-only when the round trip is too long to bound the delay', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      recordServerTimestamp(local + 30_000);
+
+      // 30s round trip says nothing useful about where in that window the
+      // stamp was taken, so it must not be trusted downward.
+      recordServerTimeFromRoundTrip(Date.now() + 2_000, 30_000);
+      expect(getServerTimeOffset()).toBe(30_000);
+
+      // Still usable in the direction delay can't fake.
+      recordServerTimeFromRoundTrip(Date.now() + 60_000, 30_000);
+      expect(getServerTimeOffset()).toBe(60_000);
+    });
+
+    it('ignores a malformed round trip measurement', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      recordServerTimestamp(local + 30_000);
+
+      recordServerTimeFromRoundTrip(Date.now() + 2_000, -5);
+      recordServerTimeFromRoundTrip(Date.now() + 2_000, NaN);
+      recordServerTimeFromRoundTrip(Date.now() + 2_000, undefined);
+
+      expect(getServerTimeOffset()).toBe(30_000);
+    });
   });
 });

--- a/src/lib/__tests__/timing.test.js
+++ b/src/lib/__tests__/timing.test.js
@@ -35,19 +35,61 @@ describe('server time offset', () => {
     expect(serverNow()).toBe(local - 30_000);
   });
 
-  it('tracks the most recent sample', () => {
+  // Every sample is biased low by however long the event was in flight, so the
+  // largest recent sample is the best estimate. Preferring the newest let one
+  // late callback rewind serverNow() and stall the displayed clock.
+  it('keeps the best sample rather than the newest one', () => {
     vi.useFakeTimers();
     const local = Date.now();
     recordServerTimestamp(local + 5_000);
+    // A delayed callback: same true offset, but 4s of queueing lands in the
+    // local term and makes the sample look smaller.
     recordServerTimestamp(local + 1_000);
 
-    expect(getServerTimeOffset()).toBe(1_000);
+    expect(getServerTimeOffset()).toBe(5_000);
+  });
+
+  it('adopts a better sample immediately', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    recordServerTimestamp(local + 1_000);
+    recordServerTimestamp(local + 5_000);
+
+    expect(getServerTimeOffset()).toBe(5_000);
+  });
+
+  it('does not let a late event rewind server time', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    recordServerTimestamp(local + 30_000);
+    const before = serverNow();
+
+    // Tab suspended: this event's callback runs two minutes after it was
+    // stamped, which would read as the device being 2min ahead of the server.
+    recordServerTimestamp(local + 30_000 - 120_000);
+
+    expect(serverNow()).toBe(before);
+  });
+
+  it('adapts to a genuine clock change once the estimate goes stale', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    recordServerTimestamp(local + 30_000);
+    expect(getServerTimeOffset()).toBe(30_000);
+
+    // Past the window, a lower sample is trusted — the device clock really did
+    // move, rather than one event arriving late.
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    recordServerTimestamp(Date.now() + 2_000);
+
+    expect(getServerTimeOffset()).toBe(2_000);
   });
 
   it('ignores samples that are not finite numbers', () => {
     vi.useFakeTimers();
     const local = Date.now();
     recordServerTimestamp(local + 7_000);
+    // A non-sample must not be treated as "no offset yet" and reset anything.
 
     recordServerTimestamp(undefined);
     recordServerTimestamp(null);

--- a/src/lib/__tests__/timing.test.js
+++ b/src/lib/__tests__/timing.test.js
@@ -71,18 +71,65 @@ describe('server time offset', () => {
     expect(serverNow()).toBe(before);
   });
 
-  it('adapts to a genuine clock change once the estimate goes stale', () => {
+  it('adapts to a genuine clock change once two samples agree', () => {
     vi.useFakeTimers();
     const local = Date.now();
     recordServerTimestamp(local + 30_000);
     expect(getServerTimeOffset()).toBe(30_000);
 
-    // Past the window, a lower sample is trusted — the device clock really did
-    // move, rather than one event arriving late.
+    // Past the window, two agreeing lower samples are believed — the device
+    // clock really did move, rather than one event arriving late.
     vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    recordServerTimestamp(Date.now() + 2_000);
+    expect(getServerTimeOffset()).toBe(30_000); // one lower sample proves nothing
     recordServerTimestamp(Date.now() + 2_000);
 
     expect(getServerTimeOffset()).toBe(2_000);
+  });
+
+  // A long suspension makes the estimate stale AND the queued sample delayed at
+  // the same time, so an expiry branch that trusted a lone sample would rewind
+  // the clock exactly when it is most likely to be wrong.
+  it('does not trust a lone delayed sample after a long suspension', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    recordServerTimestamp(local + 30_000);
+    const before = serverNow();
+
+    // Tab suspended for ten minutes; on resume a queued event's callback runs
+    // with a stamp from before the suspension.
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    recordServerTimestamp(Date.now() + 30_000 - 10 * 60 * 1000);
+
+    expect(getServerTimeOffset()).toBe(30_000);
+    expect(serverNow()).toBe(before + 10 * 60 * 1000);
+  });
+
+  it('recovers immediately from the join ack after a suspension', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    recordServerTimestamp(local + 30_000);
+
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    // Stale delayed sample first, then the reconnect's fresh ack.
+    recordServerTimestamp(Date.now() + 30_000 - 10 * 60 * 1000);
+    recordServerTimestamp(Date.now() + 45_000);
+
+    expect(getServerTimeOffset()).toBe(45_000);
+  });
+
+  it('disagreeing low samples never accumulate into an adoption', () => {
+    vi.useFakeTimers();
+    const local = Date.now();
+    recordServerTimestamp(local + 30_000);
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    // Independent delays of differing magnitude — no two agree.
+    recordServerTimestamp(Date.now() + 30_000 - 8_000);
+    recordServerTimestamp(Date.now() + 30_000 - 20_000);
+    recordServerTimestamp(Date.now() + 30_000 - 3_000);
+
+    expect(getServerTimeOffset()).toBe(30_000);
   });
 
   it('ignores samples that are not finite numbers', () => {

--- a/src/lib/__tests__/timing.test.js
+++ b/src/lib/__tests__/timing.test.js
@@ -1,10 +1,12 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
+  MAX_CLOCK_INCREMENT,
   getServerTimeOffset,
   recordServerTimeExchange,
   recordServerTimestamp,
   resetServerTimeOffset,
   serverNow,
+  unaccountedClockTime,
 } from '../timing';
 
 describe('server time offset', () => {
@@ -99,6 +101,38 @@ describe('server time offset', () => {
       recordServerTimestamp(Date.now() + 30_000 - suspension + 200);
 
       expect(getServerTimeOffset()).toBe(30_000);
+    });
+  });
+
+  describe('unaccountedClockTime', () => {
+    it('is zero for a paused or never-started clock', () => {
+      vi.useFakeTimers();
+      expect(unaccountedClockTime(undefined)).toBe(0);
+      expect(unaccountedClockTime({paused: true, lastUpdated: Date.now() - 5_000})).toBe(0);
+      expect(unaccountedClockTime({paused: false, lastUpdated: 0})).toBe(0);
+    });
+
+    it('measures the gap on the server clock', () => {
+      vi.useFakeTimers();
+      recordServerTimestamp(Date.now() + 10_000);
+      // Last event was stamped 5s ago in server time.
+      expect(unaccountedClockTime({paused: false, lastUpdated: Date.now() + 10_000 - 5_000})).toBe(5_000);
+    });
+
+    // Same cap tick() applies to a gap, so a stale lastUpdated — a device clock
+    // stepped forward, an offset estimate not yet corrected — can't inflate a
+    // recorded solve without limit.
+    it('caps the gap the way tick does', () => {
+      vi.useFakeTimers();
+      const local = Date.now();
+      expect(unaccountedClockTime({paused: false, lastUpdated: local - 60 * 60 * 1000})).toBe(
+        MAX_CLOCK_INCREMENT
+      );
+    });
+
+    it('never goes negative when lastUpdated is in the future', () => {
+      vi.useFakeTimers();
+      expect(unaccountedClockTime({paused: false, lastUpdated: Date.now() + 30_000})).toBe(0);
     });
   });
 

--- a/src/lib/__tests__/timing.test.js
+++ b/src/lib/__tests__/timing.test.js
@@ -1,7 +1,7 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   getServerTimeOffset,
-  recordServerTimeFromRoundTrip,
+  recordServerTimeExchange,
   recordServerTimestamp,
   resetServerTimeOffset,
   serverNow,
@@ -102,67 +102,98 @@ describe('server time offset', () => {
     });
   });
 
-  describe('round-trip samples from the join ack', () => {
+  describe('timed exchange from the join ack', () => {
+    // Helper: build the four timestamps for a device whose clock is `offset`
+    // behind the server, with a given one-way network time and server think time.
+    const exchange = ({offset, oneWay, processing}) => {
+      const sentAt = Date.now();
+      const serverReceivedAt = sentAt + offset + oneWay;
+      return {
+        sentAt,
+        serverReceivedAt,
+        serverSentAt: serverReceivedAt + processing,
+        receivedAt: sentAt + 2 * oneWay + processing,
+      };
+    };
+
     it('corrects the offset downward, which broadcasts cannot', () => {
       vi.useFakeTimers();
-      const local = Date.now();
-      recordServerTimestamp(local + 30_000);
+      recordServerTimestamp(Date.now() + 30_000);
       expect(getServerTimeOffset()).toBe(30_000);
 
-      // The device clock really did move: a timed round trip proves the server
-      // is only 2s ahead now.
-      recordServerTimeFromRoundTrip(Date.now() + 2_000, 0);
+      // The device clock really did move: the exchange proves the server is
+      // only 2s ahead now.
+      recordServerTimeExchange(exchange({offset: 2_000, oneWay: 0, processing: 0}));
 
       expect(getServerTimeOffset()).toBe(2_000);
     });
 
-    // The stamp was taken somewhere between our send and our receive, so
-    // assuming the midpoint leaves ±rtt/2 of error rather than a systematic lag.
-    it('credits half the round trip to the flight out', () => {
+    it('recovers the offset exactly despite symmetric network delay', () => {
       vi.useFakeTimers();
-      const local = Date.now();
-      recordServerTimeFromRoundTrip(local + 1_000, 400);
+      recordServerTimeExchange(exchange({offset: 1_000, oneWay: 200, processing: 0}));
 
-      expect(getServerTimeOffset()).toBe(1_200);
+      expect(getServerTimeOffset()).toBe(1_000);
+    });
+
+    // The whole point of sending both server timestamps: halving the total
+    // duration would charge this processing to the outbound flight.
+    it('does not mistake slow server processing for flight time', () => {
+      vi.useFakeTimers();
+      recordServerTimeExchange(exchange({offset: 1_000, oneWay: 50, processing: 8_000}));
+
+      expect(getServerTimeOffset()).toBe(1_000);
     });
 
     it('recovers immediately after a suspension', () => {
       vi.useFakeTimers();
-      const local = Date.now();
-      recordServerTimestamp(local + 30_000);
+      recordServerTimestamp(Date.now() + 30_000);
 
       vi.advanceTimersByTime(10 * 60 * 1000);
-      // Stale delayed broadcast first, then the reconnect's timed ack.
+      // Stale delayed broadcast first, then the reconnect's timed exchange.
       recordServerTimestamp(Date.now() + 30_000 - 10 * 60 * 1000);
-      recordServerTimeFromRoundTrip(Date.now() + 45_000, 100);
+      recordServerTimeExchange(exchange({offset: 45_000, oneWay: 0, processing: 120}));
 
-      expect(getServerTimeOffset()).toBe(45_050);
+      expect(getServerTimeOffset()).toBe(45_000);
     });
 
-    it('falls back to raise-only when the round trip is too long to bound the delay', () => {
+    it('falls back to raise-only when the network trip is too long to bound', () => {
+      vi.useFakeTimers();
+      recordServerTimestamp(Date.now() + 30_000);
+
+      // A 30s network trip says nothing useful about where in that window the
+      // stamp was taken, so it must not be trusted downward.
+      recordServerTimeExchange(exchange({offset: 2_000, oneWay: 15_000, processing: 10}));
+      expect(getServerTimeOffset()).toBe(30_000);
+    });
+
+    it('degrades to a one-way sample when the server sends no receive time', () => {
       vi.useFakeTimers();
       const local = Date.now();
       recordServerTimestamp(local + 30_000);
 
-      // 30s round trip says nothing useful about where in that window the
-      // stamp was taken, so it must not be trusted downward.
-      recordServerTimeFromRoundTrip(Date.now() + 2_000, 30_000);
+      // Older server: can't split the round trip, so this may only raise.
+      recordServerTimeExchange({sentAt: local, serverSentAt: local + 2_000, receivedAt: local + 40});
       expect(getServerTimeOffset()).toBe(30_000);
 
-      // Still usable in the direction delay can't fake.
-      recordServerTimeFromRoundTrip(Date.now() + 60_000, 30_000);
+      recordServerTimeExchange({sentAt: local, serverSentAt: local + 60_000, receivedAt: local + 40});
       expect(getServerTimeOffset()).toBe(60_000);
     });
 
-    it('ignores a malformed round trip measurement', () => {
+    it('ignores an incoherent exchange', () => {
       vi.useFakeTimers();
       const local = Date.now();
       recordServerTimestamp(local + 30_000);
 
-      recordServerTimeFromRoundTrip(Date.now() + 2_000, -5);
-      recordServerTimeFromRoundTrip(Date.now() + 2_000, NaN);
-      recordServerTimeFromRoundTrip(Date.now() + 2_000, undefined);
+      // Server timestamps inverted, and a receive that precedes the send.
+      recordServerTimeExchange({
+        sentAt: local,
+        serverReceivedAt: local + 500,
+        serverSentAt: local + 100,
+        receivedAt: local + 600,
+      });
+      expect(getServerTimeOffset()).toBe(30_000);
 
+      recordServerTimeExchange({sentAt: local, serverSentAt: undefined, receivedAt: local + 40});
       expect(getServerTimeOffset()).toBe(30_000);
     });
   });

--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -1,1 +1,31 @@
 export const MAX_CLOCK_INCREMENT = 1000 * 60;
+
+// The game clock's persisted portion (clock.totalTime) is accumulated from
+// server-stamped event timestamps, and the live portion is the time elapsed
+// since clock.lastUpdated — also a server timestamp. Measuring that elapsed
+// time with a raw local Date.now() would display the device's own clock skew
+// as solve time (a device 30s fast would show 00:30 the instant the clock
+// started), so we track the offset between server and local time and read
+// "now" through it.
+//
+// Only live socket events are valid samples: an event from the initial history
+// sync is legitimately old and would look like an enormous offset.
+let serverTimeOffset = 0;
+
+// Records a server-stamped timestamp from a just-received live event. The
+// estimate is short by the one-way network latency (tens of ms), which is far
+// below the clock skew this exists to cancel out.
+export const recordServerTimestamp = (serverTimestamp) => {
+  if (typeof serverTimestamp !== 'number' || !Number.isFinite(serverTimestamp)) return;
+  serverTimeOffset = serverTimestamp - Date.now();
+};
+
+export const getServerTimeOffset = () => serverTimeOffset;
+
+// Local Date.now() translated into the server's clock.
+export const serverNow = () => Date.now() + serverTimeOffset;
+
+// Test seam — the offset is module-level state shared by every game in the tab.
+export const resetServerTimeOffset = () => {
+  serverTimeOffset = 0;
+};

--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -8,76 +8,58 @@ export const MAX_CLOCK_INCREMENT = 1000 * 60;
 // started), so we track the offset between server and local time and read
 // "now" through it.
 //
-// Only live socket events are valid samples: an event from the initial history
-// sync is legitimately old and would look like an enormous offset.
+// Estimating that offset comes down to one question per sample: how long did
+// this timestamp take to reach us? A sample is `serverStamp - Date.now()`, so
+// any delay in between lands entirely in the local term — network, the database
+// write that precedes the broadcast, a throttled or suspended tab draining its
+// callback queue. Every sample is therefore `trueOffset - delay`: a lower bound,
+// never an over-estimate.
 //
-// Every sample is biased LOW, and by an unknown amount. A sample is
-// `serverStamp - Date.now()`, so anything that delays the event between the
-// server stamping it and us processing it — network, the database write that
-// precedes the broadcast, a throttled background tab draining its callback
-// queue — lands entirely in the local term: sample = trueOffset - delay. That
-// makes each sample a lower bound on the true offset, so the best available
-// estimate is the LARGEST recent sample. Taking the most recent one instead
-// let a single late callback rewind serverNow() by the length of the delay,
-// stalling the displayed clock and under-counting the recorded solve time.
+// That asymmetry decides everything. A sample ABOVE the current estimate cannot
+// be explained by delay, so it is trustworthy on sight. A sample BELOW it is
+// ambiguous — either the device clock moved, or that event was slow — and no
+// amount of squinting at a one-way sample resolves which. Two earlier attempts
+// here tried and failed: adopting any sample once the estimate went stale, and
+// then requiring two lower samples to agree. Both broke on a suspended tab,
+// which delivers a batch of queued events whose delays are near-identical, so
+// batch-mates corroborate each other into a badly rewound clock.
 //
-// "Largest" alone would pin the estimate forever, so a lower sample can still
-// win — but only with corroboration, never on its own. A single lower sample is
-// ambiguous: it means either the device clock really moved, or that one event
-// was delayed. Adopting it unconditionally once the estimate went stale would
-// re-enable the very failure above, and at the worst possible moment, since a
-// long tab suspension produces a stale estimate and a delayed sample together.
-//
-// So a lower estimate requires two consecutive lower samples that agree to
-// within AGREEMENT_TOLERANCE_MS, plus a stale current estimate. Two independent
-// delays rarely agree closely, while two samples taken after a real clock change
-// agree exactly. The cost is that a genuine clock change takes up to
-// OFFSET_WINDOW_MS to be believed — acceptable because the common recovery path
-// is upward: a suspended tab's socket reconnects, and the join_game ack is a
-// fresh, undelayed sample that wins immediately on the "largest" rule.
-const OFFSET_WINDOW_MS = 5 * 60 * 1000;
-const AGREEMENT_TOLERANCE_MS = 1000;
-
+// So one-way samples may only ever raise the estimate. Lowering it requires
+// evidence of freshness, which only a measured round trip provides.
 let serverTimeOffset = 0;
 let hasSample = false;
-let sampledAt = 0;
-// Last lower-than-current sample, held as a candidate awaiting corroboration.
-let candidate = null;
 
-// Elapsed-time reference for the window. Monotonic where available so that a
-// device clock change can't make the current estimate look fresher than it is.
-const monotonicNow = () =>
-  typeof performance !== 'undefined' && typeof performance.now === 'function'
-    ? performance.now()
-    : Date.now();
+const isFiniteNumber = (value) => typeof value === 'number' && Number.isFinite(value);
 
-// Records a server-stamped timestamp from a just-received live event or the
-// join_game ack.
+// Beyond this a "round trip" tells us too little about the delay to be worth
+// trusting in the downward direction.
+const MAX_TRUSTED_ROUND_TRIP_MS = 10 * 1000;
+
+// A one-way sample: a server-stamped timestamp off a broadcast event, whose
+// delay is unbounded. Raises the estimate, never lowers it.
 export const recordServerTimestamp = (serverTimestamp) => {
-  if (typeof serverTimestamp !== 'number' || !Number.isFinite(serverTimestamp)) return;
+  if (!isFiniteNumber(serverTimestamp)) return;
   const sample = serverTimestamp - Date.now();
-  const now = monotonicNow();
-
-  // Delay can only bias a sample downward, so anything at or above the current
-  // estimate is trustworthy on sight.
-  if (!hasSample || sample >= serverTimeOffset) {
+  if (!hasSample || sample > serverTimeOffset) {
     serverTimeOffset = sample;
-    sampledAt = now;
     hasSample = true;
-    candidate = null;
-    return;
   }
+};
 
-  // Lower than what we have. Believe it only if the previous lower sample
-  // agrees and the estimate we'd be replacing has gone stale.
-  const corroborated = candidate !== null && Math.abs(sample - candidate.value) <= AGREEMENT_TOLERANCE_MS;
-  if (corroborated && now - sampledAt > OFFSET_WINDOW_MS) {
-    serverTimeOffset = sample;
-    sampledAt = now;
-    candidate = null;
+// A sample from a request whose round trip we timed — the join_game ack. The
+// server stamped it somewhere between our send and our receive, so the delay is
+// bounded by roundTripMs rather than unknown, which makes this the only
+// evidence that can lower the estimate. Assuming the stamp landed mid-flight
+// puts the residual error at ±roundTripMs / 2.
+export const recordServerTimeFromRoundTrip = (serverTimestamp, roundTripMs) => {
+  if (!isFiniteNumber(serverTimestamp)) return;
+  if (!isFiniteNumber(roundTripMs) || roundTripMs < 0 || roundTripMs > MAX_TRUSTED_ROUND_TRIP_MS) {
+    // Delay isn't bounded after all — treat it as an ordinary one-way sample.
+    recordServerTimestamp(serverTimestamp);
     return;
   }
-  candidate = {value: sample, at: now};
+  serverTimeOffset = serverTimestamp - Date.now() + roundTripMs / 2;
+  hasSample = true;
 };
 
 export const getServerTimeOffset = () => serverTimeOffset;
@@ -89,6 +71,4 @@ export const serverNow = () => Date.now() + serverTimeOffset;
 export const resetServerTimeOffset = () => {
   serverTimeOffset = 0;
   hasSample = false;
-  sampledAt = 0;
-  candidate = null;
 };

--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -21,14 +21,28 @@ export const MAX_CLOCK_INCREMENT = 1000 * 60;
 // let a single late callback rewind serverNow() by the length of the delay,
 // stalling the displayed clock and under-counting the recorded solve time.
 //
-// The window keeps "largest" from pinning the estimate forever: once the
-// winning sample is older than OFFSET_WINDOW_MS, the next sample replaces it
-// outright, so a genuine device clock change is picked up within the window.
+// "Largest" alone would pin the estimate forever, so a lower sample can still
+// win — but only with corroboration, never on its own. A single lower sample is
+// ambiguous: it means either the device clock really moved, or that one event
+// was delayed. Adopting it unconditionally once the estimate went stale would
+// re-enable the very failure above, and at the worst possible moment, since a
+// long tab suspension produces a stale estimate and a delayed sample together.
+//
+// So a lower estimate requires two consecutive lower samples that agree to
+// within AGREEMENT_TOLERANCE_MS, plus a stale current estimate. Two independent
+// delays rarely agree closely, while two samples taken after a real clock change
+// agree exactly. The cost is that a genuine clock change takes up to
+// OFFSET_WINDOW_MS to be believed — acceptable because the common recovery path
+// is upward: a suspended tab's socket reconnects, and the join_game ack is a
+// fresh, undelayed sample that wins immediately on the "largest" rule.
 const OFFSET_WINDOW_MS = 5 * 60 * 1000;
+const AGREEMENT_TOLERANCE_MS = 1000;
 
 let serverTimeOffset = 0;
 let hasSample = false;
 let sampledAt = 0;
+// Last lower-than-current sample, held as a candidate awaiting corroboration.
+let candidate = null;
 
 // Elapsed-time reference for the window. Monotonic where available so that a
 // device clock change can't make the current estimate look fresher than it is.
@@ -43,13 +57,27 @@ export const recordServerTimestamp = (serverTimestamp) => {
   if (typeof serverTimestamp !== 'number' || !Number.isFinite(serverTimestamp)) return;
   const sample = serverTimestamp - Date.now();
   const now = monotonicNow();
-  // Adopt the first sample, any sample that beats the current estimate, or any
-  // sample at all once the current estimate has gone stale.
-  if (!hasSample || sample > serverTimeOffset || now - sampledAt > OFFSET_WINDOW_MS) {
+
+  // Delay can only bias a sample downward, so anything at or above the current
+  // estimate is trustworthy on sight.
+  if (!hasSample || sample >= serverTimeOffset) {
     serverTimeOffset = sample;
     sampledAt = now;
     hasSample = true;
+    candidate = null;
+    return;
   }
+
+  // Lower than what we have. Believe it only if the previous lower sample
+  // agrees and the estimate we'd be replacing has gone stale.
+  const corroborated = candidate !== null && Math.abs(sample - candidate.value) <= AGREEMENT_TOLERANCE_MS;
+  if (corroborated && now - sampledAt > OFFSET_WINDOW_MS) {
+    serverTimeOffset = sample;
+    sampledAt = now;
+    candidate = null;
+    return;
+  }
+  candidate = {value: sample, at: now};
 };
 
 export const getServerTimeOffset = () => serverTimeOffset;
@@ -62,4 +90,5 @@ export const resetServerTimeOffset = () => {
   serverTimeOffset = 0;
   hasSample = false;
   sampledAt = 0;
+  candidate = null;
 };

--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -86,6 +86,20 @@ export const getServerTimeOffset = () => serverTimeOffset;
 // Local Date.now() translated into the server's clock.
 export const serverNow = () => Date.now() + serverTimeOffset;
 
+// Time elapsed since the clock was last ticked, for the caller that has to
+// settle a solve before the next event arrives to tick it.
+//
+// Capped at MAX_CLOCK_INCREMENT because that is exactly what tick() would have
+// charged had an event arrived instead, and it bounds the damage when
+// lastUpdated is further in the past than real solving explains — a device
+// clock stepped forward mid-session, or a gap the offset estimate hasn't
+// caught up with yet.
+export const unaccountedClockTime = (clock) => {
+  if (!clock || clock.paused || !clock.lastUpdated) return 0;
+  const elapsed = serverNow() - clock.lastUpdated;
+  return Math.max(0, Math.min(elapsed, MAX_CLOCK_INCREMENT));
+};
+
 // Test seam — the offset is module-level state shared by every game in the tab.
 export const resetServerTimeOffset = () => {
   serverTimeOffset = 0;

--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -31,8 +31,8 @@ let hasSample = false;
 
 const isFiniteNumber = (value) => typeof value === 'number' && Number.isFinite(value);
 
-// Beyond this a "round trip" tells us too little about the delay to be worth
-// trusting in the downward direction.
+// Beyond this the network round trip tells us too little about the delay to be
+// worth trusting in the downward direction.
 const MAX_TRUSTED_ROUND_TRIP_MS = 10 * 1000;
 
 // A one-way sample: a server-stamped timestamp off a broadcast event, whose
@@ -46,19 +46,38 @@ export const recordServerTimestamp = (serverTimestamp) => {
   }
 };
 
-// A sample from a request whose round trip we timed — the join_game ack. The
-// server stamped it somewhere between our send and our receive, so the delay is
-// bounded by roundTripMs rather than unknown, which makes this the only
-// evidence that can lower the estimate. Assuming the stamp landed mid-flight
-// puts the residual error at ±roundTripMs / 2.
-export const recordServerTimeFromRoundTrip = (serverTimestamp, roundTripMs) => {
-  if (!isFiniteNumber(serverTimestamp)) return;
-  if (!isFiniteNumber(roundTripMs) || roundTripMs < 0 || roundTripMs > MAX_TRUSTED_ROUND_TRIP_MS) {
-    // Delay isn't bounded after all — treat it as an ordinary one-way sample.
-    recordServerTimestamp(serverTimestamp);
+// A timed exchange — the join_game ack, which reports both when the server
+// received our request and when it answered. Four timestamps make this the only
+// evidence that can lower the estimate:
+//
+//   sentAt ──────► serverReceivedAt ··· serverSentAt ──────► receivedAt
+//
+// The two middle values bracket the server's own processing, which can be
+// slow (a moderation cache miss goes to the database) and is not flight time.
+// Halving the whole duration instead — the obvious shortcut — charges that
+// processing to the outbound flight and overestimates the offset by roughly
+// half of it, which then sticks, because one-way samples can only raise. So
+// take each direction separately and average, leaving only the asymmetry
+// between the two network paths:
+//
+//   offset      = ((serverReceivedAt - sentAt) + (serverSentAt - receivedAt)) / 2
+//   networkTrip = (receivedAt - sentAt) - (serverSentAt - serverReceivedAt)
+//
+// An older server sends no serverReceivedAt; without it the split is unknowable,
+// so the stamp degrades to an ordinary one-way sample rather than being guessed.
+export const recordServerTimeExchange = ({sentAt, serverReceivedAt, serverSentAt, receivedAt}) => {
+  if (!isFiniteNumber(serverSentAt)) return;
+  if (!isFiniteNumber(serverReceivedAt) || !isFiniteNumber(sentAt) || !isFiniteNumber(receivedAt)) {
+    recordServerTimestamp(serverSentAt);
     return;
   }
-  serverTimeOffset = serverTimestamp - Date.now() + roundTripMs / 2;
+  const serverProcessing = serverSentAt - serverReceivedAt;
+  const networkTrip = receivedAt - sentAt - serverProcessing;
+  if (serverProcessing < 0 || networkTrip < 0 || networkTrip > MAX_TRUSTED_ROUND_TRIP_MS) {
+    recordServerTimestamp(serverSentAt);
+    return;
+  }
+  serverTimeOffset = (serverReceivedAt - sentAt + (serverSentAt - receivedAt)) / 2;
   hasSample = true;
 };
 

--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -10,14 +10,46 @@ export const MAX_CLOCK_INCREMENT = 1000 * 60;
 //
 // Only live socket events are valid samples: an event from the initial history
 // sync is legitimately old and would look like an enormous offset.
-let serverTimeOffset = 0;
+//
+// Every sample is biased LOW, and by an unknown amount. A sample is
+// `serverStamp - Date.now()`, so anything that delays the event between the
+// server stamping it and us processing it — network, the database write that
+// precedes the broadcast, a throttled background tab draining its callback
+// queue — lands entirely in the local term: sample = trueOffset - delay. That
+// makes each sample a lower bound on the true offset, so the best available
+// estimate is the LARGEST recent sample. Taking the most recent one instead
+// let a single late callback rewind serverNow() by the length of the delay,
+// stalling the displayed clock and under-counting the recorded solve time.
+//
+// The window keeps "largest" from pinning the estimate forever: once the
+// winning sample is older than OFFSET_WINDOW_MS, the next sample replaces it
+// outright, so a genuine device clock change is picked up within the window.
+const OFFSET_WINDOW_MS = 5 * 60 * 1000;
 
-// Records a server-stamped timestamp from a just-received live event. The
-// estimate is short by the one-way network latency (tens of ms), which is far
-// below the clock skew this exists to cancel out.
+let serverTimeOffset = 0;
+let hasSample = false;
+let sampledAt = 0;
+
+// Elapsed-time reference for the window. Monotonic where available so that a
+// device clock change can't make the current estimate look fresher than it is.
+const monotonicNow = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+// Records a server-stamped timestamp from a just-received live event or the
+// join_game ack.
 export const recordServerTimestamp = (serverTimestamp) => {
   if (typeof serverTimestamp !== 'number' || !Number.isFinite(serverTimestamp)) return;
-  serverTimeOffset = serverTimestamp - Date.now();
+  const sample = serverTimestamp - Date.now();
+  const now = monotonicNow();
+  // Adopt the first sample, any sample that beats the current estimate, or any
+  // sample at all once the current estimate has gone stale.
+  if (!hasSample || sample > serverTimeOffset || now - sampledAt > OFFSET_WINDOW_MS) {
+    serverTimeOffset = sample;
+    sampledAt = now;
+    hasSample = true;
+  }
 };
 
 export const getServerTimeOffset = () => serverTimeOffset;
@@ -28,4 +60,6 @@ export const serverNow = () => Date.now() + serverTimeOffset;
 // Test seam — the offset is module-level state shared by every game in the tab.
 export const resetServerTimeOffset = () => {
   serverTimeOffset = 0;
+  hasSample = false;
+  sampledAt = 0;
 };

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -15,7 +15,7 @@ import MobilePanel from '../components/common/MobilePanel';
 import Chat from '../components/Chat';
 import {isMobile} from '../lib/jsUtils';
 import {pickDistinctColor} from '../lib/colorAssignment';
-import {serverNow} from '../lib/timing';
+import {unaccountedClockTime} from '../lib/timing';
 import getLocalId from '../localAuth';
 
 import {recordSolve} from '../api/puzzle.ts';
@@ -470,14 +470,12 @@ class Game extends Component {
       // Compute the true total time: if the clock hasn't been ticked yet
       // (e.g. optimistic event just confirmed), add the unaccounted elapsed time.
       const gameClock = this.game.clock;
-      // lastUpdated is a server timestamp, so the elapsed time since it has to
-      // be measured on the server's clock — a skewed local Date.now() would be
-      // baked straight into the recorded solve time.
-      const unaccountedTime =
-        gameClock.paused || !gameClock.lastUpdated ? 0 : serverNow() - gameClock.lastUpdated;
+      // Measured on the server's clock, and capped the same way tick() caps a
+      // gap, so neither a skewed device clock nor a stale lastUpdated can be
+      // baked into the recorded solve time unbounded.
       const solvedClock = {
         ...gameClock,
-        totalTime: gameClock.totalTime + Math.max(0, unaccountedTime),
+        totalTime: gameClock.totalTime + unaccountedClockTime(gameClock),
         paused: true,
       };
       const snapshot = {

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -15,6 +15,7 @@ import MobilePanel from '../components/common/MobilePanel';
 import Chat from '../components/Chat';
 import {isMobile} from '../lib/jsUtils';
 import {pickDistinctColor} from '../lib/colorAssignment';
+import {serverNow} from '../lib/timing';
 import getLocalId from '../localAuth';
 
 import {recordSolve} from '../api/puzzle.ts';
@@ -469,8 +470,11 @@ class Game extends Component {
       // Compute the true total time: if the clock hasn't been ticked yet
       // (e.g. optimistic event just confirmed), add the unaccounted elapsed time.
       const gameClock = this.game.clock;
+      // lastUpdated is a server timestamp, so the elapsed time since it has to
+      // be measured on the server's clock — a skewed local Date.now() would be
+      // baked straight into the recorded solve time.
       const unaccountedTime =
-        gameClock.paused || !gameClock.lastUpdated ? 0 : Date.now() - gameClock.lastUpdated;
+        gameClock.paused || !gameClock.lastUpdated ? 0 : serverNow() - gameClock.lastUpdated;
       const solvedClock = {
         ...gameClock,
         totalTime: gameClock.totalTime + Math.max(0, unaccountedTime),

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -3,7 +3,7 @@ import EventEmitter from 'events';
 import _ from 'lodash';
 import * as uuid from 'uuid';
 import * as colors from '../lib/colors';
-import {recordServerTimestamp} from '../lib/timing';
+import {recordServerTimeFromRoundTrip, recordServerTimestamp} from '../lib/timing';
 import {emitAsync, emitAsyncWithTimeout} from '../sockets/emitAsync';
 import {getSocket, resetSocket} from '../sockets/getSocket';
 // ============ Serialize / Deserialize Helpers ========== //
@@ -160,7 +160,9 @@ export default class Game extends EventEmitter {
     // completed, and flushes queued events.
     socket.on('connect', async () => {
       console.log('reconnecting...');
+      const joinSentAt = Date.now();
       const ack = await emitAsync(socket, 'join_game', this.gid);
+      const joinRoundTrip = Date.now() - joinSentAt;
       if (ack && ack.error) {
         if (isTerminalJoinError(ack.error)) {
           this.joinRejected = ack.error;
@@ -176,7 +178,7 @@ export default class Game extends EventEmitter {
         return;
       }
       console.log('reconnected...');
-      recordServerTimestamp(ack?.serverTime);
+      recordServerTimeFromRoundTrip(ack?.serverTime, joinRoundTrip);
       this._joined = true;
       this.syncState = null;
       if (!this._initialSyncCompleted) {
@@ -190,7 +192,9 @@ export default class Game extends EventEmitter {
     // never arrives) doesn't hang attach() forever — the reconnect handler
     // above will re-issue join_game on its own.
     try {
+      const joinSentAt = Date.now();
       const joinAck = await emitAsyncWithTimeout(socket, 10000, 'join_game', this.gid);
+      const joinRoundTrip = Date.now() - joinSentAt;
       if (joinAck && joinAck.error) {
         if (isTerminalJoinError(joinAck.error)) {
           // Server refused (banned/locked). Mark this connection terminal so
@@ -209,7 +213,9 @@ export default class Game extends EventEmitter {
       }
       // Seed the server/local clock offset before the first live event, so a
       // refresh mid-solve doesn't render the clock against a skewed device.
-      recordServerTimestamp(joinAck?.serverTime);
+      // The measured round trip is what lets this correct the offset downward
+      // as well as up — broadcast events can only ever raise it.
+      recordServerTimeFromRoundTrip(joinAck?.serverTime, joinRoundTrip);
       this._joined = true;
     } catch (e) {
       // Ack lost mid-flight (bounce, transient network) — leave _joined

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -3,7 +3,7 @@ import EventEmitter from 'events';
 import _ from 'lodash';
 import * as uuid from 'uuid';
 import * as colors from '../lib/colors';
-import {recordServerTimeFromRoundTrip, recordServerTimestamp} from '../lib/timing';
+import {recordServerTimeExchange, recordServerTimestamp} from '../lib/timing';
 import {emitAsync, emitAsyncWithTimeout} from '../sockets/emitAsync';
 import {getSocket, resetSocket} from '../sockets/getSocket';
 // ============ Serialize / Deserialize Helpers ========== //
@@ -162,7 +162,7 @@ export default class Game extends EventEmitter {
       console.log('reconnecting...');
       const joinSentAt = Date.now();
       const ack = await emitAsync(socket, 'join_game', this.gid);
-      const joinRoundTrip = Date.now() - joinSentAt;
+      const joinReceivedAt = Date.now();
       if (ack && ack.error) {
         if (isTerminalJoinError(ack.error)) {
           this.joinRejected = ack.error;
@@ -178,7 +178,12 @@ export default class Game extends EventEmitter {
         return;
       }
       console.log('reconnected...');
-      recordServerTimeFromRoundTrip(ack?.serverTime, joinRoundTrip);
+      recordServerTimeExchange({
+        sentAt: joinSentAt,
+        serverReceivedAt: ack?.serverReceivedAt,
+        serverSentAt: ack?.serverTime,
+        receivedAt: joinReceivedAt,
+      });
       this._joined = true;
       this.syncState = null;
       if (!this._initialSyncCompleted) {
@@ -194,7 +199,7 @@ export default class Game extends EventEmitter {
     try {
       const joinSentAt = Date.now();
       const joinAck = await emitAsyncWithTimeout(socket, 10000, 'join_game', this.gid);
-      const joinRoundTrip = Date.now() - joinSentAt;
+      const joinReceivedAt = Date.now();
       if (joinAck && joinAck.error) {
         if (isTerminalJoinError(joinAck.error)) {
           // Server refused (banned/locked). Mark this connection terminal so
@@ -213,9 +218,14 @@ export default class Game extends EventEmitter {
       }
       // Seed the server/local clock offset before the first live event, so a
       // refresh mid-solve doesn't render the clock against a skewed device.
-      // The measured round trip is what lets this correct the offset downward
-      // as well as up — broadcast events can only ever raise it.
-      recordServerTimeFromRoundTrip(joinAck?.serverTime, joinRoundTrip);
+      // The timed exchange is what lets this correct the offset downward as
+      // well as up — broadcast events can only ever raise it.
+      recordServerTimeExchange({
+        sentAt: joinSentAt,
+        serverReceivedAt: joinAck?.serverReceivedAt,
+        serverSentAt: joinAck?.serverTime,
+        receivedAt: joinReceivedAt,
+      });
       this._joined = true;
     } catch (e) {
       // Ack lost mid-flight (bounce, transient network) — leave _joined

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -3,6 +3,7 @@ import EventEmitter from 'events';
 import _ from 'lodash';
 import * as uuid from 'uuid';
 import * as colors from '../lib/colors';
+import {recordServerTimestamp} from '../lib/timing';
 import {emitAsync, emitAsyncWithTimeout} from '../sockets/emitAsync';
 import {getSocket, resetSocket} from '../sockets/getSocket';
 // ============ Serialize / Deserialize Helpers ========== //
@@ -115,6 +116,11 @@ export default class Game extends EventEmitter {
     });
     socket.on('game_event', (event) => {
       event = castNullsToUndefined(event);
+      // Live events are server-stamped, so each one is a fresh sample of the
+      // offset between server time and this device's clock. The game clock
+      // measures its live portion against that offset instead of a raw
+      // Date.now(), so a skewed local clock doesn't show up as solve time.
+      recordServerTimestamp(event.timestamp);
       this.emitWSEvent(event);
     });
     // Server broadcasts 'kicked' to the room when the owner kicks a player.
@@ -170,6 +176,7 @@ export default class Game extends EventEmitter {
         return;
       }
       console.log('reconnected...');
+      recordServerTimestamp(ack?.serverTime);
       this._joined = true;
       this.syncState = null;
       if (!this._initialSyncCompleted) {
@@ -200,6 +207,9 @@ export default class Game extends EventEmitter {
         console.warn('join_game returned non-terminal error:', joinAck.error);
         return;
       }
+      // Seed the server/local clock offset before the first live event, so a
+      // refresh mid-solve doesn't render the clock against a skewed device.
+      recordServerTimestamp(joinAck?.serverTime);
       this._joined = true;
     } catch (e) {
       // Ack lost mid-flight (bounce, transient network) — leave _joined


### PR DESCRIPTION
## Summary

Fixes a bug where players' device clock skew was charged to the game timer, causing the clock to jump ~30 seconds when a peer's event interleaved with yours (typically on first letter typed). The solution establishes a single server-based clock for all game events and measures elapsed time against the server's clock rather than the device's potentially-skewed local clock.

## Key Changes

- **Server timestamp enforcement**: `SocketManager` now overwrites all client-supplied event timestamps with server time (`Date.now()`), ensuring a single authoritative clock for the game. This prevents mixing wall clocks from different devices.

- **Client-side clock offset tracking**: New `src/lib/timing.js` module tracks the offset between server time and local device time:
  - `recordServerTimestamp()` — samples the offset from live socket events and the `join_game` ack
  - `serverNow()` — returns local time adjusted by the offset
  - `getServerTimeOffset()` / `resetServerTimeOffset()` — accessors and test seam

- **Clock component updated**: `Clock.js` now uses `serverNow()` instead of `Date.now()` when measuring elapsed time, since `startTime` and `lastUpdated` are server timestamps.

- **Game page updated**: Solve time calculation in `Game.js` uses `serverNow()` to measure unaccounted elapsed time, preventing skewed local clocks from being baked into recorded solve times.

- **Join game ack includes server time**: `SocketManager.join_game` now returns `{serverTime: Date.now()}` to seed the client's offset before any live event arrives, so a page refresh mid-solve renders the clock against server time.

- **Comprehensive test coverage**: 
  - New `src/lib/__tests__/timing.test.js` validates offset tracking and `serverNow()` behavior
  - New `src/components/Toolbar/__tests__/Clock.test.js` validates clock display with various timing scenarios, including clock skew edge cases
  - Updated `server/__tests__/SocketManager.test.ts` with tests for timestamp overwriting and server time in ack payloads

## Implementation Details

- The offset is module-level state shared by every game in the tab, sampled from live events only (history sync events are legitimately old and would skew the estimate).
- The estimate is short by one-way network latency (~tens of ms), which is negligible compared to device clock skew (seconds to minutes).
- All changes are backwards compatible — older clients that ignore the `serverTime` field in the ack will still work, though they may see clock jumps if peers have skewed clocks.

https://claude.ai/code/session_0196mVoMkRsCAEQfoZQhpqsb