### PR TITLE
Fix Security Audit CI failure from nanoid advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
       "qs": "^6.15.2",
       "follow-redirects": ">=1.16.0",
       "postcss": ">=8.5.18",
+      "nanoid": ">=3.3.17 <4",
       "ip-address": ">=10.3.1",
       "fast-uri": ">=3.1.4 <4",
       "brace-expansion@1": ">=1.1.16 <2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   qs: ^6.15.2
   follow-redirects: '>=1.16.0'
   postcss: '>=8.5.18'
+  nanoid: '>=3.3.17 <4'
   ip-address: '>=10.3.1'
   fast-uri: '>=3.1.4 <4'
   brace-expansion@1: '>=1.1.16 <2'
@@ -4881,8 +4882,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -11589,7 +11590,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -11870,7 +11871,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

A newly-published advisory moved nanoid's patched-version boundary past what the existing `pnpm.overrides` pins resolve to, so `pnpm audit` exits non-zero and blocks CI on `master` and every open PR. Same class of breakage as #595.

```
high  nanoid: custom generators can loop indefinitely when size is zero
      Vulnerable versions  <3.3.17
      Patched versions     >=3.3.17
      Paths                .>stylelint>postcss>nanoid
      GHSA-2v37-7h3g-55p8
```

This also cascades beyond the audit job itself: `build` declares `needs: [..., audit]`, so Build is skipped rather than run.

## Change

One override: `"nanoid": ">=3.3.17 <4"`.

The upper bound is deliberate and follows the existing convention here (`fast-uri: ">=3.1.4 <4"`, `undici: ">=7.29.0 <8"`). `postcss` depends on `nanoid ^3.3.x` and is the only consumer — reached via both `stylelint` and `vite` — so an unbounded `>=3.3.17` could pull nanoid off the 3.x line and break the CSS lint and build toolchains. Resolves to 3.3.18.

## Verification

- `pnpm audit --ignore-registry-errors` → **No known vulnerabilities found** (was 1 high)
- Stylelint, Build, frontend tests (388), server tests (294) all pass — these are the paths that actually consume nanoid
- ESLint and Prettier clean

Found while driving #602 to green; split out per the #595 precedent so it unblocks `master` and every open PR at once rather than only that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196mVoMkRsCAEQfoZQhpqsb

---
_Generated by [Claude Code](https://claude.ai/code/session_0196mVoMkRsCAEQfoZQhpqsb)_